### PR TITLE
Enable relaying more post types for other plugins

### DIFF
--- a/class-friend-user-query.php
+++ b/class-friend-user-query.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * Friend User Query
+ *
+ * This wraps WP_User_Query and so that it generates instances of Friend_User.
+ *
+ * @package Friends
+ */
+
+/**
+ * This is the class for the User part of the Friends Plugin.
+ *
+ * @since 0.21
+ *
+ * @package Friends
+ * @author Alex Kirk
+ */
+class Friend_User_Query extends WP_User_Query {
+	/**
+	 * Whether to cache the retrieved users
+	 *
+	 * @var boolean
+	 */
+	public static $cache = true;
+
+	/**
+	 * List of found Friend_User objects.
+	 *
+	 * @var array
+	 */
+	private $results = array();
+
+	/**
+	 * Execute the query and ensure that we populate Friend_User objects
+	 */
+	public function query() {
+		parent::query();
+		foreach ( parent::get_results() as $k => $user ) {
+			$this->results[ $k ] = new Friend_User( $user );
+		}
+	}
+
+	/**
+	 * Return the list of users.
+	 *
+	 * @return array Array of results.
+	 */
+	public function get_results() {
+		return $this->results;
+	}
+
+	/**
+	 * Gets all friends.
+	 */
+	public static function all_friends() {
+		static $all_friends;
+		if ( ! self::$cache || ! isset( $all_friends ) ) {
+			$all_friends = new self( array( 'role__in' => array( 'friend', 'acquaintance' ) ) );
+		}
+		return $all_friends;
+	}
+
+	/**
+	 * Gets all friends.
+	 */
+	public static function all_friends_subscriptions() {
+		static $all_friends;
+		if ( ! self::$cache || ! isset( $all_friends ) ) {
+			$all_friends = new self( array( 'role__in' => array( 'friend', 'acquaintance', 'subscription' ) ) );
+		}
+		return $all_friends;
+	}
+
+	/**
+	 * Gets all friend requests.
+	 */
+	public static function all_friend_requests() {
+		static $all_friend_requests;
+		if ( ! self::$cache || ! isset( $all_friend_requests ) ) {
+			$all_friend_requests = new self( array( 'role' => 'friend_request' ) );
+		}
+		return $all_friend_requests;
+	}
+
+	/**
+	 * Gets all subscriptions.
+	 */
+	public static function all_subscriptions() {
+		static $all_subscriptions;
+		if ( ! self::$cache || ! isset( $all_subscriptions ) ) {
+			$all_subscriptions = new self( array( 'role' => 'subscription' ) );
+		}
+		return $all_subscriptions;
+	}
+
+	/**
+	 * Gets all admin users.
+	 */
+	public static function all_admin_users() {
+		static $all_admin_users;
+		if ( ! self::$cache || ! isset( $all_admin_users ) ) {
+			$all_admin_users = new self( array( 'role' => Friends::REQUIRED_ROLE ) );
+		}
+		return $all_admin_users;
+	}
+
+}

