### PR TITLE
Use home_url() instead of site_url()

### DIFF
--- a/includes/class-friend-user.php
+++ b/includes/class-friend-user.php
@@ -551,7 +551,7 @@ class Friend_User extends WP_User {
 		if ( $post_id ) {
 			$path = '/' . $post_id . '/';
 		}
-		return site_url( '/friends/' . self::get_user_login_for_url( $this->user_login ) . $path );
+		return home_url( '/friends/' . self::get_user_login_for_url( $this->user_login ) . $path );
 	}
 
 	/**
@@ -562,7 +562,7 @@ class Friend_User extends WP_User {
 	 * @return     string      The local friends page url.
 	 */
 	function get_local_friends_page_post_format_url( $post_format ) {
-		return site_url( '/friends/' . $this->user_login . '/type/' . $post_format . '/' );
+		return home_url( '/friends/' . $this->user_login . '/type/' . $post_format . '/' );
 	}
 
 	/**

--- a/includes/class-friends-admin.php
+++ b/includes/class-friends-admin.php
@@ -127,7 +127,7 @@ class Friends_Admin {
 				echo wp_kses( sprintf( __( "First, you'll want to go to <a href=%1\$s>%2\$s</a> and add a new friend or enter the URL of a website or blog you'd like to subscribe to.", 'friends' ), '"' . admin_url( 'admin.php?page=add-friend' ) . '"', __( 'Send Friend Request', 'friends' ) ), array( 'a' => array( 'href' => array() ) ) );
 				echo ' ';
 				// translators: %s is the URL of the user's friends page.
-				echo wp_kses( sprintf( __( "As soon as you have done this, you'll be able see all the compiled posts of your friends (and subscriptions) on your <a href=%s>Friends page</a>.", 'friends' ), site_url( '/friends/' ) ), array( 'a' => array( 'href' => array() ) ) );
+				echo wp_kses( sprintf( __( "As soon as you have done this, you'll be able see all the compiled posts of your friends (and subscriptions) on your <a href=%s>Friends page</a>.", 'friends' ), home_url( '/friends/' ) ), array( 'a' => array( 'href' => array() ) ) );
 				?>
 				</p>
 
@@ -352,7 +352,7 @@ class Friends_Admin {
 					'version'  => 2,
 					'codeword' => $codeword,
 					'name'     => $current_user->display_name,
-					'url'      => site_url(),
+					'url'      => home_url(),
 					'icon_url' => get_avatar_url( $current_user->ID ),
 					'message'  => mb_substr( trim( $message ), 0, 2000 ),
 					'key'      => $future_in_token,
@@ -420,7 +420,7 @@ class Friends_Admin {
 	 * Redirect to the Friends page
 	 */
 	public function redirect_to_friends_page() {
-		wp_safe_redirect( site_url( '/friends/' ) );
+		wp_safe_redirect( home_url( '/friends/' ) );
 		exit;
 	}
 