--- a/class-friend-user.php
+++ b/class-friend-user.php
@@ -1,0 +1,395 @@
+<?php
+/**
+ * Friend User
+ *
+ * This wraps WP_User and adds friend specific functions.
+ *
+ * @package Friends
+ */
+
+/**
+ * This is the class for the User part of the Friends Plugin.
+ *
+ * @since 0.21
+ *
+ * @package Friends
+ * @author Alex Kirk
+ */
+class Friend_User extends WP_User {
+	/**
+	 * Caches the feed rules.
+	 *
+	 * @var array
+	 */
+	public static $feed_rules = array();
+
+	/**
+	 * Caches the feed catch all action.
+	 *
+	 * @var array
+	 */
+	public static $feed_catch_all = array();
+
+	/**
+	 * Create a Friend_User with a specific Friends-related role
+	 *
+	 * @param  string $url     The site URL for which to create the user.
+	 * @param  string $role         The role: subscription, pending_friend_request, or friend_request.
+	 * @param  string $display_name The user's display name.
+	 * @param  string $icon_url     The user_icon_url URL.
+	 * @return Friend_User|WP_Error The created user or an error.
+	 */
+	public static function create( $url, $role, $display_name = null, $icon_url = null ) {
+		$role_rank = array_flip(
+			array(
+				'subscription',
+				'pending_friend_request',
+				'friend_request',
+			)
+		);
+		if ( ! isset( $role_rank[ $role ] ) ) {
+			return new WP_Error( 'invalid_role', 'Invalid role for creation specified' );
+		}
+
+		$friend_user = self::get_user_for_url( $url );
+		if ( $friend_user && ! is_wp_error( $friend_user ) ) {
+			if ( is_multisite() ) {
+				$current_site = get_current_site();
+				if ( ! is_user_member_of_blog( $friend_user->ID, $current_site->ID ) ) {
+					add_user_to_blog( $current_site->ID, $friend_user->ID, $role );
+				}
+			}
+
+			foreach ( $role_rank as $_role => $rank ) {
+				if ( $rank > $role_rank[ $role ] ) {
+					break;
+				}
+				if ( $friend_user->has_cap( $_role ) ) {
+					// Upgrade user role.
+					$friend_user->set_role( $role );
+					break;
+				}
+			}
+			return $friend_user;
+		}
+
+		$userdata  = array(
+			'user_login'   => self::get_user_login_for_url( $url ),
+			'display_name' => $display_name,
+			'first_name'   => $display_name,
+			'nickname'     => $display_name,
+			'user_url'     => $url,
+			'user_pass'    => wp_generate_password( 256 ),
+			'role'         => $role,
+		);
+		$friend_id = wp_insert_user( $userdata );
+		update_user_option( $friend_id, 'friends_new_friend', true );
+
+		$friend_user = new Friend_User( $friend_id );
+		$friend_user->update_user_icon_url( $icon_url, $url );
+		return $friend_user;
+	}
+
+
+	/**
+	 * Convert a site URL to a username
+	 *
+	 * @param  string $url The site URL in question.
+	 * @return string The corresponding username.
+	 */
+	public static function get_user_login_for_url( $url ) {
+		$host = wp_parse_url( $url, PHP_URL_HOST );
+		$path = wp_parse_url( $url, PHP_URL_PATH );
+
+		$user_login = trim( preg_replace( '#^www\.#', '', preg_replace( '#[^a-z0-9.-]+#', ' ', strtolower( $host . ' ' . $path ) ) ) );
+		return $user_login;
+	}
+
+	/**
+	 * Checks whether a user already exists for a site URL.
+	 *
+	 * @param  string $url The site URL for which to create the user.
+	 * @return Friend_User|false Whether the user already exists
+	 */
+	public static function get_user_for_url( $url ) {
+		$user_login = self::get_user_login_for_url( $url );
+		$user       = get_user_by( 'login', $user_login );
+		if ( $user && ! $user->data->user_url ) {
+			wp_update_user(
+				array(
+					'ID'       => $user->ID,
+					'user_url' => $url,
+				)
+			);
+			$user = get_user_by( 'login', $user_login );
+		}
+		if ( $user ) {
+			// Ensure we return a Friend_User.
+			return new self( $user );
+		}
+		return $user;
+	}
+
+	/**
+	 * Retrieve the posts for this user
+	 *
+	 * @return array The new posts.
+	 */
+	public function retrieve_posts() {
+		$friends = Friends::get_instance();
+		return $friends->feed->retrieve_single_friend_posts( $this );
+	}
+
+	/**
+	 * Update a friend's avatar URL
+	 *
+	 * @param  string $user_icon_url  The user icon URL.
+	 * @return string|false The URL that was set or false.
+	 */
+	public function update_user_icon_url( $user_icon_url ) {
+		if ( $user_icon_url && wp_http_validate_url( $user_icon_url ) ) {
+			if ( $this->has_cap( 'friend' ) || $this->has_cap( 'pending_friend_request' ) || $this->has_cap( 'friend_request' ) || $this->has_cap( 'subscription' ) ) {
+				$icon_host_parts = array_reverse( explode( '.', parse_url( strtolower( $user_icon_url ), PHP_URL_HOST ) ) );
+				if ( 'gravatar.com' === $icon_host_parts[1] . '.' . $icon_host_parts[0] ) {
+					update_user_option( $this->ID, 'friends_user_icon_url', $user_icon_url );
+					return $user_icon_url;
+				}
+
+				$user_host_parts = array_reverse( explode( '.', parse_url( strtolower( $this->user_url ), PHP_URL_HOST ) ) );
+				if ( $user_host_parts[1] . '.' . $user_host_parts[0] === $icon_host_parts[1] . '.' . $icon_host_parts[0] ) {
+					update_user_option( $this->ID, 'friends_user_icon_url', $user_icon_url );
+					return $user_icon_url;
+				}
+			} elseif ( $this->has_cap( 'subscription' ) ) {
+				update_user_option( $this->ID, 'friends_user_icon_url', $gravatar );
+				return $gravatar;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Retrieve the rules for this feed.
+	 *
+	 * @return array The rules set by the user for this feed.
+	 */
+	public function get_feed_rules() {
+		$friends = Friends::get_instance();
+		if ( ! isset( self::$feed_rules[ $this->ID ] ) ) {
+			self::$feed_rules[ $this->ID ] = $friends->feed->validate_feed_rules( get_option( 'friends_feed_rules_' . $this->ID ) );
+		}
+		return self::$feed_rules[ $this->ID ];
+	}
+
+
+	/**
+	 * Retrieve the catch_all value for this feed.
+	 *
+	 * @return array The rules set by the user for this feed.
+	 */
+	public function get_feed_catch_all() {
+		$friends = Friends::get_instance();
+		if ( ! isset( self::$feed_catch_all[ $this->ID ] ) ) {
+			self::$feed_catch_all[ $this->ID ] = $friends->feed->validate_feed_catch_all( get_option( 'friends_feed_catch_all_' . $this->ID ) );
+		}
+		return self::$feed_catch_all[ $this->ID ];
+	}
+
+	/**
+	 * Retrieve the remote post ids.
+	 *
+	 * @return array A mapping of the remote post ids.
+	 */
+	public function get_remote_post_ids() {
+		$friends = Friends::get_instance();
+		$remote_post_ids = array();
+		$existing_posts  = new WP_Query(
+			array(
+				'post_type'   => $friends->post_types->get_all_cached(),
+				'post_status' => array( 'publish', 'private', 'trash' ),
+				'author'      => $this->ID,
+				'nopaging'    => true,
+			)
+		);
+
+		if ( $existing_posts->have_posts() ) {
+			while ( $existing_posts->have_posts() ) {
+				$post           = $existing_posts->next_post();
+				$remote_post_id = get_post_meta( $post->ID, 'remote_post_id', true );
+				if ( $remote_post_id ) {
+					$remote_post_ids[ $remote_post_id ] = $post->ID;
+				}
+				$permalink                     = get_permalink( $post );
+				$remote_post_ids[ $permalink ] = $post->ID;
+				$permalink                     = str_replace( array( '&#38;', '&#038;' ), '&', ent2ncr( $permalink ) );
+				$remote_post_ids[ $permalink ] = $post->ID;
+			}
+		}
+
+		do_action( 'friends_remote_post_ids', $remote_post_ids );
+		return $remote_post_ids;
+	}
+
+	/**
+	 * Get the (private) feed URL for a friend.
+	 *
+	 * @param  string  $post_type   The post type for which to get the feed.
+	 * @param  boolean $private     Whether to generate a private feed URL (if possible).
+	 * @return string               The feed URL.
+	 */
+	public function get_feed_url( $post_type = 'post', $private = true ) {
+		$feed_url = $this->get_user_option( 'friends_feed_url' );
+		if ( ! $feed_url ) {
+			$feed_url = rtrim( $this->user_url, '/' ) . '/feed/';
+		}
+
+		$sep = '?';
+		if ( $private && ( current_user_can( Friends::REQUIRED_ROLE ) || wp_doing_cron() ) ) {
+			$token = $this->get_user_option( 'friends_out_token' );
+			if ( $token ) {
+				$feed_url .= $sep . 'friend=' . $token;
+				$sep = '&';
+			}
+		}
+		if ( 'post' !== $post_type ) {
+			$feed_url .= $sep . 'post_type=' . $post_type;
+			$sep = '&';
+		}
+
+		return apply_filters( 'friends_friend_feed_url', $feed_url, $this );
+	}
+
+
+	/**
+	 * Convert a user to a friend
+	 *
+	 * @param  string $out_token The token to authenticate against the remote.
+	 * @param  string $in_token The token the remote needs to use to authenticate to us.
+	 */
+	public function make_friend( $out_token, $in_token ) {
+		$this->update_user_option( 'friends_out_token', $out_token );
+		if ( $this->update_user_option( 'friends_in_token', $in_token ) ) {
+			update_option( 'friends_in_token_' . $in_token, $this->ID );
+		}
+		$this->set_role( get_option( 'friends_default_friend_role', 'friend' ) );
+	}
+
+	/**
+	 * Check whether this is a valid friend
+	 *
+	 * @return boolean Whether the user has valid friend data.
+	 */
+	public function is_valid_friend() {
+		if ( ! $this->has_cap( 'friend' ) ) {
+			return false;
+		}
+
+		if ( ! $this->data->user_url ) {
+			return false;
+		}
+
+		if ( ! $this->get_user_option( 'friends_in_token' ) ) {
+			return false;
+		}
+
+		if ( ! $this->get_user_option( 'friends_out_token' ) ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Get the REST URL for the friend
+	 *
+	 * @return string        The REST URL.
+	 */
+	public function get_rest_url() {
+		$friends = Friends::get_instance();
+		$rest_url = $this->get_user_option( 'friends_rest_url' );
+		if ( ! $rest_url || false === strpos( $rest_url, Friends_REST::PREFIX ) ) {
+			$rest_url = $friends->rest->discover_rest_url( $this->user_url );
+			if ( $rest_url ) {
+				$this->update_user_option( 'friends_rest_url', $rest_url );
+			}
+		}
+		return $rest_url;
+	}
+
+	/**
+	 * Is this a new user?
+	 *
+	 * @return boolean [description]
+	 */
+	public function is_new() {
+		return $this->get_user_option( 'friends_new_friend' );
+	}
+
+	/**
+	 * Flag the user as no lopnger new
+	 */
+	public function set_not_new() {
+		$this->delete_user_option( 'friends_new_friend' );
+	}
+
+	/**
+	 * Get the whitelisted post types for this user
+	 *
+	 * @return array All the post types.
+	 */
+	public function get_post_types() {
+		$post_types = $this->get_user_option( 'friends_post_types' );
+
+		if ( false === $post_types ) {
+			$post_types = get_option( 'friends_default_post_types' );
+			if ( false === $post_types ) {
+				$post_types = 'all';
+			}
+		}
+
+		if ( 'all' === $post_types ) {
+			$friends = Friends::get_instance();
+			return $friends->post_types->get_all_registered();
+		}
+
+		return explode( ',', $post_types );
+	}
+
+	/**
+	 * Wrap get_user_option
+	 *
+	 * @param string $option_name User option name.
+	 * @return int|bool User meta ID if the option didn't exist, true on successful update,
+	 *                  false on failure.
+	 */
+	function get_user_option( $option_name ) {
+		return get_user_option( $option_name, $this->ID );
+	}
+
+	/**
+	 * Wrap update_user_option
+	 *
+	 * @param string $option_name User option name.
+	 * @param mixed  $newvalue    User option value.
+	 * @param bool   $global      Optional. Whether option name is global or blog specific.
+	 *                            Default false (blog specific).
+	 * @return int|bool User meta ID if the option didn't exist, true on successful update,
+	 *                  false on failure.
+	 */
+	function update_user_option( $option_name, $newvalue, $global = false ) {
+		return update_user_option( $this->ID, $option_name, $newvalue, $global );
+	}
+
+	/**
+	 * Wrap delete_user_option
+	 *
+	 * @param string $option_name User option name.
+	 * @param bool   $global      Optional. Whether option name is global or blog specific.
+	 *                            Default false (blog specific).
+	 * @return bool True on success, false on failure.
+	 */
+	function delete_user_option( $option_name, $global = false ) {
+		return delete_user_option( $this->ID, $option_name, $global );
+	}
+}

--- a/class-friends-access-control.php
+++ b/class-friends-access-control.php
@@ -63,7 +63,7 @@ class Friends_Access_Control {
 	/**
 	 * Get authenticated feed user
 	 *
-	 * @return WP_User|null The authentication status of the feed.
+	 * @return Friend_User|null The authentication status of the feed.
 	 */
 	public function get_authenticated_feed_user() {
 		if ( is_null( $this->feed_authenticated ) ) {
@@ -74,7 +74,7 @@ class Friends_Access_Control {
 			return null;
 		}
 
-		return new WP_User( $this->feed_authenticated );
+		return new Friend_User( $this->feed_authenticated );
 	}
 
 	/**
@@ -246,7 +246,7 @@ class Friends_Access_Control {
 		if ( ! $user_id ) {
 			return;
 		}
-		$user = new WP_User( $user_id );
+		$user = new Friend_User( $user_id );
 		if ( ! $user->has_cap( 'friend' ) ) {
 			return;
 		}
@@ -270,7 +270,7 @@ class Friends_Access_Control {
 		if ( isset( $_GET['friend'] ) ) {
 			$user_id = $this->verify_token( $_GET['friend'] );
 			if ( $user_id ) {
-				$user = new WP_User( $user_id );
+				$user = new Friend_User( $user_id );
 				if ( $user->has_cap( 'friend' ) ) {
 					$this->feed_authenticated = $user_id;
 					return $this->feed_authenticated;
@@ -294,7 +294,7 @@ class Friends_Access_Control {
 			delete_option( 'friends_in_token_' . $current_secret );
 		}
 
-		$user = new WP_User( $user_id );
+		$user = new Friend_User( $user_id );
 
 		// No need to delete user options as the user will be deleted.
 		return $current_secret;
@@ -314,71 +314,7 @@ class Friends_Access_Control {
 			return;
 		}
 
-		do_action( 'notify_new_friend_request', new WP_User( $user_id ) );
-	}
-
-	/**
-	 * Convert a user to a friend
-	 *
-	 * @param  WP_User $user  The user to become a friend of the blog.
-	 * @param  string  $out_token The token to authenticate against the remote.
-	 * @param  string  $in_token The token the remote needs to use to authenticate to us.
-	 * @return WP_User|WP_Error The user or an error.
-	 */
-	public function make_friend( WP_User $user, $out_token, $in_token ) {
-		if ( ! $user || is_wp_error( $user ) ) {
-			return $user;
-		}
-		update_user_option( $user->ID, 'friends_out_token', $out_token );
-		if ( update_user_option( $user->ID, 'friends_in_token', $in_token ) ) {
-			update_option( 'friends_in_token_' . $in_token, $user->ID );
-		}
-		$user->set_role( get_option( 'friends_default_friend_role', 'friend' ) );
-
-		return $user;
-	}
-
-	/**
-	 * Check whether a user is a valid friend
-	 *
-	 * @param  WP_User $user The potential friend user.
-	 * @return boolean       Whether the user has valid friend data.
-	 */
-	public function is_valid_friend( WP_User $user ) {
-		if ( ! $user->has_cap( 'friend' ) ) {
-			return false;
-		}
-
-		if ( ! $user->data->user_url ) {
-			return false;
-		}
-
-		if ( ! get_user_option( 'friends_in_token', $user->ID ) ) {
-			return false;
-		}
-
-		if ( ! get_user_option( 'friends_out_token', $user->ID ) ) {
-			return false;
-		}
-
-		return true;
-	}
-
-	/**
-	 * Get the REST URL for the friend
-	 *
-	 * @param  WP_User $user A friend user.
-	 * @return string        The REST URL.
-	 */
-	public function get_rest_url( WP_User $user ) {
-		$rest_url = get_user_option( 'friends_rest_url', $user->ID );
-		if ( ! $rest_url || false === strpos( $rest_url, Friends_REST::PREFIX ) ) {
-			$rest_url = $this->friends->rest->discover_rest_url( $user->user_url );
-			if ( $rest_url ) {
-				update_user_option( $user->ID, 'friends_rest_url', $rest_url );
-			}
-		}
-		return $rest_url;
+		do_action( 'notify_new_friend_request', new Friend_User( $user_id ) );
 	}
 
 	/**

--- a/class-friends-admin.php
+++ b/class-friends-admin.php
@@ -104,7 +104,7 @@ class Friends_Admin {
 			return;
 		}
 
-		$friends_subscriptions = Friends::all_friends_subscriptions();
+		$friends_subscriptions = Friend_User_Query::all_friends_subscriptions();
 		if ( $friends_subscriptions->get_total() ) {
 			return;
 		}
@@ -127,7 +127,7 @@ class Friends_Admin {
 	 * Registers the admin menus
 	 */
 	public function register_admin_menu() {
-		$friend_requests = Friends::all_friend_requests();
+		$friend_requests = Friend_User_Query::all_friend_requests();
 		$friend_request_count = $friend_requests->get_total();
 		$unread_badge = $this->get_unread_badge( $friend_request_count );
 
@@ -239,14 +239,6 @@ class Friends_Admin {
 	 * Admin menu to refresh the friend posts.
 	 */
 	public function admin_refresh_friend_posts() {
-		$friend = null;
-		if ( isset( $_GET['user'] ) ) {
-			$friend = new WP_User( intval( $_GET['user'] ) );
-			if ( ! $friend || is_wp_error( $friend ) ) {
-				wp_die( esc_html__( 'Invalid user ID.' ) );
-			}
-		}
-
 		?>
 		<h1><?php esc_html_e( "Refreshing Your Friends' Posts", 'friends' ); ?></h1>
 		<?php
@@ -267,8 +259,12 @@ class Friends_Admin {
 		add_action(
 			'friends_retrieved_new_posts',
 			function( $new_posts, $friend_user ) {
+				$count = 0;
+				foreach ( $new_posts as $post_type => $posts ) {
+					$count += count( $posts );
+				}
 				// translators: %s is the number of new posts found.
-				printf( _n( 'Found %d new post.', 'Found %d new posts.', count( $new_posts ), 'friends' ) . '<br/>', count( $new_posts ) );
+				printf( _n( 'Found %d new post.', 'Found %d new posts.', $count, 'friends' ) . '<br/>', $count );
 			},
 			10,
 			2
@@ -296,7 +292,15 @@ class Friends_Admin {
 			3
 		);
 
-		$this->friends->feed->retrieve_friend_posts( $friend );
+		if ( isset( $_GET['user'] ) ) {
+			$friend_user = new Friend_User( intval( $_GET['user'] ) );
+			if ( ! $friend_user || is_wp_error( $friend_user ) ) {
+				wp_die( esc_html__( 'Invalid user ID.' ) );
+			}
+			$friend_user->retrieve_posts();
+		} else {
+			$this->friends->feed->retrieve_friend_posts();
+		}
 	}
 
 	/**
@@ -330,8 +334,8 @@ class Friends_Admin {
 			$url = substr( $feed_url, 0, -6 );
 		}
 
-		$user = $this->friends->access_control->get_user_for_url( $url );
-		if ( $user && ! is_wp_error( $user ) && $this->friends->access_control->is_valid_friend( $user ) ) {
+		$friend_user = Friend_User::get_user_for_url( $url );
+		if ( $friend_user && ! is_wp_error( $friend_user ) && $friend_user->is_valid_friend() ) {
 			return new WP_Error( 'already-friend', __( 'You are already subscribed to this site.', 'friends' ) );
 		}
 
@@ -366,13 +370,13 @@ class Friends_Admin {
 			}
 		}
 		$feed_title = trim( str_replace( '&raquo; Feed', '', $feed->get_title() ) );
-		$user = $this->friends->access_control->create_user( $url, 'subscription', $feed_title, $favicon );
-		if ( ! is_wp_error( $user ) ) {
-			$this->friends->feed->process_friend_feed( $user, $feed, Friends::CPT );
-			update_user_option( $user->ID, 'friends_feed_url', $feed_url );
+		$friend_user = Friend_User::create( $url, 'subscription', $feed_title, $favicon );
+		if ( ! is_wp_error( $friend_user ) ) {
+			$this->friends->feed->process_friend_feed( $friend_user, $feed, Friends::CPT );
+			$friend_user->update_user_option( 'friends_feed_url', $feed_url );
 		}
 
-		return $user;
+		return $friend_user;
 	}
 
 	/**
@@ -392,8 +396,8 @@ class Friends_Admin {
 			return new WP_Error( 'friend-yourself', __( 'It seems like you sent a friend request to yourself.', 'friends' ) );
 		}
 
-		$friend_user = $this->friends->access_control->get_user_for_url( $friend_url );
-		if ( $friend_user && ! is_wp_error( $friend_user ) && $this->friends->access_control->is_valid_friend( $friend_user ) ) {
+		$friend_user = Friend_User::get_user_for_url( $friend_url );
+		if ( $friend_user && ! is_wp_error( $friend_user ) && $friend_user->is_valid_friend() ) {
 			return new WP_Error( 'already-friend', __( 'You are already friends with this site.', 'friends' ) );
 		}
 
@@ -414,7 +418,7 @@ class Friends_Admin {
 		// }
 		//
 		*/
-		$user_login      = $this->friends->access_control->get_user_login_for_url( $friend_url );
+		$user_login      = Friend_User::get_user_login_for_url( $friend_url );
 		$future_in_token = sha1( wp_generate_password( 256 ) );
 
 		$current_user = wp_get_current_user();
@@ -450,52 +454,50 @@ class Friends_Admin {
 			return new WP_Error( 'unexpected-rest-response', 'Unexpected remote response.', $response );
 		}
 
-		$friend_user = $this->friends->access_control->create_user( $friend_url, 'pending_friend_request' );
-		if ( ! is_wp_error( $friend_user ) ) {
-			update_user_option( $friend_user->ID, 'friends_rest_url', $rest_url );
-
-			if ( isset( $json->request ) ) {
-				update_option( 'friends_request_' . sha1( $json->request ), $friend_user->ID );
-				update_user_option( $friend_user->ID, 'friends_future_in_token_' . sha1( $json->request ), $future_in_token );
-				$friend_user->set_role( 'pending_friend_request' );
-				// } elseif ( isset( $json->friend ) ) {
-				// $this->friends->access_control->make_friend( $user, $json->friend );
-				// if ( isset( $json->gravatar ) ) {
-				// $this->friends->access_control->update_gravatar( $user->ID, $json->gravatar );
-				// }
-				// if ( isset( $json->name ) ) {
-				// wp_update_user(
-				// array(
-				// 'ID'           => $user->ID,
-				// 'nickname'     => $json->name,
-				// 'first_name'   => $json->name,
-				// 'display_name' => $json->name,
-				// )
-				// );
-				// }
-				// $response = wp_safe_remote_post(
-				// $friend_rest_url . '/friend-request-accepted',
-				// array(
-				// 'body'        => array(
-				// 'token'  => $json->token,
-				// 'friend' => $this->friends->access_control->update_in_token( $user->ID ),
-				// 'proof'  => sha1( $json->token . $friend_request_token ),
-				// ),
-				// 'timeout'     => 20,
-				// 'redirection' => 5,
-				// )
-				// );
-				// delete_user_option( $user->ID, 'friends_request_token' );
-				// $json = json_decode( wp_remote_retrieve_body( $response ) );
-				// if ( $json->friend ) {
-				// update_user_option( $user->ID, 'friends_out_token', $json->friend );
-				// }
-			}
+		$friend_user = Friend_User::create( $friend_url, 'pending_friend_request' );
+		if ( is_wp_error( $friend_user ) ) {
+			return $friend_user;
 		}
+		$friend_user->update_user_option( 'friends_rest_url', $rest_url );
 
-		if ( ! is_wp_error( $friend_user ) ) {
-			$this->friends->feed->retrieve_friend_posts( $friend_user );
+		if ( isset( $json->request ) ) {
+			update_option( 'friends_request_' . sha1( $json->request ), $friend_user->ID );
+			$friend_user->update_user_option( 'friends_future_in_token_' . sha1( $json->request ), $future_in_token );
+			$friend_user->set_role( 'pending_friend_request' );
+			// } elseif ( isset( $json->friend ) ) {
+			// $this->friends->access_control->make_friend( $user, $json->friend );
+			// if ( isset( $json->gravatar ) ) {
+			// $this->friends->access_control->update_gravatar( $user->ID, $json->gravatar );
+			// }
+			// if ( isset( $json->name ) ) {
+			// wp_update_user(
+			// array(
+			// 'ID'           => $user->ID,
+			// 'nickname'     => $json->name,
+			// 'first_name'   => $json->name,
+			// 'display_name' => $json->name,
+			// )
+			// );
+			// }
+			// $response = wp_safe_remote_post(
+			// $friend_rest_url . '/friend-request-accepted',
+			// array(
+			// 'body'        => array(
+			// 'token'  => $json->token,
+			// 'friend' => $this->friends->access_control->update_in_token( $user->ID ),
+			// 'proof'  => sha1( $json->token . $friend_request_token ),
+			// ),
+			// 'timeout'     => 20,
+			// 'redirection' => 5,
+			// )
+			// );
+			// delete_user_option( $user->ID, 'friends_request_token' );
+			// $json = json_decode( wp_remote_retrieve_body( $response ) );
+			// if ( $json->friend ) {
+			// update_user_option( $user->ID, 'friends_out_token', $json->friend );
+			// }
 		}
+		$friend_user->retrieve_posts();
 
 		return $friend_user;
 	}
@@ -629,7 +631,7 @@ class Friends_Admin {
 			<?php
 		}
 
-		$potential_main_users = Friends::all_admin_users();
+		$potential_main_users = Friend_User_Query::all_admin_users();
 		$main_user_id         = $this->friends->get_main_friend_user_id();
 		$default_role         = get_option( 'friends_default_friend_role', 'friend' );
 
@@ -755,7 +757,7 @@ class Friends_Admin {
 		$friend       = $this->check_admin_edit_friend_rules();
 		$friend_posts = new WP_Query(
 			array(
-				'post_type'      => $this->friends->get_all_cached_post_types(),
+				'post_type'      => $this->friends->post_types->get_all_cached(),
 				'post_status'    => array( 'publish', 'private', 'trash' ),
 				'author'         => $friend->ID,
 				'posts_per_page' => 25,
@@ -896,7 +898,7 @@ class Friends_Admin {
 		$friend = $this->check_admin_edit_friend();
 		$friend_posts = new WP_Query(
 			array(
-				'post_type'   => $this->friends->get_all_cached_post_types(),
+				'post_type'   => $this->friends->post_types->get_all_cached(),
 				'post_status' => array( 'publish', 'private' ),
 				'author'      => $friend->ID,
 			)
@@ -992,7 +994,7 @@ class Friends_Admin {
 				?>
 				</div>
 				<?php
-			} elseif ( $friend_user instanceof WP_User ) {
+			} elseif ( $friend_user instanceof Friend_User ) {
 				$friend_link = '<a href="' . esc_url( $friend_user->user_url ) . '" target="_blank" rel="noopener noreferrer">' . esc_html( $friend_user->user_url ) . '</a>';
 				if ( $friend_user->has_cap( 'pending_friend_request' ) ) {
 					?>
@@ -1141,7 +1143,7 @@ class Friends_Admin {
 		}
 
 		if ( ! $friend && isset( $_GET['url'] ) ) {
-			$friend = $this->friends->access_control->get_user_for_url( $_GET['url'] );
+			$friend = Friend_User::get_user_for_url( $_GET['url'] );
 			$url    = $_GET['url'];
 			if ( 'http' !== substr( $url, 0, 4 ) ) {
 				$url = 'http://' . $url;
@@ -1323,7 +1325,7 @@ class Friends_Admin {
 	 * @return array The extended bulk options.
 	 */
 	public function add_user_bulk_options( $actions ) {
-		$friends = Friends::all_friend_requests();
+		$friends = Friend_User_Query::all_friend_requests();
 		$friends->get_results();
 
 		if ( ! empty( $friends ) ) {
@@ -1377,7 +1379,7 @@ class Friends_Admin {
 
 		$friends_main_url = $friends_url;
 		if ( current_user_can( Friends::REQUIRED_ROLE ) ) {
-			$friend_requests = Friends::all_friend_requests();
+			$friend_requests = Friend_User_Query::all_friend_requests();
 			$friend_request_count = $friend_requests->get_total();
 			if ( $friend_request_count > 0 ) {
 				$friends_main_url = self_admin_url( 'users.php?role=friend_request' );

--- a/class-friends-admin.php
+++ b/class-friends-admin.php
@@ -755,7 +755,7 @@ class Friends_Admin {
 		$friend       = $this->check_admin_edit_friend_rules();
 		$friend_posts = new WP_Query(
 			array(
-				'post_type'      => Friends::CPT,
+				'post_type'      => $this->friends->get_all_cached_post_types(),
 				'post_status'    => array( 'publish', 'private', 'trash' ),
 				'author'         => $friend->ID,
 				'posts_per_page' => 25,
@@ -896,7 +896,7 @@ class Friends_Admin {
 		$friend = $this->check_admin_edit_friend();
 		$friend_posts = new WP_Query(
 			array(
-				'post_type'   => Friends::CPT,
+				'post_type'   => $this->friends->get_all_cached_post_types(),
 				'post_status' => array( 'publish', 'private' ),
 				'author'      => $friend->ID,
 			)

--- a/class-friends-admin.php
+++ b/class-friends-admin.php
@@ -368,7 +368,7 @@ class Friends_Admin {
 		$feed_title = trim( str_replace( '&raquo; Feed', '', $feed->get_title() ) );
 		$user = $this->friends->access_control->create_user( $url, 'subscription', $feed_title, $favicon );
 		if ( ! is_wp_error( $user ) ) {
-			$this->friends->feed->process_friend_feed( $user, $feed );
+			$this->friends->feed->process_friend_feed( $user, $feed, Friends::CPT );
 			update_user_option( $user->ID, 'friends_feed_url', $feed_url );
 		}
 

--- a/class-friends-admin.php
+++ b/class-friends-admin.php
@@ -650,7 +650,7 @@ class Friends_Admin {
 			wp_die( esc_html__( 'Invalid user ID.' ) );
 		}
 
-		$friend = new WP_User( intval( $_GET['user'] ) );
+		$friend = new Friend_User( intval( $_GET['user'] ) );
 		if ( ! $friend || is_wp_error( $friend ) ) {
 			wp_die( esc_html__( 'Invalid user ID.' ) );
 		}
@@ -701,9 +701,8 @@ class Friends_Admin {
 	 */
 	public function render_admin_edit_friend_rules() {
 		$friend    = $this->check_admin_edit_friend_rules();
-		$catch_all = $this->friends->feed->get_feed_catch_all( $friend );
-		$rules     = $this->friends->feed->get_feed_rules( $friend );
-
+		$catch_all = $friend->get_feed_catch_all();
+		$rules     = $friend->get_feed_rules();
 		?>
 		<h1>
 		<?php
@@ -764,9 +763,10 @@ class Friends_Admin {
 			)
 		);
 
-		$feed                                = $this->friends->feed;
-		$feed->feed_rules[ $friend->ID ]     = $this->friends->feed->validate_feed_rules( $rules );
-		$feed->feed_catch_all[ $friend->ID ] = $this->friends->feed->validate_feed_catch_all( $catch_all );
+		$feed = $this->friends->feed;
+
+		Friend_User::$feed_rules[ $friend->ID ]     = $feed->validate_feed_rules( $rules );
+		Friend_User::$feed_catch_all[ $friend->ID ] = $feed->validate_feed_catch_all( $catch_all );
 
 		include apply_filters( 'friends_template_path', 'admin/preview-rules.php' );
 	}
@@ -783,7 +783,7 @@ class Friends_Admin {
 			wp_die( esc_html__( 'Invalid user ID.' ) );
 		}
 
-		$friend = new WP_User( intval( $_GET['user'] ) );
+		$friend = new Friend_User( intval( $_GET['user'] ) );
 		if ( ! $friend || is_wp_error( $friend ) ) {
 			wp_die( esc_html__( 'Invalid user ID.' ) );
 		}
@@ -903,8 +903,7 @@ class Friends_Admin {
 				'author'      => $friend->ID,
 			)
 		);
-
-		$rules = $this->friends->feed->get_feed_rules( $friend );
+		$rules = $friend->get_feed_rules();
 		$hide_from_friends_page = get_user_option( 'friends_hide_from_friends_page' );
 		if ( ! $hide_from_friends_page ) {
 			$hide_from_friends_page = array();
@@ -1290,7 +1289,7 @@ class Friends_Admin {
 
 		$accepted = 0;
 		foreach ( $users as $user_id ) {
-			$user = new WP_User( $user_id );
+			$user = new Friend_User( $user_id );
 			if ( ! $user || is_wp_error( $user ) ) {
 				continue;
 			}
@@ -1332,7 +1331,7 @@ class Friends_Admin {
 			$actions['accept_friend_request'] = __( 'Accept Friend Request', 'friends' );
 		}
 
-		$friends = new WP_User_Query( array( 'role' => 'subscription' ) );
+		$friends = Friend_User_Query::all_subscriptions();
 		$friends->get_results();
 
 		if ( ! empty( $friends ) ) {

--- a/class-friends-api.php
+++ b/class-friends-api.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Friends
+ *
+ * A plugin to connect WordPresses and communicate privately with your friends.
+ *
+ * @package Friends
+ */
+
+/**
+ * This is the class for the Friends Plugin.
+ *
+ * @package Friends
+ * @author Alex Kirk
+ */
+class Friends_API {
+	/**
+	 * Register a post type with the Friends plugin
+	 *
+	 * @param  string $post_type The name of a post_type.
+	 */
+	public static function register_post_type( $post_type ) {
+		if ( ! post_type_exists( $post_type ) ) {
+			return false;
+		}
+		$friends = Friends::get_instance();
+		if ( $friends->is_known_post_type( $post_type ) ) {
+			// Already registered.
+			return false;
+		}
+		$friends->registered_post_types[ $post_type ] = Friends::CPT_PREFIX . $post_type;
+	}
+}

--- a/class-friends-api.php
+++ b/class-friends-api.php
@@ -17,17 +17,28 @@ class Friends_API {
 	/**
 	 * Register a post type with the Friends plugin
 	 *
-	 * @param  string $post_type The name of a post_type.
+	 * @param  string $post_type The name of a post type.
 	 */
 	public static function register_post_type( $post_type ) {
-		if ( ! post_type_exists( $post_type ) ) {
-			return false;
-		}
 		$friends = Friends::get_instance();
-		if ( $friends->is_known_post_type( $post_type ) ) {
+		if ( $friends->post_types->is_known( $post_type ) ) {
 			// Already registered.
 			return false;
 		}
-		$friends->registered_post_types[ $post_type ] = Friends::CPT_PREFIX . $post_type;
+		$friends->post_types->register( $post_type );
+	}
+
+	/**
+	 * Unregister a post type from the Friends plugin
+	 *
+	 * @param  string $post_type The name of a post type.
+	 */
+	public static function unregister_post_type( $post_type ) {
+		$friends = Friends::get_instance();
+		if ( ! $friends->post_types->is_known( $post_type ) ) {
+			// Already registered.
+			return false;
+		}
+		$friends->post_types->unregister( $post_type );
 	}
 }

--- a/class-friends-blocks.php
+++ b/class-friends-blocks.php
@@ -238,7 +238,7 @@ class Friends_Blocks {
 				array(
 					'numberposts' => $count,
 					'offset'      => $offset,
-					'post_type'   => Friends::CPT,
+					'post_type'   => $this->friends->get_all_cached_post_types(),
 				)
 			);
 			if ( count( $recent_posts ) === 0 ) {

--- a/class-friends-blocks.php
+++ b/class-friends-blocks.php
@@ -129,23 +129,23 @@ class Friends_Blocks {
 	public function render_block_friends_list( $attributes, $content ) {
 		switch ( $attributes['user_types'] ) {
 			case 'friend_requests':
-				$friends  = Friends::all_friend_requests();
+				$friends  = Friend_User_Query::all_friend_requests();
 				$no_users = __( "You currently don't have any friend requests.", 'friends' );
 				break;
 
 			case 'friends_subscriptions':
-				$friends  = Friends::all_friends_subscriptions();
+				$friends  = Friend_User_Query::all_friends_subscriptions();
 				$no_users = __( "You don't have any friends or subscriptions yet.", 'friends' );
 				break;
 
 			case 'subscriptions':
-				$friends  = Friends::all_subscriptions();
+				$friends  = Friend_User_Query::all_subscriptions();
 				$no_users = __( "You don't have any subscriptions yet.", 'friends' );
 				break;
 
 			case 'friends':
 			default:
-				$friends  = Friends::all_friends();
+				$friends  = Friend_User_Query::all_friends();
 				$no_users = __( "You don't have any friends yet.", 'friends' );
 		}
 
@@ -238,7 +238,7 @@ class Friends_Blocks {
 				array(
 					'numberposts' => $count,
 					'offset'      => $offset,
-					'post_type'   => $this->friends->get_all_cached_post_types(),
+					'post_type'   => $this->friends->post_types->get_all_cached(),
 				)
 			);
 			if ( count( $recent_posts ) === 0 ) {

--- a/class-friends-feed.php
+++ b/class-friends-feed.php
@@ -26,20 +26,6 @@ class Friends_Feed {
 	private $friends;
 
 	/**
-	 * Caches the feed rules.
-	 *
-	 * @var array
-	 */
-	public $feed_rules = array();
-
-	/**
-	 * Caches the feed catch all action.
-	 *
-	 * @var array
-	 */
-	public $feed_catch_all = array();
-
-	/**
 	 * Constructor
 	 *
 	 * @param Friends $friends A reference to the Friends object.
@@ -77,120 +63,80 @@ class Friends_Feed {
 	}
 
 	/**
-	 * Retrieve posts from a remote WordPress for a user or all friend users.
+	 * Retrieve posts from a remote WordPress for a friend.
 	 *
-	 * @param  WP_User|null $single_user A single user or null to fetch all.
+	 * @param  Friend_User $friend_user A single user to fetch.
 	 */
-	public function retrieve_friend_posts( WP_User $single_user = null ) {
-		if ( $single_user ) {
-			$friends = array(
-				$single_user,
-			);
-		} else {
-			$friends = new WP_User_Query( array( 'role__in' => array( 'friend', 'acquaintance', 'pending_friend_request', 'subscription' ) ) );
-			$friends = $friends->get_results();
+	public function retrieve_single_friend_posts( Friend_User $friend_user ) {
+		$new_posts = array();
+		foreach ( $friend_user->get_post_types() as $post_type ) {
+			$feed_url = $friend_user->get_feed_url( $post_type );
 
-			if ( empty( $friends ) ) {
-				return;
+			$feed = $this->fetch_feed( $feed_url );
+			if ( is_wp_error( $feed ) ) {
+				do_action( 'friends_retrieve_friends_error', $feed_url, $feed, $friend_user );
+				continue;
 			}
+			$cache_post_type = $this->friends->post_types->get_cache_post_type( $post_type );
+			$feed = apply_filters( 'friends_feed_content', $feed, $friend_user, $cache_post_type );
+			$new_posts[ $post_type ] = $this->process_friend_feed( $friend_user, $feed, $cache_post_type );
+		}
+
+		$this->notify_about_new_friend_posts( $friend_user, $new_posts );
+
+		do_action( 'friends_retrieved_new_posts', $new_posts, $friend_user );
+		return $new_posts;
+	}
+
+	/**
+	 * Notify users about new posts of this friend
+	 *
+	 * @param  Friend_User $friend_user The friend.
+	 * @param  array       $new_posts   The new posts of this friend.
+	 */
+	public function notify_about_new_friend_posts( Friend_User $friend_user, $new_posts ) {
+		if ( $friend_user->is_new() ) {
+			$friend_user->set_not_new();
+		} else {
+			foreach ( $new_posts as $post_type => $posts ) {
+				foreach ( $posts as $post_id ) {
+					$notify_users = apply_filters( 'notify_about_new_friend_post', true, $friend_user, $post_id );
+					if ( $notify_users ) {
+						do_action( 'notify_new_friend_post', get_post( intval( $post_id ) ) );
+					}
+				}
+			}
+		}
+
+	}
+
+	/**
+	 * Retrieve posts from all friend.
+	 */
+	public function retrieve_friend_posts() {
+		$friends = new Friend_User_Query( array( 'role__in' => array( 'friend', 'acquaintance', 'pending_friend_request', 'subscription' ) ) );
+		$friends = $friends->get_results();
+
+		if ( empty( $friends ) ) {
+			return;
 		}
 
 		foreach ( $friends as $friend_user ) {
-			$post_types = get_user_option( 'friends_post_types', $friend_user->ID );
-			if ( false === $post_types ) {
-				$post_types = 'post';
-			}
-			foreach ( explode( ',', $post_types ) as $post_type ) {
-				$feed_url = $this->get_feed_url( $friend_user, $post_type );
-
-				$feed = $this->fetch_feed( $feed_url );
-				if ( is_wp_error( $feed ) ) {
-					do_action( 'friends_retrieve_friends_error', $feed_url, $feed, $friend_user );
-					continue;
-				}
-				$cache_post_type = $this->friends->get_cache_post_type( $post_type );
-
-				$feed      = apply_filters( 'friends_feed_content', $feed, $friend_user, $cache_post_type );
-				$new_posts = $this->process_friend_feed( $friend_user, $feed );
-				do_action( 'friends_retrieved_new_posts', $new_posts, $friend_user );
-			}
+			$this->retrieve_single_friend_posts( $friend_user );
 		}
-	}
-
-	/**
-	 * Get the (private) feed URL for a friend.
-	 *
-	 * @param  WP_User $friend_user The friend user.
-	 * @param  string  $post_type   The post type for which to get the feed.
-	 * @return string               The feed URL.
-	 */
-	public function get_feed_url( WP_User $friend_user, $post_type = 'post' ) {
-		$feed_url = get_user_option( 'friends_feed_url', $friend_user->ID );
-		if ( ! $feed_url ) {
-			$feed_url = rtrim( $friend_user->user_url, '/' ) . '/feed/';
-		}
-
-		if ( $private && ( current_user_can( Friends::REQUIRED_ROLE ) || wp_doing_cron() ) ) {
-			$token = get_user_option( 'friends_out_token', $friend_user->ID );
-			$sep = '?';
-			if ( $token ) {
-				$feed_url .= $sep . 'friend=' . $token;
-				$sep = '&';
-			}
-			if ( 'post' !== $post_type ) {
-				$feed_url .= $sep . 'post_type=' . $post_type;
-				$sep = '&';
-			}
-		}
-		return apply_filters( 'friends_friend_feed_url', $feed_url, $friend_user );
-	}
-
-	/**
-	 * Retrieve the remote post ids.
-	 *
-	 * @param  WP_User $friend_user The friend user.
-	 * @return array A mapping of the remote post ids.
-	 */
-	public function get_remote_post_ids( WP_User $friend_user ) {
-		$remote_post_ids = array();
-		$existing_posts  = new WP_Query(
-			array(
-				'post_type'   => $this->friends->get_all_cached_post_types(),
-				'post_status' => array( 'publish', 'private', 'trash' ),
-				'author'      => $friend_user->ID,
-				'nopaging'    => true,
-			)
-		);
-
-		if ( $existing_posts->have_posts() ) {
-			while ( $existing_posts->have_posts() ) {
-				$post           = $existing_posts->next_post();
-				$remote_post_id = get_post_meta( $post->ID, 'remote_post_id', true );
-				if ( $remote_post_id ) {
-					$remote_post_ids[ $remote_post_id ] = $post->ID;
-				}
-				$permalink                     = get_permalink( $post );
-				$remote_post_ids[ $permalink ] = $post->ID;
-				$permalink                     = str_replace( array( '&#38;', '&#038;' ), '&', ent2ncr( $permalink ) );
-				$remote_post_ids[ $permalink ] = $post->ID;
-			}
-		}
-
-		do_action( 'friends_remote_post_ids', $remote_post_ids );
-		return $remote_post_ids;
 	}
 
 	/**
 	 * Apply the feed rules
 	 *
-	 * @param  object  $item         The feed item.
-	 * @param  object  $feed         The feed object.
-	 * @param  WP_User $friend_user The friend user.
+	 * @param  object      $item         The feed item.
+	 * @param  object      $feed         The feed object.
+	 * @param  Friend_User $friend_user The friend user.
 	 * @return object The modified feed item.
 	 */
-	public function apply_feed_rules( $item, $feed, WP_User $friend_user ) {
-		$rules  = $this->get_feed_rules( $friend_user );
-		$action = $this->get_feed_catch_all( $friend_user );
+	public function apply_feed_rules( $item, $feed, Friend_User $friend_user ) {
+		$rules  = $friend_user->get_feed_rules();
+		$action = $friend_user->get_feed_catch_all();
 
 		foreach ( $rules as $rule ) {
 			$field = $this->get_feed_rule_field( $rule['field'], $item );
@@ -259,19 +205,6 @@ class Friends_Feed {
 	}
 
 	/**
-	 * Retrieve the rules for this feed.
-	 *
-	 * @param  WP_User $friend_user The friend user.
-	 * @return array The rules set by the user for this feed.
-	 */
-	public function get_feed_rules( WP_User $friend_user ) {
-		if ( ! isset( $this->feed_rules[ $friend_user->ID ] ) ) {
-			$this->feed_rules[ $friend_user->ID ] = $this->validate_feed_rules( get_option( 'friends_feed_rules_' . $friend_user->ID ) );
-		}
-		return $this->feed_rules[ $friend_user->ID ];
-	}
-
-	/**
 	 * Validate feed item rules
 	 *
 	 * @param  array $rules The rules to validate.
@@ -331,19 +264,6 @@ class Friends_Feed {
 	}
 
 	/**
-	 * Retrieve the catch_all value for this feed.
-	 *
-	 * @param  WP_User $friend_user The friend user.
-	 * @return array The rules set by the user for this feed.
-	 */
-	public function get_feed_catch_all( WP_User $friend_user ) {
-		if ( ! isset( $this->feed_catch_all[ $friend_user->ID ] ) ) {
-			$this->feed_catch_all[ $friend_user->ID ] = $this->validate_feed_catch_all( get_option( 'friends_feed_catch_all_' . $friend_user->ID ) );
-		}
-		return $this->feed_catch_all[ $friend_user->ID ];
-	}
-
-	/**
 	 * Validate feed catch_all
 	 *
 	 * @param  array $catch_all The catch_all value to.
@@ -360,15 +280,13 @@ class Friends_Feed {
 	/**
 	 * Process the feed of a friend user.
 	 *
-	 * @param  WP_User   $friend_user The friend user.
-	 * @param  SimplePie $feed        The RSS feed object of the friend user.
-	 * @param  string    $cache_post_type The post type to be used for caching the feed items.
+	 * @param  Friend_User $friend_user The friend user.
+	 * @param  SimplePie   $feed        The RSS feed object of the friend user.
+	 * @param  string      $cache_post_type The post type to be used for caching the feed items.
 	 */
-	public function process_friend_feed( WP_User $friend_user, SimplePie $feed, $cache_post_type ) {
-		$new_friend = get_user_option( 'friends_new_friend', $friend_user->ID );
-
-		$remote_post_ids = $this->get_remote_post_ids( $friend_user );
-		$rules           = $this->get_feed_rules( $friend_user );
+	public function process_friend_feed( Friend_User $friend_user, SimplePie $feed, $cache_post_type ) {
+		$remote_post_ids = $friend_user->get_remote_post_ids();
+		$rules           = $friend_user->get_feed_rules();
 		$new_posts       = array();
 
 		foreach ( $feed->get_items() as $item ) {
@@ -471,17 +389,6 @@ class Friends_Feed {
 			$wpdb->update( $wpdb->posts, array( 'comment_count' => $item->comment_count ), array( 'ID' => $post_id ) );
 		}
 
-		if ( $new_friend ) {
-			delete_user_option( $friend_user->ID, 'friends_new_friend' );
-		} else {
-			foreach ( $new_posts as $post_id ) {
-				$notify_users = apply_filters( 'notify_about_new_friend_post', true, $friend_user, $post_id );
-				if ( $notify_users ) {
-					do_action( 'notify_new_friend_post', get_post( intval( $post_id ) ) );
-				}
-			}
-		}
-
 		return $new_posts;
 	}
 
@@ -563,7 +470,7 @@ class Friends_Feed {
 			wp_die( esc_html__( 'Sorry, you are not allowed to view this page.', 'friends' ) );
 		}
 
-		$friends = new WP_User_Query( array( 'role__in' => array( 'friend', 'acquaintance', 'friend_request', 'subscription' ) ) );
+		$friends = new Friend_User_Query( array( 'role__in' => array( 'friend', 'acquaintance', 'friend_request', 'subscription' ) ) );
 		$feed    = $this->friends->feed;
 
 		include apply_filters( 'friends_template_path', 'admin/opml.php' );
@@ -644,7 +551,8 @@ class Friends_Feed {
 	public function retrieve_new_friends_posts( $user_id, $new_role, $old_roles ) {
 		if ( ( 'friend' === $new_role || 'acquaintance' === $new_role ) && apply_filters( 'friends_immediately_fetch_feed', true ) ) {
 			update_user_option( $user_id, 'friends_new_friend', true );
-			$this->retrieve_friend_posts( new WP_User( $user_id ) );
+			$friend = new Friend_User( $user_id );
+			$friend->retrieve_posts();
 		}
 	}
 

--- a/class-friends-frontend.php
+++ b/class-friends-frontend.php
@@ -184,7 +184,7 @@ class Friends_Frontend {
 	public function friend_post_edit_link( $link, $post_id ) {
 		global $post;
 
-		if ( $post && Friends::CPT === $post->post_type ) {
+		if ( $post && $this->friends->is_cached_post_type( $post->post_type ) ) {
 			if ( $this->on_friends_page ) {
 				return false;
 			}
@@ -203,7 +203,7 @@ class Friends_Frontend {
 	 * @reeturn string The overriden post link.
 	 */
 	public function friend_post_link( $post_link, WP_Post $post, $leavename, $sample ) {
-		if ( Friends::CPT === $post->post_type ) {
+		if ( $post && $this->friends->is_cached_post_type( $post->post_type ) ) {
 			return get_the_guid( $post );
 		}
 		return $post_link;
@@ -250,10 +250,17 @@ class Friends_Frontend {
 
 		$page_id = get_query_var( 'page' );
 
+		// Potentially limit post types to be displayed on the friends page.
+		$post_types = get_user_option( 'friends_page_post_types' );
+		if ( false === $post_types ) {
+			$post_types = $this->friends->get_all_post_types();
+		} else {
+			$post_types = explode( ',', $post_types );
+		}
+		$query->set( 'post_type', $post_types );
+
 		$query->set( 'post_status', array( 'publish', 'private' ) );
-		$query->set( 'post_type', array( Friends::CPT, 'post' ) );
 		$query->is_page = false;
-		$query->set( 'page', null );
 		$query->set( 'pagename', null );
 
 		$pagename_parts = explode( '/', trim( $wp_query->query['pagename'], '/' ) );

--- a/class-friends-frontend.php
+++ b/class-friends-frontend.php
@@ -184,7 +184,7 @@ class Friends_Frontend {
 	public function friend_post_edit_link( $link, $post_id ) {
 		global $post;
 
-		if ( $post && $this->friends->is_cached_post_type( $post->post_type ) ) {
+		if ( $post && $this->friends->post_types->is_cached_post_type( $post->post_type ) ) {
 			if ( $this->on_friends_page ) {
 				return false;
 			}
@@ -203,7 +203,7 @@ class Friends_Frontend {
 	 * @reeturn string The overriden post link.
 	 */
 	public function friend_post_link( $post_link, WP_Post $post, $leavename, $sample ) {
-		if ( $post && $this->friends->is_cached_post_type( $post->post_type ) ) {
+		if ( $post && $this->friends->post_types->is_cached_post_type( $post->post_type ) ) {
 			return get_the_guid( $post );
 		}
 		return $post_link;
@@ -253,7 +253,7 @@ class Friends_Frontend {
 		// Potentially limit post types to be displayed on the friends page.
 		$post_types = get_user_option( 'friends_page_post_types' );
 		if ( false === $post_types ) {
-			$post_types = $this->friends->get_all_post_types();
+			$post_types = $this->friends->post_types->get_all();
 		} else {
 			$post_types = explode( ',', $post_types );
 		}

--- a/class-friends-notifications.php
+++ b/class-friends-notifications.php
@@ -52,7 +52,7 @@ class Friends_Notifications {
 			return;
 		}
 
-		$users = Friends::all_admin_users();
+		$users = Friend_User_Query::all_admin_users();
 		$users = $users->get_results();
 
 		foreach ( $users as $user ) {
@@ -94,7 +94,7 @@ class Friends_Notifications {
 			return;
 		}
 
-		$users = Friends::all_admin_users();
+		$users = Friend_User_Query::all_admin_users();
 		$users = $users->get_results();
 
 		foreach ( $users as $user ) {
@@ -132,7 +132,7 @@ class Friends_Notifications {
 	 * @param  WP_User $friend_user The user who accepted friendship.
 	 */
 	public function notify_accepted_friend_request( WP_User $friend_user ) {
-		$users = Friends::all_admin_users();
+		$users = Friend_User_Query::all_admin_users();
 		$users = $users->get_results();
 
 		foreach ( $users as $user ) {

--- a/class-friends-post-types.php
+++ b/class-friends-post-types.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * Friends REST
+ *
+ * This contains the functions for post types.
+ *
+ * @package Friends
+ */
+
+/**
+ * This is the class for the post types part of the Friends Plugin.
+ *
+ * @since 0.21
+ *
+ * @package Friends
+ * @author Alex Kirk
+ */
+class Friends_Post_Types {
+	/**
+	 * Post types registered by other plugins.
+	 *
+	 * @var array
+	 */
+	private $registered_post_types = array();
+
+	/**
+	 * Contains a reference to the Friends class.
+	 *
+	 * @var Friends
+	 */
+	private $friends;
+
+	/**
+	 * Constructor
+	 *
+	 * @param Friends $friends A reference to the Friends object.
+	 */
+	public function __construct( Friends $friends ) {
+		$this->friends = $friends;
+	}
+
+	/**
+	 * Get all the post types that have been registered to be handled by the Friends plugin.
+	 *
+	 * @return array The array of cache post types.
+	 */
+	public function get_all_registered() {
+		return array_keys( $this->registered_post_types );
+	}
+	/**
+	 * Get all the post types that cache posts for friends.
+	 *
+	 * @return array The array of cache post types.
+	 */
+	public function get_all_cached() {
+		return array_values( $this->registered_post_types );
+	}
+
+	/**
+	 * Get all the cached and original post types.
+	 *
+	 * @return array The array of post types.
+	 */
+	public function get_all() {
+		return array_merge( array_keys( $this->registered_post_types ), array_values( $this->registered_post_types ) );
+	}
+
+	/**
+	 * Check whether a post type is a cached post type.
+	 *
+	 * @param  string $cached_post_type The post type to check.
+	 * @return boolean                  Whether the post type is a cached post type.
+	 */
+	public function is_cached_post_type( $cached_post_type ) {
+		return in_array( $cached_post_type, $this->registered_post_types, true );
+	}
+
+	/**
+	 * Check whether a post type has been registered with the Friends plugin.
+	 * Register this through Friends_API::register_post_type( $post_type );
+	 *
+	 * @param  string $post_type The post type to check.
+	 * @return boolean           Whether the post type has been registered.
+	 */
+	public function is_known( $post_type ) {
+		return isset( $this->registered_post_types[ $post_type ] );
+	}
+
+	/**
+	 * Get the corresponding cached post type for the given post type.
+	 *
+	 * @param  string $post_type The post type to check.
+	 * @return string            The post type to be used for caching.
+	 */
+	public function get_cache_post_type( $post_type ) {
+		return $this->registered_post_types[ $post_type ];
+	}
+
+	/**
+	 * Registers a custom post type to be handled by the friends plugin.
+	 *
+	 * @param string $post_type The post type to be registered.
+	 * @return string|false
+	 */
+	public function register( $post_type ) {
+		if ( ! post_type_exists( $post_type ) ) {
+			return new WP_Error( 'inexistant-post-type', "You're trying to register a post type that is not known to WordPress." );
+		}
+
+		$cache_post_type = Friends::CPT_PREFIX . $post_type;
+		if ( 'post' === $post_type ) {
+			$cache_post_type = Friends::CPT;
+		}
+		$this->registered_post_types[ $post_type ] = $cache_post_type;
+		do_action( 'friends_register_post_type', $post_type, $cache_post_type );
+
+		return $post_type;
+	}
+
+	/**
+	 * Unregisters the custom post type from being handled by the friends plugin.
+	 *
+	 * @param string $post_type The post type to be unregistered.
+	 * @return boolean
+	 */
+	public function unregister( $post_type ) {
+		if ( ! isset( $this->registered_post_types[ $post_type ] ) ) {
+			return false;
+		}
+		unset( $this->registered_post_types[ $post_type ] );
+		return true;
+	}
+
+}

--- a/class-friends-reactions.php
+++ b/class-friends-reactions.php
@@ -81,7 +81,7 @@ class Friends_Reactions {
 			'show_admin_column' => true,
 			'query_var'         => true,
 		);
-		register_taxonomy( 'friend-reaction-' . $user_id, array( 'post', Friends::CPT ), $args );
+		register_taxonomy( 'friend-reaction-' . $user_id, $this->friends->get_all_post_types(), $args );
 	}
 
 	/**

--- a/class-friends-reactions.php
+++ b/class-friends-reactions.php
@@ -81,7 +81,7 @@ class Friends_Reactions {
 			'show_admin_column' => true,
 			'query_var'         => true,
 		);
-		register_taxonomy( 'friend-reaction-' . $user_id, $this->friends->get_all_post_types(), $args );
+		register_taxonomy( 'friend-reaction-' . $user_id, $this->friends->post_types->get_all(), $args );
 	}
 
 	/**

--- a/class-friends-recommendation.php
+++ b/class-friends-recommendation.php
@@ -58,7 +58,7 @@ class Friends_Recommendation {
 	 * @return string        The post content with buttons or nothing if echoed.
 	 */
 	public function post_recommendation( $text = '', $echo = false ) {
-		if ( ( Friends::CPT === get_post_type() ) && is_user_logged_in() ) {
+		if ( $this->friends->is_cached_post_type( get_post_type() ) && is_user_logged_in() ) {
 			ob_start();
 			include apply_filters( 'friends_template_path', 'friends/post-recommendation.php' );
 			$recommendation_text = ob_get_contents();
@@ -124,7 +124,7 @@ class Friends_Recommendation {
 
 		$post_id = intval( $_POST['post_id'] );
 		$post    = WP_Post::get_instance( $post_id );
-		if ( Friends::CPT !== $post->post_type ) {
+		if ( ! $this->friends->is_cached_post_type( $post->post_type ) ) {
 			return;
 		}
 
@@ -140,6 +140,7 @@ class Friends_Recommendation {
 				'author'      => get_the_author_meta( 'display_name', $post->post_author ),
 				'gravatar'    => get_avatar_url( $friend_user->ID ),
 				'description' => $post->post_content,
+				'post_type'   => $post->post_type,
 				'message'     => $_POST['message'],
 			);
 		} else {

--- a/class-friends-recommendation.php
+++ b/class-friends-recommendation.php
@@ -58,7 +58,7 @@ class Friends_Recommendation {
 	 * @return string        The post content with buttons or nothing if echoed.
 	 */
 	public function post_recommendation( $text = '', $echo = false ) {
-		if ( $this->friends->is_cached_post_type( get_post_type() ) && is_user_logged_in() ) {
+		if ( $this->friends->post_types->is_cached_post_type( get_post_type() ) && is_user_logged_in() ) {
 			ob_start();
 			include apply_filters( 'friends_template_path', 'friends/post-recommendation.php' );
 			$recommendation_text = ob_get_contents();
@@ -79,7 +79,7 @@ class Friends_Recommendation {
 	 */
 	public function recommendation_form() {
 		if ( is_user_logged_in() ) {
-			$friends = Friends::all_friends();
+			$friends = Friend_User_Query::all_friends();
 			include apply_filters( 'friends_template_path', 'friends/recommendation-form.php' );
 		}
 	}
@@ -124,7 +124,7 @@ class Friends_Recommendation {
 
 		$post_id = intval( $_POST['post_id'] );
 		$post    = WP_Post::get_instance( $post_id );
-		if ( ! $this->friends->is_cached_post_type( $post->post_type ) ) {
+		if ( ! $this->friends->post_types->is_cached_post_type( $post->post_type ) ) {
 			return;
 		}
 

--- a/class-friends-rest.php
+++ b/class-friends-rest.php
@@ -152,7 +152,7 @@ class Friends_REST {
 		$friend_user_id = get_option( 'friends_request_' . sha1( $request_id ) );
 		$friend_user    = false;
 		if ( $friend_user_id ) {
-			$friend_user = new WP_User( $friend_user_id );
+			$friend_user = new Friend_User( $friend_user_id );
 		}
 
 		if ( ! $request_id || ! $friend_user || is_wp_error( $friend_user ) || ! $friend_user->user_url ) {
@@ -177,7 +177,7 @@ class Friends_REST {
 			);
 		}
 
-		$friend_user_login = $this->friends->access_control->get_user_login_for_url( $friend_user->user_url );
+		$friend_user_login = Friend_User::get_user_login_for_url( $friend_user->user_url );
 		if ( $friend_user_login !== $friend_user->user_login ) {
 			return new WP_Error(
 				'friends_offer_no_longer_valid',
@@ -198,9 +198,9 @@ class Friends_REST {
 				)
 			);
 		}
-		$this->friends->access_control->make_friend( $friend_user, $future_out_token, $future_in_token );
+		$friend_user->make_friend( $future_out_token, $future_in_token );
 
-		$this->friends->access_control->update_user_icon_url( $friend_user->ID, $request->get_param( 'icon_url' ) );
+		$friend_user->update_user_icon_url( $request->get_param( 'icon_url' ) );
 		if ( $request->get_param( 'name' ) ) {
 			wp_update_user(
 				array(
@@ -271,20 +271,19 @@ class Friends_REST {
 			);
 		}
 
-		$friend_user = $this->friends->access_control->create_user( $url, 'friend_request', $request->get_param( 'name' ), $request->get_param( 'icon_url' ) );
+		$friend_user = Friend_User::create( $url, 'friend_request', $request->get_param( 'name' ), $request->get_param( 'icon_url' ) );
 		if ( $friend_user->has_cap( 'friend' ) ) {
 			if ( get_user_option( 'friends_out_token', $friend_user->ID ) && ! get_user_option( 'friends_out_token', $friend_user->ID ) ) {
 				// TODO: trigger an accept friend request right away?
 			}
 			$friend_user->set_role( 'friend_request' );
 		}
-		$this->friends->access_control->update_user_icon_url( $friend_user->ID, $request->get_param( 'icon_url' ) );
-
-		update_user_option( $friend_user->ID, 'friends_future_out_token', $request->get_param( 'key' ) );
-		update_user_option( $friend_user->ID, 'friends_request_message', mb_substr( $request->get_param( 'message' ), 0, 2000 ) );
+		$friend_user->update_user_icon_url( $request->get_param( 'icon_url' ) );
+		$friend_user->update_user_option( 'friends_future_out_token', $request->get_param( 'key' ) );
+		$friend_user->update_user_option( 'friends_request_message', mb_substr( $request->get_param( 'message' ), 0, 2000 ) );
 
 		$request_id = sha1( wp_generate_password( 256 ) );
-		update_user_option( $friend_user->ID, 'friends_request_id', $request_id );
+		$friend_user->update_user_option( 'friends_request_id', $request_id );
 
 		return array(
 			'request' => $request_id,
@@ -302,18 +301,18 @@ class Friends_REST {
 			return;
 		}
 
-		$friends = Friends::all_friends();
+		$friends = Friend_User_Query::all_friends();
 		$friends = $friends->get_results();
 
 		foreach ( $friends as $friend_user ) {
-			$friend_rest_url = $this->friends->access_control->get_rest_url( $friend_user );
+			$friend_rest_url = $friend_user->get_rest_url();
 
 			$response = wp_safe_remote_post(
 				$friend_rest_url . '/post-deleted',
 				array(
 					'body'        => array(
 						'post_id' => $post_id,
-						'friend'  => get_user_option( 'friends_out_token', $friend_user->ID ),
+						'friend'  => $friend_user->get_user_option( 'friends_out_token' ),
 					),
 					'timeout'     => 20,
 					'redirection' => 5,
@@ -340,7 +339,7 @@ class Friends_REST {
 				)
 			);
 		}
-		$friend_user     = new WP_User( $user_id );
+		$friend_user     = new Friend_User( $user_id );
 		$remote_post_id  = $request->get_param( 'post_id' );
 		$remote_post_ids = $this->friends->feed->get_remote_post_ids( $friend_user );
 
@@ -352,7 +351,7 @@ class Friends_REST {
 
 		$post_id = $remote_post_ids[ $remote_post_id ];
 		$post    = WP_Post::get_instance( $post_id );
-		if ( $this->friends->is_cached_post_type( $post->post_type ) ) {
+		if ( $this->friends->post_types->is_cached_post_type( $post->post_type ) ) {
 			wp_delete_post( $post_id );
 		}
 
@@ -374,7 +373,7 @@ class Friends_REST {
 			return;
 		}
 
-		$friends = new WP_User_Query(
+		$friends = new Friend_User_Query(
 			array(
 				'role'    => 'friend',
 				'exclude' => array( $exclude_friend_user_id ),
@@ -417,7 +416,7 @@ class Friends_REST {
 				)
 			);
 		}
-		$friend_user     = new WP_User( $user_id );
+		$friend_user     = new Friend_User( $user_id );
 		$remote_post_id  = $request->get_param( 'post_id' );
 		$remote_post_ids = $this->friends->feed->get_remote_post_ids( $friend_user );
 
@@ -443,16 +442,16 @@ class Friends_REST {
 	 */
 	public function notify_friend_of_my_reaction( $post_id ) {
 		$post = WP_Post::get_instance( $post_id );
-		if ( ! $this->friends->is_cached_post_type( $post->post_type ) ) {
+		if ( ! $this->friends->post_types->is_cached_post_type( $post->post_type ) ) {
 			return;
 		}
 
-		$friend_user = new WP_User( $post->post_author );
+		$friend_user = new Friend_User( $post->post_author );
 
 		$reactions      = $this->friends->reactions->get_my_reactions( $post->ID );
 		$remote_post_id = get_post_meta( $post->ID, 'remote_post_id', true );
 
-		$friend_rest_url = $this->friends->access_control->get_rest_url( $friend_user );
+		$friend_rest_url = $friend_user->get_rest_url( $friend_user );
 
 		$response = wp_safe_remote_post(
 			$friend_rest_url . '/my-reactions',
@@ -486,7 +485,7 @@ class Friends_REST {
 				)
 			);
 		}
-		$friend_user = new WP_User( $user_id );
+		$friend_user = new Friend_User( $user_id );
 		$post_id     = $request->get_param( 'post_id' );
 		$post        = WP_Post::get_instance( $post_id );
 
@@ -531,7 +530,7 @@ class Friends_REST {
 			'thank' => 'you',
 		);
 
-		$friend_user = new WP_User( $user_id );
+		$friend_user = new Friend_User( $user_id );
 
 		$permalink = $request->get_param( 'link' );
 		$sha1_link = $request->get_param( 'sha1_link' );
@@ -588,7 +587,7 @@ class Friends_REST {
 			'post_status'  => 'publish',
 			'post_author'  => $friend_user->ID,
 			'guid'         => $permalink,
-			'post_type'    => $this->friends->get_cache_post_type( $request->get_param( 'post_type' ) ),
+			'post_type'    => $this->friends->post_types->get_cache_post_type( $request->get_param( 'post_type' ) ),
 			'tags_input'   => array( 'recommendation' ),
 		);
 
@@ -674,11 +673,11 @@ class Friends_REST {
 			return;
 		}
 
-		$friend_user = new WP_User( $user_id );
+		$friend_user = new Friend_User( $user_id );
 
-		$friend_rest_url  = $this->friends->access_control->get_rest_url( $friend_user );
-		$request_id       = get_user_option( 'friends_request_id', $friend_user->ID );
-		$future_out_token = get_user_option( 'friends_future_out_token', $friend_user->ID );
+		$friend_rest_url  = $friend_user->get_rest_url();
+		$request_id       = $friend_user->get_user_option( 'friends_request_id' );
+		$future_out_token = $friend_user->get_user_option( 'friends_future_out_token' );
 		$future_in_token  = sha1( wp_generate_password( 256 ) );
 
 		$current_user = wp_get_current_user();
@@ -709,9 +708,9 @@ class Friends_REST {
 			return;
 		}
 
-		$this->friends->access_control->make_friend( $friend_user, $future_out_token, $future_in_token );
-		delete_user_option( $friend_user->ID, 'friends_request_id' );
-		delete_user_option( $friend_user->ID, 'friends_future_out_token' );
+		$friend_user->make_friend( $future_out_token, $future_in_token );
+		$friend_user->delete_user_option( 'friends_request_id' );
+		$friend_user->delete_user_option( 'friends_future_out_token' );
 
 		/*
 		TODO

--- a/class-friends-shortcodes.php
+++ b/class-friends-shortcodes.php
@@ -95,7 +95,7 @@ class Friends_Shortcodes {
 			$atts
 		);
 
-		$friends = Friends::all_friends();
+		$friends = Friend_User_Query::all_friends();
 		$ret     = '<ul class="friend-list">';
 
 		foreach ( $friends->get_results() as $friend_user ) {
@@ -127,7 +127,7 @@ class Friends_Shortcodes {
 	 * @return string The content to be output.
 	 */
 	public function friends_count_shortcode( $atts ) {
-		$friends = Friends::all_friends();
+		$friends = Friend_User_Query::all_friends();
 		return $friends->get_total();
 	}
 

--- a/friends.php
+++ b/friends.php
@@ -20,13 +20,18 @@
 
 defined( 'ABSPATH' ) || exit;
 
+include __DIR__ . '/class-friend-user.php';
+include __DIR__ . '/class-friend-user-query.php';
+
 include __DIR__ . '/class-friends-access-control.php';
 include __DIR__ . '/class-friends-admin.php';
+include __DIR__ . '/class-friends-api.php';
 include __DIR__ . '/class-friends-blocks.php';
 include __DIR__ . '/class-friends-feed.php';
 include __DIR__ . '/class-friends-frontend.php';
 include __DIR__ . '/class-friends-logging.php';
 include __DIR__ . '/class-friends-notifications.php';
+include __DIR__ . '/class-friends-post-types.php';
 include __DIR__ . '/class-friends-reactions.php';
 include __DIR__ . '/class-friends-recommendation.php';
 include __DIR__ . '/class-friends-rest.php';

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -7,6 +7,9 @@
 		<exclude name="WordPress.PHP.StrictInArray.MissingTrueStrict" />
 	</rule>
 	<rule ref="WordPress-Docs" />
+	<rule ref="WordPress.WP.GlobalVariablesOverride.OverrideProhibited">
+		<exclude-pattern>bin/tests/isolated/*</exclude-pattern>
+	</rule>
 
 	<!-- Check all PHP files in directory tree by default. -->
 	<arg name="extensions" value="php"/>

--- a/templates/friends/posts.php
+++ b/templates/friends/posts.php
@@ -46,7 +46,7 @@ include __DIR__ . '/header.php'; ?>
 		<article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
 			<header class="entry-header">
 				<div class="avatar">
-					<?php if ( Friends::CPT === get_post_type() ) : ?>
+					<?php if ( $friends->is_cached_post_type( get_post_type() ) ) : ?>
 						<?php if ( $recommendation ) : ?>
 							<a href="<?php the_permalink(); ?>" rel="noopener noreferrer">
 								<img src="<?php echo esc_url( $avatar ); ?>" width="36" height="36" class="avatar" />
@@ -64,7 +64,7 @@ include __DIR__ . '/header.php'; ?>
 				</div>
 				<div class="post-meta">
 					<div class="author">
-						<?php if ( Friends::CPT === get_post_type() ) : ?>
+						<?php if ( $friends->is_cached_post_type( get_post_type() ) ) : ?>
 							<?php if ( $recommendation ) : ?>
 								<a href="<?php the_permalink(); ?>" rel="noopener noreferrer" ><strong><?php echo esc_html( get_post_meta( get_the_ID(), 'author', true ) ); ?></strong></a>
 							<?php else : ?>
@@ -81,7 +81,7 @@ include __DIR__ . '/header.php'; ?>
 					<span class="post-date" title="<?php echo get_the_time( 'r' ); ?>"><?php /* translators: %s is a time span */ printf( __( '%s ago' ), human_time_diff( get_the_time( 'U' ), current_time( 'timestamp' ) ) ); ?></span>
 					<?php edit_post_link(); ?>
 				</div>
-				<?php if ( false && Friends::CPT === get_post_type() ) : ?>
+				<?php if ( false && $friends->is_cached_post_type( get_post_type() ) ) : ?>
 					<button class="friends-trash-post" title="<?php esc_attr_e( 'Trash this post', 'friends' ); ?>" data-trash-nonce="<?php echo esc_attr( wp_create_nonce( 'trash-post_' . get_the_ID() ) ); ?>" data-untrash-nonce="<?php echo esc_attr( wp_create_nonce( 'untrash-post_' . get_the_ID() ) ); ?>" data-id="<?php echo esc_attr( get_the_ID() ); ?>">
 						&#x1F5D1;
 					</button>
@@ -89,7 +89,7 @@ include __DIR__ . '/header.php'; ?>
 			</header>
 
 			<h4 class="entry-title">
-				<?php if ( Friends::CPT === get_post_type() ) : ?>
+				<?php if ( $friends->is_cached_post_type( get_post_type() ) ) : ?>
 					<?php if ( $recommendation ) : ?>
 						<a href="<?php the_permalink(); ?>" target="_blank" rel="noopener noreferrer" class="auth-link" data-token="<?php echo esc_attr( $token ); ?>">
 							<?php
@@ -109,7 +109,7 @@ include __DIR__ . '/header.php'; ?>
 
 			<div class="entry-content">
 				<?php
-				if ( Friends::CPT === get_post_type() && $recommendation ) {
+				if ( $friends->is_cached_post_type( get_post_type() ) && $recommendation ) {
 					$friend_name = '<a href="' . esc_url( get_the_author_meta( 'url' ) ) . '" class="auth-link" data-token="' . esc_attr( $token ) . '">' . esc_html( get_the_author() ) . '</a>';
 					?>
 					<p class="friend-recommendation">
@@ -150,12 +150,12 @@ include __DIR__ . '/header.php'; ?>
 			</div>
 
 			<footer class="entry-meta">
-				<?php if ( Friends::CPT === get_post_type() && $token ) : ?>
+				<?php if ( $friends->is_cached_post_type( get_post_type() ) && $token ) : ?>
 				<button href="<?php comments_link(); ?>" target="_blank" rel="noopener noreferrer" class="comments auth-link" data-token="<?php echo esc_attr( $token ); ?>">
 					<span class="dashicons dashicons-admin-comments"></span>
 					<?php comments_number( '', 1, '%' ); ?>
 				</button>
-				<?php elseif ( Friends::CPT === get_post_type() ) : ?>
+				<?php elseif ( $friends->is_cached_post_type( get_post_type() ) ) : ?>
 				<a href="<?php comments_link(); ?>" target="_blank" rel="noopener noreferrer" class="comments button">
 					<span class="dashicons dashicons-admin-comments"></span>
 					<?php comments_number( '', 1, '%' ); ?>
@@ -167,7 +167,7 @@ include __DIR__ . '/header.php'; ?>
 				</a>
 				<?php endif; ?>
 				<?php echo $friends->reactions->post_reactions(); ?>
-				<?php if ( Friends::CPT === get_post_type() ) : ?>
+				<?php if ( $friends->is_cached_post_type( get_post_type() ) ) : ?>
 					<?php echo $friends->recommendation->post_recommendation(); ?>
 				<?php endif; ?>
 			</footer>

--- a/templates/friends/posts.php
+++ b/templates/friends/posts.php
@@ -46,7 +46,7 @@ include __DIR__ . '/header.php'; ?>
 		<article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
 			<header class="entry-header">
 				<div class="avatar">
-					<?php if ( $friends->is_cached_post_type( get_post_type() ) ) : ?>
+					<?php if ( $friends->post_types->is_cached_post_type( get_post_type() ) ) : ?>
 						<?php if ( $recommendation ) : ?>
 							<a href="<?php the_permalink(); ?>" rel="noopener noreferrer">
 								<img src="<?php echo esc_url( $avatar ); ?>" width="36" height="36" class="avatar" />
@@ -64,7 +64,7 @@ include __DIR__ . '/header.php'; ?>
 				</div>
 				<div class="post-meta">
 					<div class="author">
-						<?php if ( $friends->is_cached_post_type( get_post_type() ) ) : ?>
+						<?php if ( $friends->post_types->is_cached_post_type( get_post_type() ) ) : ?>
 							<?php if ( $recommendation ) : ?>
 								<a href="<?php the_permalink(); ?>" rel="noopener noreferrer" ><strong><?php echo esc_html( get_post_meta( get_the_ID(), 'author', true ) ); ?></strong></a>
 							<?php else : ?>
@@ -81,7 +81,7 @@ include __DIR__ . '/header.php'; ?>
 					<span class="post-date" title="<?php echo get_the_time( 'r' ); ?>"><?php /* translators: %s is a time span */ printf( __( '%s ago' ), human_time_diff( get_the_time( 'U' ), current_time( 'timestamp' ) ) ); ?></span>
 					<?php edit_post_link(); ?>
 				</div>
-				<?php if ( false && $friends->is_cached_post_type( get_post_type() ) ) : ?>
+				<?php if ( false && $friends->post_types->is_cached_post_type( get_post_type() ) ) : ?>
 					<button class="friends-trash-post" title="<?php esc_attr_e( 'Trash this post', 'friends' ); ?>" data-trash-nonce="<?php echo esc_attr( wp_create_nonce( 'trash-post_' . get_the_ID() ) ); ?>" data-untrash-nonce="<?php echo esc_attr( wp_create_nonce( 'untrash-post_' . get_the_ID() ) ); ?>" data-id="<?php echo esc_attr( get_the_ID() ); ?>">
 						&#x1F5D1;
 					</button>
@@ -89,7 +89,7 @@ include __DIR__ . '/header.php'; ?>
 			</header>
 
 			<h4 class="entry-title">
-				<?php if ( $friends->is_cached_post_type( get_post_type() ) ) : ?>
+				<?php if ( $friends->post_types->is_cached_post_type( get_post_type() ) ) : ?>
 					<?php if ( $recommendation ) : ?>
 						<a href="<?php the_permalink(); ?>" target="_blank" rel="noopener noreferrer" class="auth-link" data-token="<?php echo esc_attr( $token ); ?>">
 							<?php
@@ -109,7 +109,7 @@ include __DIR__ . '/header.php'; ?>
 
 			<div class="entry-content">
 				<?php
-				if ( $friends->is_cached_post_type( get_post_type() ) && $recommendation ) {
+				if ( $friends->post_types->is_cached_post_type( get_post_type() ) && $recommendation ) {
 					$friend_name = '<a href="' . esc_url( get_the_author_meta( 'url' ) ) . '" class="auth-link" data-token="' . esc_attr( $token ) . '">' . esc_html( get_the_author() ) . '</a>';
 					?>
 					<p class="friend-recommendation">
@@ -150,12 +150,12 @@ include __DIR__ . '/header.php'; ?>
 			</div>
 
 			<footer class="entry-meta">
-				<?php if ( $friends->is_cached_post_type( get_post_type() ) && $token ) : ?>
+				<?php if ( $friends->post_types->is_cached_post_type( get_post_type() ) && $token ) : ?>
 				<button href="<?php comments_link(); ?>" target="_blank" rel="noopener noreferrer" class="comments auth-link" data-token="<?php echo esc_attr( $token ); ?>">
 					<span class="dashicons dashicons-admin-comments"></span>
 					<?php comments_number( '', 1, '%' ); ?>
 				</button>
-				<?php elseif ( $friends->is_cached_post_type( get_post_type() ) ) : ?>
+				<?php elseif ( $friends->post_types->is_cached_post_type( get_post_type() ) ) : ?>
 				<a href="<?php comments_link(); ?>" target="_blank" rel="noopener noreferrer" class="comments button">
 					<span class="dashicons dashicons-admin-comments"></span>
 					<?php comments_number( '', 1, '%' ); ?>
@@ -167,7 +167,7 @@ include __DIR__ . '/header.php'; ?>
 				</a>
 				<?php endif; ?>
 				<?php echo $friends->reactions->post_reactions(); ?>
-				<?php if ( $friends->is_cached_post_type( get_post_type() ) ) : ?>
+				<?php if ( $friends->post_types->is_cached_post_type( get_post_type() ) ) : ?>
 					<?php echo $friends->recommendation->post_recommendation(); ?>
 				<?php endif; ?>
 			</footer>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -82,3 +82,5 @@ if ( defined( 'TESTS_VERBOSE' ) && TESTS_VERBOSE ) {
 		4
 	);
 }
+
+Friend_User_query::$cache = false;

--- a/tests/class-local-feed-fetcher.php
+++ b/tests/class-local-feed-fetcher.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * Class Local_Feed_Fetcher
+ *
+ * @package Friends
+ */
+
+/**
+ * Allow local fetching of a feed by attaching a filter
+ */
+class Local_Feed_Fetcher extends SimplePie_File {
+	/**
+	 * The URL that was retrieved.
+	 *
+	 * @var string
+	 */
+	public $url;
+
+	/**
+	 * The user-agent that was used.
+	 *
+	 * @var $useragent
+	 */
+	public $useragent;
+
+	/**
+	 * Whether the fetch was successful.
+	 *
+	 * @var boolean
+	 */
+	public $success = true;
+
+	/**
+	 * The server headers returned.
+	 *
+	 * @var array
+	 */
+	public $headers = array(
+		'content-type' => 'application/rss+xml',
+	);
+
+	/**
+	 * The body that was returned.
+	 *
+	 * @var string
+	 */
+	public $body;
+
+	/**
+	 * The status code that was returned.
+	 *
+	 * @var integer
+	 */
+	public $status_code = 200;
+
+	/**
+	 * The number of redirects that happened.
+	 *
+	 * @var integer
+	 */
+	public $redirects = 0;
+
+	/**
+	 * A possible error message
+	 *
+	 * @var string
+	 */
+	public $error;
+
+	/**
+	 * The method that was used to retrieve the content.
+	 *
+	 * @var integer
+	 */
+	public $method = SIMPLEPIE_FILE_SOURCE_REMOTE;
+
+	/**
+	 * Instanciate the class
+	 *
+	 * @param string  $url             The url to retrieve.
+	 * @param integer $timeout         The time we have to fetch this.
+	 * @param integer $redirects       How many redirects are ok.
+	 * @param array   $headers         Headers to send in the request.
+	 * @param string  $useragent       User-agent to use in this request.
+	 * @param boolean $force_fsockopen Whether to force usage of fsockopen.
+	 */
+	public function __construct( $url, $timeout = 10, $redirects = 5, $headers = null, $useragent = null, $force_fsockopen = false ) {
+		$this->url = $url;
+		$this->useragent = $useragent;
+		return apply_filters( 'local_fetch_feed', $this );
+	}
+}

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -1,0 +1,200 @@
+<?php
+/**
+ * Class Friends_APITest
+ *
+ * @package Friends
+ */
+
+/**
+ * Test the Notifications
+ */
+class Friends_APITest extends WP_UnitTestCase {
+	/**
+	 * Current User ID
+	 *
+	 * @var int
+	 */
+	private $user_id;
+
+	/**
+	 * User ID of a friend at friend.local
+	 *
+	 * @var int
+	 */
+	private $friend_id;
+
+	/**
+	 * Token for the friend at friend.local
+	 *
+	 * @var int
+	 */
+	private $friends_in_token;
+
+	/**
+	 * Setup the unit tests.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->factory->post->create(
+			array(
+				'post_type'     => 'post',
+				'post_title'    => 'First Friend Post',
+				'post_date_gmt' => '2018-05-01 10:00:00',
+				'post_status'   => 'private',
+			)
+		);
+
+		$this->factory->post->create(
+			array(
+				'post_type'     => 'post',
+				'post_title'    => 'Public Friend Post',
+				'post_date_gmt' => '2018-05-02 10:00:00',
+				'post_status'   => 'publish',
+			)
+		);
+		register_post_type( 'photo' );
+		Friends_API::register_post_type( 'photo' );
+
+		$this->factory->post->create(
+			array(
+				'post_type'     => 'photo',
+				'post_title'    => 'First Friend Photo',
+				'post_date_gmt' => '2018-05-03 10:00:00',
+				'post_status'   => 'private',
+			)
+		);
+
+		$this->factory->post->create(
+			array(
+				'post_type'     => 'photo',
+				'post_title'    => 'Public Friend Photo',
+				'post_date_gmt' => '2018-05-04 10:00:00',
+				'post_status'   => 'publish',
+			)
+		);
+
+		$this->user_id = $this->factory->user->create(
+			array(
+				'user_login' => 'me.local',
+				'user_email' => 'me@example.org',
+				'role'       => 'administrator',
+				'user_url'   => 'https://me.local',
+			)
+		);
+
+		$this->friend_id        = $this->factory->user->create(
+			array(
+				'user_login' => 'friend.local',
+				'user_email' => 'friend@example.org',
+				'role'       => 'friend',
+				'user_url'   => 'https://friend.local',
+			)
+		);
+		$friends                = Friends::get_instance();
+
+		$this->friends_in_token = sha1( wp_generate_password( 256 ) );
+		if ( update_user_option( $this->friend_id, 'friends_in_token', $this->friends_in_token ) ) {
+			update_option( 'friends_in_token_' . $this->friends_in_token, $this->friend_id );
+		}
+
+		if ( ! class_exists( 'SimplePie', false ) ) {
+			spl_autoload_register( array( $friends->feed, 'wp_simplepie_autoload' ) );
+
+			require_once __DIR__ . '/../lib/SimplePie.php';
+		}
+		require_once __DIR__ . '/class-local-feed-fetcher.php';
+		add_action( 'wp_feed_options', array( $this, 'wp_feed_options' ), 100, 2 );
+		add_filter( 'local_fetch_feed', array( $this, 'local_fetch_feed' ), 100, 2 );
+	}
+
+	/**
+	 * Clean up after unit tests
+	 */
+	public function tearDown() {
+		parent::tearDown();
+		unregister_post_type( 'photo' );
+		Friends_API::unregister_post_type( 'photo' );
+	}
+
+	/**
+	 * Simulate that a feed was retrieved
+	 *
+	 * @param  Local_Feed_Fetcher $file The class that SimplePie asked to retrieve the content.
+	 * @return Local_Feed_Fetcher The class that has the content set to its properties.
+	 *
+	 * @throws Exception  This might be triggered by feed-rss2.
+	 */
+	public function local_fetch_feed( $file ) {
+		ob_start();
+		$this->go_to( $file->url );
+		// Nasty hack! In the future it would better to leverage do_feed( 'rss2' ).
+		global $post;
+		try {
+			require( ABSPATH . 'wp-includes/feed-rss2.php' );
+			$out = ob_get_clean();
+		} catch ( Exception $e ) {
+			$out = ob_get_clean();
+			throw($e);
+		}
+		$file->body = $out;
+		return $file;
+	}
+
+	/**
+	 * Configure feed downloading options
+	 *
+	 * @param  SimplePie $feed The SimplePie object.
+	 * @param  string    $url  The URL to fetch.
+	 */
+	public function wp_feed_options( $feed, $url ) {
+		$feed->enable_cache( false );
+		$feed->set_file_class( 'Local_Feed_Fetcher' );
+	}
+
+	/**
+	 * Test getting your friends posts via RSS.
+	 */
+	public function test_get_non_friend_posts() {
+		$friend_user = new Friend_User( $this->friend_id );
+		$posts = $friend_user->retrieve_posts();
+		$this->assertArrayHasKey( 'post', $posts );
+		$this->assertCount( 1, $posts['post'] );
+	}
+
+	/**
+	 * Test getting your friends posts via RSS.
+	 */
+	public function test_get_friend_posts() {
+		wp_set_current_user( $this->user_id );
+		$friend_user = new Friend_User( $this->friend_id );
+		$posts = $friend_user->retrieve_posts();
+		$this->assertArrayHasKey( 'post', $posts );
+		$this->assertCount( 2, $posts['post'] );
+	}
+
+	/**
+	 * Test getting your friends posts via RSS.
+	 */
+	public function test_get_non_friend_posts_photos() {
+		$friend_user = new Friend_User( $this->friend_id );
+		$posts = $friend_user->retrieve_posts();
+		$this->assertArrayHasKey( 'post', $posts );
+		$this->assertArrayHasKey( 'photo', $posts );
+		$this->assertCount( 1, $posts['post'] );
+		$this->assertCount( 1, $posts['photo'] );
+	}
+
+	/**
+	 * Test getting your friends posts via RSS.
+	 */
+	public function test_get_friend_posts_photos() {
+		wp_set_current_user( $this->user_id );
+		$friend_user = new Friend_User( $this->friend_id );
+		$posts = $friend_user->retrieve_posts();
+		$this->assertArrayHasKey( 'post', $posts );
+		$this->assertArrayHasKey( 'photo', $posts );
+		$this->assertCount( 2, $posts['post'] );
+		$this->assertCount( 2, $posts['photo'] );
+	}
+}

--- a/tests/test-feed.php
+++ b/tests/test-feed.php
@@ -1,21 +1,14 @@
 <?php
 /**
- * Class Friends_NoticiationTest
+ * Class Friends_FeedTest
  *
  * @package Friends
  */
 
 /**
- * Test the Notifications
+ * Test the Feed
  */
 class Friends_FeedTest extends WP_UnitTestCase {
-	/**
-	 * Current User ID
-	 *
-	 * @var int
-	 */
-	private $user_id;
-
 	/**
 	 * User ID of a friend at friend.local
 	 *
@@ -107,7 +100,7 @@ class Friends_FeedTest extends WP_UnitTestCase {
 		$feed->set_file( $file );
 		$feed->init();
 
-		$user = new WP_User( $this->friend_id );
+		$user = new Friend_User( $this->friend_id );
 
 		$friends   = Friends::get_instance();
 		$new_items = $friends->feed->process_friend_feed( $user, $feed, Friends::CPT );
@@ -127,7 +120,7 @@ class Friends_FeedTest extends WP_UnitTestCase {
 		$feed->set_file( $file );
 		$feed->init();
 
-		$user = new WP_User( $this->friend_id );
+		$user = new Friend_User( $this->friend_id );
 
 		$friends   = Friends::get_instance();
 		$new_items = $friends->feed->process_friend_feed( $user, $feed, Friends::CPT );
@@ -147,7 +140,7 @@ class Friends_FeedTest extends WP_UnitTestCase {
 		$feed->set_file( $file );
 		$feed->init();
 
-		$user = new WP_User( $this->friend_id );
+		$user = new Friend_User( $this->friend_id );
 
 		$friends   = Friends::get_instance();
 		$new_items = $friends->feed->process_friend_feed( $user, $feed, Friends::CPT );
@@ -167,7 +160,7 @@ class Friends_FeedTest extends WP_UnitTestCase {
 		$feed->set_file( $file );
 		$feed->init();
 
-		$user = new WP_User( $this->friend_id );
+		$user = new Friend_User( $this->friend_id );
 
 		$friends   = Friends::get_instance();
 		$new_items = $friends->feed->process_friend_feed( $user, $feed, Friends::CPT );

--- a/tests/test-feed.php
+++ b/tests/test-feed.php
@@ -110,10 +110,10 @@ class Friends_FeedTest extends WP_UnitTestCase {
 		$user = new WP_User( $this->friend_id );
 
 		$friends   = Friends::get_instance();
-		$new_items = $friends->feed->process_friend_feed( $user, $feed );
+		$new_items = $friends->feed->process_friend_feed( $user, $feed, Friends::CPT );
 		$this->assertCount( 1, $new_items );
 
-		$new_items = $friends->feed->process_friend_feed( $user, $feed );
+		$new_items = $friends->feed->process_friend_feed( $user, $feed, Friends::CPT );
 		$this->assertCount( 0, $new_items );
 	}
 
@@ -130,10 +130,10 @@ class Friends_FeedTest extends WP_UnitTestCase {
 		$user = new WP_User( $this->friend_id );
 
 		$friends   = Friends::get_instance();
-		$new_items = $friends->feed->process_friend_feed( $user, $feed );
+		$new_items = $friends->feed->process_friend_feed( $user, $feed, Friends::CPT );
 		$this->assertCount( 1, $new_items );
 
-		$new_items = $friends->feed->process_friend_feed( $user, $feed );
+		$new_items = $friends->feed->process_friend_feed( $user, $feed, Friends::CPT );
 		$this->assertCount( 0, $new_items );
 	}
 
@@ -150,10 +150,10 @@ class Friends_FeedTest extends WP_UnitTestCase {
 		$user = new WP_User( $this->friend_id );
 
 		$friends   = Friends::get_instance();
-		$new_items = $friends->feed->process_friend_feed( $user, $feed );
+		$new_items = $friends->feed->process_friend_feed( $user, $feed, Friends::CPT );
 		$this->assertCount( 1, $new_items );
 
-		$new_items = $friends->feed->process_friend_feed( $user, $feed );
+		$new_items = $friends->feed->process_friend_feed( $user, $feed, Friends::CPT );
 		$this->assertCount( 0, $new_items );
 	}
 
@@ -170,10 +170,10 @@ class Friends_FeedTest extends WP_UnitTestCase {
 		$user = new WP_User( $this->friend_id );
 
 		$friends   = Friends::get_instance();
-		$new_items = $friends->feed->process_friend_feed( $user, $feed );
+		$new_items = $friends->feed->process_friend_feed( $user, $feed, Friends::CPT );
 		$this->assertCount( 11, $new_items );
 
-		$new_items = $friends->feed->process_friend_feed( $user, $feed );
+		$new_items = $friends->feed->process_friend_feed( $user, $feed, Friends::CPT );
 		$this->assertCount( 0, $new_items );
 	}
 

--- a/tests/test-notifications.php
+++ b/tests/test-notifications.php
@@ -91,7 +91,7 @@ class Friends_NotificationTest extends WP_UnitTestCase {
 
 		$user = new WP_User( $this->friend_id );
 
-		$friends->feed->process_friend_feed( $user, $feed );
+		$friends->feed->process_friend_feed( $user, $feed, Friends::CPT );
 	}
 
 	/**
@@ -125,7 +125,7 @@ class Friends_NotificationTest extends WP_UnitTestCase {
 		update_user_option( $test_user->ID, 'friends_no_new_post_notification_' . $this->friend_id, true );
 
 		$friends = Friends::get_instance();
-		$friends->feed->process_friend_feed( $user, $feed );
+		$friends->feed->process_friend_feed( $user, $feed, Friends::CPT );
 	}
 
 	/**

--- a/tests/test-notifications.php
+++ b/tests/test-notifications.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Class Friends_NoticiationTest
+ * Class Friends_NotificationTest
  *
  * @package Friends
  */
@@ -45,7 +45,6 @@ class Friends_NotificationTest extends WP_UnitTestCase {
 				'role'       => 'friend',
 			)
 		);
-
 		remove_filter( 'friends_send_mail', '__return_false' );
 	}
 
@@ -89,9 +88,11 @@ class Friends_NotificationTest extends WP_UnitTestCase {
 		$feed->set_file( $file );
 		$feed->init();
 
-		$user = new WP_User( $this->friend_id );
+		$user = new Friend_User( $this->friend_id );
 
-		$friends->feed->process_friend_feed( $user, $feed, Friends::CPT );
+		$new_posts = $friends->feed->process_friend_feed( $user, $feed, Friends::CPT );
+		$friends->feed->notify_about_new_friend_posts( $user, array( 'post' => $new_posts ) );
+
 	}
 
 	/**
@@ -119,13 +120,14 @@ class Friends_NotificationTest extends WP_UnitTestCase {
 		$feed->set_file( $file );
 		$feed->init();
 
-		$user = new WP_User( $this->friend_id );
+		$user = new Friend_User( $this->friend_id );
 
 		$test_user = get_user_by( 'email', WP_TESTS_EMAIL );
 		update_user_option( $test_user->ID, 'friends_no_new_post_notification_' . $this->friend_id, true );
 
 		$friends = Friends::get_instance();
-		$friends->feed->process_friend_feed( $user, $feed, Friends::CPT );
+		$new_posts = $friends->feed->process_friend_feed( $user, $feed, Friends::CPT );
+		$friends->feed->notify_about_new_friend_posts( $user, array( 'post' => $new_posts ) );
 	}
 
 	/**
@@ -228,7 +230,7 @@ class Friends_NotificationTest extends WP_UnitTestCase {
 			)
 		);
 
-		$me = new WP_User( $me_id );
+		$me = new Friend_User( $me_id );
 		$me->set_role( 'friend' );
 		do_action( 'notify_accepted_friend_request', $me );
 	}

--- a/widgets/class-friends-widget-friend-list.php
+++ b/widgets/class-friends-widget-friend-list.php
@@ -41,9 +41,9 @@ class Friends_Widget_Friend_List extends WP_Widget {
 		echo $args['before_widget'];
 		echo $args['before_title'];
 
-		$friends         = Friends::all_friends();
-		$friend_requests = Friends::all_friend_requests();
-		$subscriptions   = Friends::all_subscriptions();
+		$friends         = Friend_User_Query::all_friends();
+		$friend_requests = Friend_User_Query::all_friend_requests();
+		$subscriptions   = Friend_User_Query::all_subscriptions();
 
 		// translators: %s is the number of your friends.
 		$friends_title = sprintf( _n( '%s Friend', '%s Friends', $friends->get_total(), 'friends' ), '<span class="friend-count">' . $friends->get_total() . '</span>' );


### PR DESCRIPTION
By allowing other plugins to register their custom post types with the function `Friends_API::register_post_type( $post_type )`, they can make use of the existing friends network to distribute their own posts.

Another plugin could implement post types that can be shared with friends in the same way as posts. For example: recipes, photos, events, etc.

As a vision for the future, mobile apps could talk to these plugins to implement custom UI (e.g. apply filters to photos, display friends' images in a streamlined way) and talk to your own friends install while using your pre-existing social graph that you don't have to share with anyone else.

This still needs UI to enable/disable post types on a per friend basis.