@@ -1131,7 +1131,7 @@ class Friends_Admin {
 				// translators: %s is a Site URL.
 				echo wp_kses( sprintf( __( "You're now a friend of site %s.", 'friends' ), $friend_link ), array( 'a' => array( 'href' => array() ) ) );
 				// translators: %s is the friends page URL.
-				echo ' ', wp_kses( sprintf( __( 'Go to your <a href=%s>friends page</a> to view their posts.', 'friends' ), '"' . site_url( '/friends/' . $friend_user->user_login . '/' ) . '"' ), array( 'a' => array( 'href' => array() ) ) );
+				echo ' ', wp_kses( sprintf( __( 'Go to your <a href=%s>friends page</a> to view their posts.', 'friends' ), '"' . home_url( '/friends/' . $friend_user->user_login . '/' ) . '"' ), array( 'a' => array( 'href' => array() ) ) );
 				?>
 			</p></div>
 			<?php
@@ -1153,7 +1153,7 @@ class Friends_Admin {
 				}
 				esc_html_e( 'We subscribed you to their updates.', 'friends' );
 				// translators: %s is the friends page URL.
-				echo ' ', wp_kses( sprintf( __( 'Go to your <a href=%s>friends page</a> to view their posts.', 'friends' ), '"' . site_url( '/friends/' . $friend_user->user_login . '/' ) . '"' ), array( 'a' => array( 'href' => array() ) ) );
+				echo ' ', wp_kses( sprintf( __( 'Go to your <a href=%s>friends page</a> to view their posts.', 'friends' ), '"' . home_url( '/friends/' . $friend_user->user_login . '/' ) . '"' ), array( 'a' => array( 'href' => array() ) ) );
 				?>
 			</p></div>
 			<?php
@@ -1218,7 +1218,7 @@ class Friends_Admin {
 				$friend_url = 'https://' . $friend_url;
 			}
 
-			if ( 0 === strcasecmp( site_url(), $friend_url ) ) {
+			if ( 0 === strcasecmp( home_url(), $friend_url ) ) {
 				return new WP_Error( 'friend-yourself', __( 'It seems like you sent a friend request to yourself.', 'friends' ) );
 			}
 
@@ -1719,7 +1719,7 @@ class Friends_Admin {
 	 * @param  WP_Admin_Bar $wp_menu The admin bar to modify.
 	 */
 	public function admin_bar_friends_menu( WP_Admin_Bar $wp_menu ) {
-		$friends_url = site_url( '/friends/' );
+		$friends_url = home_url( '/friends/' );
 
 		if ( current_user_can( 'friend' ) ) {
 			$current_user = wp_get_current_user();
@@ -1759,7 +1759,7 @@ class Friends_Admin {
 					'id'     => 'your-feed',
 					'parent' => 'friends',
 					'title'  => esc_html__( 'Latest Posts', 'friends' ),
-					'href'   => site_url( '/friends/' ),
+					'href'   => home_url( '/friends/' ),
 				)
 			);
 			$wp_menu->add_menu(
@@ -1767,7 +1767,7 @@ class Friends_Admin {
 					'id'     => 'your-profile',
 					'parent' => 'friends',
 					'title'  => esc_html__( 'Your Profile', 'friends' ),
-					'href'   => site_url( '/friends/?public' ),
+					'href'   => home_url( '/friends/?public' ),
 				)
 			);
 			$wp_menu->add_menu(
@@ -1810,7 +1810,7 @@ class Friends_Admin {
 					'id'     => 'profile',
 					'parent' => 'friends',
 					'title'  => esc_html__( 'Profile' ),
-					'href'   => site_url( '/friends/' ),
+					'href'   => home_url( '/friends/' ),
 				)
 			);
 		}
@@ -1946,7 +1946,7 @@ class Friends_Admin {
 
 		if ( $friend_post_count ) {
 			// translators: %s is the number of friend posts.
-			$items[] = '<a class="friend-posts" href="' . site_url( '/friends/' ) . '">' . sprintf( _n( '%s Post by Friends', '%s Posts by Friends', $friend_post_count, 'friends' ), $friend_post_count ) . '</a>';
+			$items[] = '<a class="friend-posts" href="' . home_url( '/friends/' ) . '">' . sprintf( _n( '%s Post by Friends', '%s Posts by Friends', $friend_post_count, 'friends' ), $friend_post_count ) . '</a>';
 		}
 		return $items;
 	}

--- a/includes/class-friends-frontend.php
+++ b/includes/class-friends-frontend.php
@@ -430,7 +430,7 @@ class Friends_Frontend {
 	 * @return     string  The modified title.
 	 */
 	function header_widget_title( $title ) {
-		$title = '<a href="' . esc_url( site_url( '/friends/' ) ) . '">' . esc_html( $title ) . '</a>';
+		$title = '<a href="' . esc_url( home_url( '/friends/' ) ) . '">' . esc_html( $title ) . '</a>';
 		if ( $this->author ) {
 			$title .= ' &raquo; ' . '<a href="' . esc_url( $this->author->get_local_friends_page_url() ) . '">' . esc_html( $this->author->display_name ) . '</a>';
 		}

--- a/includes/class-friends-notifications.php
+++ b/includes/class-friends-notifications.php
@@ -48,7 +48,7 @@ class Friends_Notifications {
 	 * @return     string  The friends plugin from email address.
 	 */
 	public function get_friends_plugin_from_email_address() {
-		$domain = parse_url( get_option( 'siteurl' ), PHP_URL_HOST );
+		$domain = parse_url( get_option( 'home' ), PHP_URL_HOST );
 		return apply_filters( 'wp_mail_from', 'friends-plugin@' . $domain );
 	}
 

--- a/includes/class-friends-rest.php
+++ b/includes/class-friends-rest.php
@@ -186,7 +186,7 @@ class Friends_REST {
 		}
 
 		$url = trim( $request->get_param( 'url' ) );
-		if ( ! is_string( $url ) || ! Friends::check_url( $url ) || 0 === strcasecmp( site_url(), $url ) ) {
+		if ( ! is_string( $url ) || ! Friends::check_url( $url ) || 0 === strcasecmp( home_url(), $url ) ) {
 			return new WP_Error(
 				'friends_invalid_site',
 				'An invalid site was provided.',

--- a/includes/class-friends.php
+++ b/includes/class-friends.php
@@ -737,7 +737,7 @@ class Friends {
 		foreach ( get_post_format_strings() as $format => $title ) {
 			// translators: 1: Blog title, 2: Separator (raquo), 3: Post Format.
 			$title = sprintf( __( '%1$s %2$s %3$s Feed', 'friends' ), $blog_title, $separator, $title );
-			$links[] = '<link rel="alternate" type="application/rss+xml" href="' . esc_url( site_url( '/type/' . $format . '/feed/' ) ) . '" title="' . esc_attr( $title ) . '" />';
+			$links[] = '<link rel="alternate" type="application/rss+xml" href="' . esc_url( home_url( '/type/' . $format . '/feed/' ) ) . '" title="' . esc_attr( $title ) . '" />';
 		}
 
 		return $links;

--- a/templates/admin/settings.php
+++ b/templates/admin/settings.php
@@ -181,7 +181,7 @@ do_action( 'friends_settings_before_form' );
 				<td>
 					<?php
 					// translators: %s is a URL.
-					echo wp_kses( sprintf( __( 'Download <a href=%s>this OPML file</a> and import it to your feed reader.', 'friends' ), esc_url( site_url( '/friends/opml/?auth=' . $args['private_rss_key'] ) ) ), array( 'a' => array( 'href' => array() ) ) );
+					echo wp_kses( sprintf( __( 'Download <a href=%s>this OPML file</a> and import it to your feed reader.', 'friends' ), esc_url( home_url( '/friends/opml/?auth=' . $args['private_rss_key'] ) ) ), array( 'a' => array( 'href' => array() ) ) );
 					?>
 					<p class="description">
 					<?php
@@ -194,7 +194,7 @@ do_action( 'friends_settings_before_form' );
 				<td>
 					<?php
 					// translators: %s is a URL.
-					echo wp_kses( sprintf( __( 'You can also subscribe to a <a href=%s>compiled RSS feed of friend posts</a>.', 'friends' ), esc_url( site_url( '/friends/feed/?auth=' . $args['private_rss_key'] ) ) ), array( 'a' => array( 'href' => array() ) ) );
+					echo wp_kses( sprintf( __( 'You can also subscribe to a <a href=%s>compiled RSS feed of friend posts</a>.', 'friends' ), esc_url( home_url( '/friends/feed/?auth=' . $args['private_rss_key'] ) ) ), array( 'a' => array( 'href' => array() ) ) );
 					?>
 					<p class="description">
 					<?php

--- a/templates/email/accepted-friend-request.php
+++ b/templates/email/accepted-friend-request.php
@@ -24,13 +24,13 @@
 <p>
 	<?php
 	// translators: %s is a URL.
-	printf( __( 'Go to your <a href=%s>friends page</a> and look at their posts.', 'friends' ), esc_url( site_url( $args['friend_user']->get_local_friends_page_url() . '/' ) ) );
+	printf( __( 'Go to your <a href=%s>friends page</a> and look at their posts.', 'friends' ), esc_url( home_url( $args['friend_user']->get_local_friends_page_url() . '/' ) ) );
 	?>
 </p>
 
 <p>
 	<?php
 		// translators: %s is a site name.
-		echo wp_kses( sprintf( __( 'This notification was sent by the Friends plugin on %s.', 'friends' ), '<a href="' . esc_attr( site_url() ) . '">' . ( is_multisite() ? get_site_option( 'site_name' ) : get_option( 'blogname' ) ) . '</a>' ), array( 'a' => array( 'href' => array() ) ) );
+		echo wp_kses( sprintf( __( 'This notification was sent by the Friends plugin on %s.', 'friends' ), '<a href="' . esc_attr( home_url() ) . '">' . ( is_multisite() ? get_site_option( 'site_name' ) : get_option( 'blogname' ) ) . '</a>' ), array( 'a' => array( 'href' => array() ) ) );
 	?>
 </p>

--- a/templates/email/accepted-friend-request.text.php
+++ b/templates/email/accepted-friend-request.text.php
@@ -18,7 +18,7 @@ echo PHP_EOL . PHP_EOL;
 printf( strip_tags( __( 'Go to your <a href=%s>friends page</a> and look at their posts.', 'friends' ) ) );
 echo PHP_EOL . PHP_EOL;
 
-echo site_url( $args['friend_user']->get_local_friends_page_url() . '/' );
+echo home_url( $args['friend_user']->get_local_friends_page_url() . '/' );
 
 echo PHP_EOL . PHP_EOL;
 

--- a/templates/email/new-friend-post.php
+++ b/templates/email/new-friend-post.php
@@ -48,6 +48,6 @@
 <p>
 	<?php
 		// translators: %s is a site name.
-		echo wp_kses( sprintf( __( 'This notification was sent by the Friends plugin on %s.', 'friends' ), '<a href="' . esc_attr( site_url() ) . '">' . ( is_multisite() ? get_site_option( 'site_name' ) : get_option( 'blogname' ) ) . '</a>' ), array( 'a' => array( 'href' => array() ) ) );
+		echo wp_kses( sprintf( __( 'This notification was sent by the Friends plugin on %s.', 'friends' ), '<a href="' . esc_attr( home_url() ) . '">' . ( is_multisite() ? get_site_option( 'site_name' ) : get_option( 'blogname' ) ) . '</a>' ), array( 'a' => array( 'href' => array() ) ) );
 	?>
 </p>

--- a/templates/email/new-friend-request.php
+++ b/templates/email/new-friend-request.php
@@ -31,6 +31,6 @@
 <p>
 	<?php
 		// translators: %s is a site name.
-		echo wp_kses( sprintf( __( 'This notification was sent by the Friends plugin on %s.', 'friends' ), '<a href="' . esc_attr( site_url() ) . '">' . ( is_multisite() ? get_site_option( 'site_name' ) : get_option( 'blogname' ) ) . '</a>' ), array( 'a' => array( 'href' => array() ) ) );
+		echo wp_kses( sprintf( __( 'This notification was sent by the Friends plugin on %s.', 'friends' ), '<a href="' . esc_attr( home_url() ) . '">' . ( is_multisite() ? get_site_option( 'site_name' ) : get_option( 'blogname' ) ) . '</a>' ), array( 'a' => array( 'href' => array() ) ) );
 	?>
 </p>

--- a/templates/frontend/header.php
+++ b/templates/frontend/header.php
@@ -21,7 +21,7 @@ if ( isset( $_GET['s'] ) ) {
 <body <?php body_class( 'off-canvas off-canvas-sidebar-show' ); ?>>
 	<div id="friends-sidebar" class="off-canvas-sidebar">
 		<div class="friends-brand">
-			<a class="friends-logo" href="<?php echo esc_url( site_url( '/friends/' ) ); ?>"><h2><?php esc_html_e( 'Friends', 'friends' ); ?></h2></a>
+			<a class="friends-logo" href="<?php echo esc_url( home_url( '/friends/' ) ); ?>"><h2><?php esc_html_e( 'Friends', 'friends' ); ?></h2></a>
 		</div>
 		<div class="friends-nav accordion-container">
 			<?php dynamic_sidebar( 'friends-sidebar' ); ?>
@@ -59,7 +59,7 @@ if ( isset( $_GET['s'] ) ) {
 
 			</section>
 			<section class="navbar-section">
-				<form class="input-group input-inline form-autocomplete" action="<?php echo esc_url( site_url( '/friends/' ) ); ?>">
+				<form class="input-group input-inline form-autocomplete" action="<?php echo esc_url( home_url( '/friends/' ) ); ?>">
 					<div class="form-autocomplete-input form-input">
 						<div class="has-icon-right">
 							<input class="form-input" type="text" tabindex="2" name="s" placeholder="<?php esc_attr_e( 'Search' ); ?>" value="<?php echo esc_attr( $search ); ?>" id="master-search" autocomplete="off"/>

--- a/templates/frontend/index.php
+++ b/templates/frontend/index.php
@@ -49,7 +49,7 @@ Friends::template_loader()->get_template_part(
 						)
 					);
 					?>
-					<a href="<?php echo esc_url( site_url( '/friends/' ) ); ?>"><?php esc_html_e( 'Remove post format filter', 'friends' ); ?></a>
+					<a href="<?php echo esc_url( home_url( '/friends/' ) ); ?>"><?php esc_html_e( 'Remove post format filter', 'friends' ); ?></a>
 					<?php
 				}
 			} else {

--- a/templates/frontend/main-feed-header.php
+++ b/templates/frontend/main-feed-header.php
@@ -7,7 +7,7 @@
 
 $data = $args['friends']->get_main_header_data();
 ?><div id="main-header">
-<h2 id="page-title"><a href="<?php echo esc_url( site_url( '/friends/' ) ); ?>">
+<h2 id="page-title"><a href="<?php echo esc_url( home_url( '/friends/' ) ); ?>">
 <?php
 switch ( $args['friends']->frontend->post_format ) {
 	case 'standard':
@@ -55,7 +55,7 @@ switch ( $args['friends']->frontend->post_format ) {
 <?php endif; ?>
 
 <?php foreach ( $data['post_count_by_post_format'] as $post_format => $count ) : ?>
-	<a class="chip" href="<?php echo esc_url( site_url( '/friends/type/' . $post_format . '/' ) ); ?>"><?php echo esc_html( $args['friends']->get_post_format_plural_string( $post_format, $count ) ); ?></a>
+	<a class="chip" href="<?php echo esc_url( home_url( '/friends/type/' . $post_format . '/' ) ); ?>"><?php echo esc_html( $args['friends']->get_post_format_plural_string( $post_format, $count ) ); ?></a>
 <?php endforeach; ?>
 
 <a class="chip" href="<?php echo esc_attr( self_admin_url( 'admin.php?page=add-friend' ) ); ?>"><?php esc_html_e( 'Add New Friend', 'friends' ); ?></a>

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -72,7 +72,7 @@ class Friends_APITest extends WP_UnitTestCase {
 			)
 		);
 		$friends                = Friends::get_instance();
-		update_option( 'siteurl', 'http://me.local' );
+		update_option( 'home', 'http://me.local' );
 
 		$this->friends_in_token = wp_generate_password( 128, false );
 		if ( update_user_option( $this->friend_id, 'friends_in_token', $this->friends_in_token ) ) {

--- a/tests/test-notifications.php
+++ b/tests/test-notifications.php
@@ -75,7 +75,7 @@ class Friends_NotificationTest extends WP_UnitTestCase {
 		);
 		$friends = Friends::get_instance();
 		fetch_feed( null ); // load SimplePie.
-		update_option( 'siteurl', 'http://me.local' );
+		update_option( 'home', 'http://me.local' );
 
 		$file = new SimplePie_File( __DIR__ . '/data/friend-feed-1-private-post.rss' );
 		$parser = new Friends_Feed_Parser_SimplePie;
@@ -114,7 +114,7 @@ class Friends_NotificationTest extends WP_UnitTestCase {
 		if ( ! class_exists( 'SimplePie', false ) ) {
 			require_once( ABSPATH . WPINC . '/class-simplepie.php' );
 		}
-		update_option( 'siteurl', 'http://me.local' );
+		update_option( 'home', 'http://me.local' );
 
 		$file = new SimplePie_File( __DIR__ . '/data/friend-feed-1-private-post.rss' );
 		$parser = new Friends_Feed_Parser_SimplePie;
@@ -153,7 +153,7 @@ class Friends_NotificationTest extends WP_UnitTestCase {
 			10
 		);
 
-		update_option( 'siteurl', 'http://me.local' );
+		update_option( 'home', 'http://me.local' );
 
 		$test_user = get_user_by( 'email', WP_TESTS_EMAIL );
 		update_user_option( $test_user->ID, 'friends_no_friend_request_notification', true );
@@ -195,7 +195,7 @@ class Friends_NotificationTest extends WP_UnitTestCase {
 			5
 		);
 
-		update_option( 'siteurl', 'http://me.local' );
+		update_option( 'home', 'http://me.local' );
 
 		$me_id = $this->factory->user->create(
 			array(
@@ -226,7 +226,7 @@ class Friends_NotificationTest extends WP_UnitTestCase {
 			5
 		);
 
-		update_option( 'siteurl', 'http://me.local' );
+		update_option( 'home', 'http://me.local' );
 
 		$test_user = get_user_by( 'email', WP_TESTS_EMAIL );
 		update_user_option( $test_user->ID, 'friends_no_friend_request_notification', true );

--- a/tests/test-rest.php
+++ b/tests/test-rest.php
@@ -31,7 +31,7 @@ class Friends_RestTest extends WP_UnitTestCase {
 		add_filter(
 			'rest_url',
 			function() {
-				return get_option( 'siteurl' ) . '/wp-json/';
+				return get_option( 'home' ) . '/wp-json/';
 			}
 		);
 
@@ -41,14 +41,14 @@ class Friends_RestTest extends WP_UnitTestCase {
 			function( $preempt, $request, $url ) {
 				$p = wp_parse_url( $url );
 
-				$site_url = home_url();
+				$home_url = home_url();
 
 				// Pretend the url now is the requested one.
-				update_option( 'siteurl', $p['scheme'] . '://' . $p['host'] );
+				update_option( 'home', $p['scheme'] . '://' . $p['host'] );
 				$rest_prefix = home_url() . '/wp-json';
 				if ( substr( $url, -6 ) === '/feed/' ) {
-					// Restore the old site_url.
-					update_option( 'siteurl', $site_url );
+					// Restore the old home_url.
+					update_option( 'home', $home_url );
 					return apply_filters(
 						'fake_http_response',
 						array(
@@ -67,8 +67,8 @@ class Friends_RestTest extends WP_UnitTestCase {
 				} elseif ( false === strpos( $url, $rest_prefix ) ) {
 					$html = Friends::get_html_link_rel_friends_base_url();
 
-					// Restore the old site_url.
-					update_option( 'siteurl', $site_url );
+					// Restore the old home_url.
+					update_option( 'home', $home_url );
 					return apply_filters(
 						'fake_http_response',
 						array(
@@ -97,7 +97,7 @@ class Friends_RestTest extends WP_UnitTestCase {
 				$response = $wp_rest_server->dispatch( $r );
 
 				// Restore the old url.
-				update_option( 'siteurl', $url );
+				update_option( 'home', $url );
 
 				return apply_filters(
 					'fake_http_response',
@@ -145,7 +145,7 @@ class Friends_RestTest extends WP_UnitTestCase {
 	public function test_friend_request() {
 		$my_url     = 'http://me.local';
 		$friend_url = 'http://friend.local';
-		update_option( 'siteurl', $my_url );
+		update_option( 'home', $my_url );
 		$friends = Friends::get_instance();
 		$future_in_token = 'future_in_token';
 		$future_out_token = 'future_out_token';
@@ -155,7 +155,7 @@ class Friends_RestTest extends WP_UnitTestCase {
 		update_option( 'friends_request_token_' . sha1( $friend_url . '/wp-json/' . Friends_REST::PREFIX ), $friend_request_token );
 
 		// Let's send a friend request to $friend_url.
-		update_option( 'siteurl', $friend_url );
+		update_option( 'home', $friend_url );
 		$request = new WP_REST_Request( 'POST', '/' . Friends_REST::PREFIX . '/friend-request' );
 		$request->set_param( 'url', $my_url );
 		$request->set_param( 'key', $future_in_token );
@@ -184,7 +184,7 @@ class Friends_RestTest extends WP_UnitTestCase {
 		$friend_user->update_user_option( 'friends_future_in_token_' . sha1( $friend_request_response->data['request'] ), $future_in_token );
 
 		// Now let's accept the friend request.
-		update_option( 'siteurl', $my_url );
+		update_option( 'home', $my_url );
 		$request = new WP_REST_Request( 'POST', '/' . Friends_REST::PREFIX . '/accept-friend-request' );
 		$request->set_param( 'request', $friend_request_response->data['request'] );
 		$request->set_param( 'key', $future_out_token );
@@ -211,7 +211,7 @@ class Friends_RestTest extends WP_UnitTestCase {
 	public function test_friend_request_with_admin_and_accept_on_mobile() {
 		$my_url     = 'http://me.local';
 		$friend_url = 'http://friend.local';
-		update_option( 'siteurl', $my_url );
+		update_option( 'home', $my_url );
 		$friends = Friends::get_instance();
 		$friend_username = Friend_User::get_user_login_for_url( $friend_url );
 
@@ -233,7 +233,7 @@ class Friends_RestTest extends WP_UnitTestCase {
 		$this->assertFalse( $my_user_at_friend->has_cap( 'friend' ) );
 
 		// Remote approves friend request = sets user to friend.
-		update_option( 'siteurl', $friend_url );
+		update_option( 'home', $friend_url );
 		$my_user_at_friend->set_role( 'friend' );
 
 		// Refresh the users before querying them again.
@@ -256,7 +256,7 @@ class Friends_RestTest extends WP_UnitTestCase {
 	public function test_friend_request_with_admin() {
 		$my_url     = 'http://me.local';
 		$friend_url = 'http://friend.local';
-		update_option( 'siteurl', $my_url );
+		update_option( 'home', $my_url );
 		$friends = Friends::get_instance();
 		$friend_username = Friend_User::get_user_login_for_url( $friend_url );
 
@@ -278,7 +278,7 @@ class Friends_RestTest extends WP_UnitTestCase {
 		$this->assertFalse( $my_user_at_friend->has_cap( 'friend' ) );
 
 		// Remote approves friend request through admin.
-		update_option( 'siteurl', $friend_url );
+		update_option( 'home', $friend_url );
 		$friends->admin->handle_bulk_friend_request_approval( false, 'accept_friend_request', array( $my_user_at_friend->ID ) );
 
 		// Refresh the users before querying them again.
@@ -301,7 +301,7 @@ class Friends_RestTest extends WP_UnitTestCase {
 	public function test_friend_request_with_local_user_without_metadata() {
 		$my_url     = 'http://me.local';
 		$friend_url = 'http://friend.local';
-		update_option( 'siteurl', $my_url );
+		update_option( 'home', $my_url );
 		$friends = Friends::get_instance();
 		$friend_username = Friend_User::get_user_login_for_url( $friend_url );
 
@@ -332,7 +332,7 @@ class Friends_RestTest extends WP_UnitTestCase {
 		$this->assertFalse( $my_user_at_friend->has_cap( 'friend' ) );
 
 		// Remote approves friend request through admin.
-		update_option( 'siteurl', $friend_url );
+		update_option( 'home', $friend_url );
 		$friends->admin->handle_bulk_friend_request_approval( false, 'accept_friend_request', array( $my_user_at_friend->ID ) );
 
 		// Refresh the users before querying them again.
@@ -358,8 +358,8 @@ class Friends_RestTest extends WP_UnitTestCase {
 
 		add_filter(
 			'fake_http_response',
-			function( $response, $site_url, $url, $request ) use ( $my_url, $friend_url ) {
-				if ( $site_url === $my_url ) {
+			function( $response, $home_url, $url, $request ) use ( $my_url, $friend_url ) {
+				if ( $home_url === $my_url ) {
 					return $response;
 				}
 				if ( rtrim( $url, '/' ) === $friend_url ) {
@@ -396,7 +396,7 @@ class Friends_RestTest extends WP_UnitTestCase {
 			4
 		);
 
-		update_option( 'siteurl', $my_url );
+		update_option( 'home', $my_url );
 		$friends = Friends::get_instance();
 		$friend_username = Friend_User::get_user_login_for_url( $friend_url );
 
@@ -429,8 +429,8 @@ class Friends_RestTest extends WP_UnitTestCase {
 
 		add_filter(
 			'fake_http_response',
-			function( $response, $site_url, $url, $request ) use ( $my_url, $friend_url ) {
-				if ( $site_url === $my_url ) {
+			function( $response, $home_url, $url, $request ) use ( $my_url, $friend_url ) {
+				if ( $home_url === $my_url ) {
 					return $response;
 				}
 				return new WP_Error(
@@ -442,7 +442,7 @@ class Friends_RestTest extends WP_UnitTestCase {
 			4
 		);
 
-		update_option( 'siteurl', $my_url );
+		update_option( 'home', $my_url );
 		$friends = Friends::get_instance();
 		$friend_username = Friend_User::get_user_login_for_url( $friend_url );
 

--- a/tests/test-rest.php
+++ b/tests/test-rest.php
@@ -41,11 +41,11 @@ class Friends_RestTest extends WP_UnitTestCase {
 			function( $preempt, $request, $url ) {
 				$p = wp_parse_url( $url );
 
-				$site_url = site_url();
+				$site_url = home_url();
 
 				// Pretend the url now is the requested one.
 				update_option( 'siteurl', $p['scheme'] . '://' . $p['host'] );
-				$rest_prefix = site_url() . '/wp-json';
+				$rest_prefix = home_url() . '/wp-json';
 				if ( substr( $url, -6 ) === '/feed/' ) {
 					// Restore the old site_url.
 					update_option( 'siteurl', $site_url );

--- a/widgets/class-friends-widget-header.php
+++ b/widgets/class-friends-widget-header.php
@@ -57,7 +57,7 @@ class Friends_Widget_Header extends WP_Widget {
 						__( 'Visit %1$s. Back to <a href=%2$s>your friends page</a>.', 'friends' ),
 						// translators: 1: a friend's display name, 2: a URL.
 						'<a href="' . esc_url( $friends->frontend->author->user_url ) . '" class="auth-link" data-token="' . esc_attr( get_user_option( 'friends_out_token', $friends->frontend->author->ID ) ) . '">' . esc_html( sprintf( __( '%1$s\'s external site at %2$s', 'friends' ), $friends->frontend->author->display_name, preg_replace( '#https?://#', '', trim( $friends->frontend->author->user_url, '/' ) ) ) ) . '</a>',
-						'"' . esc_attr( site_url( '/friends/' ) ) . '"'
+						'"' . esc_attr( home_url( '/friends/' ) ) . '"'
 					),
 					array(
 						'a' => array(

--- a/widgets/class-friends-widget-post-formats.php
+++ b/widgets/class-friends-widget-post-formats.php
@@ -49,7 +49,7 @@ class Friends_Widget_Post_Formats extends WP_Widget {
 				?>
 			</summary>
 			<ul class="friends-post-formats menu menu-nav accordion-body">
-				<li class="menu-item"><a href="<?php echo esc_attr( site_url( '/friends/' ) ); ?>"><?php _ex( 'All', 'all posts', 'friends' ); ?></a></li>
+				<li class="menu-item"><a href="<?php echo esc_attr( home_url( '/friends/' ) ); ?>"><?php _ex( 'All', 'all posts', 'friends' ); ?></a></li>
 				<?php
 				foreach ( get_post_format_strings() as $slug => $title ) :
 
@@ -60,7 +60,7 @@ class Friends_Widget_Post_Formats extends WP_Widget {
 						$instance[ 'post_format_title_' . $slug ] = $title;
 					}
 					?>
-					<li class="menu-item"><a href="<?php echo esc_attr( site_url( '/friends/type/' . $slug . '/' ) ); ?>"> <?php echo esc_attr( $instance[ 'post_format_title_' . $slug ] ); ?></a></li>
+					<li class="menu-item"><a href="<?php echo esc_attr( home_url( '/friends/type/' . $slug . '/' ) ); ?>"> <?php echo esc_attr( $instance[ 'post_format_title_' . $slug ] ); ?></a></li>
 				<?php endforeach; ?>
 			</ul>
 		</details>


### PR DESCRIPTION
@meszarosrob has pointed out to me that throughout the plugin `site_url()` is used when it should be `home_url()` (see https://wp-mix.com/wordpress-difference-between-home_url-site_url/) since the Friends UI resides on the frontend URL.

See also the WordPress.org documentation:

[`home_url()`](http://developer.wordpress.org/reference/functions/get_home_url/)
> Retrieves the URL for a given site where the front end is accessible

[`site_url()`](http://developer.wordpress.org/reference/functions/get_site_url/)
> Retrieves the URL for a given site where WordPress application files (e.g. wp-blog-header.php or the wp-admin/ folder) are accessible.

So this doesn't necessarily need to be the same which so far has been treated as if it were.

props @meszarosrob, thank you very much!