### PR TITLE
Automatically create draft status posts based on actions inside Friends

### DIFF
--- a/friends-admin.js
+++ b/friends-admin.js
@@ -160,6 +160,9 @@ jQuery( function( $ ) {
 		$( '#keyword-notifications' ).append( '<li>' + $( '#keyword-template' ).html().replace( /\[0\]/g, '[' + $( '#keyword-notifications li' ).length + ']' ) );
 		$( '#keyword-notifications input:last ' ).focus()
 		return false;
+
+	$( document ).on( 'click', '#friends-bulk-publish', function() {
+		$( this ).closest( 'div' ).find( 'select option[value=publish]' ).prop( 'selected', true );
 	} );
 
 } );

--- a/friends-admin.js
+++ b/friends-admin.js
@@ -160,6 +160,7 @@ jQuery( function( $ ) {
 		$( '#keyword-notifications' ).append( '<li>' + $( '#keyword-template' ).html().replace( /\[0\]/g, '[' + $( '#keyword-notifications li' ).length + ']' ) );
 		$( '#keyword-notifications input:last ' ).focus()
 		return false;
+	} );
 
 	$( document ).on( 'click', '#friends-bulk-publish', function() {
 		$( this ).closest( 'div' ).find( 'select option[value=publish]' ).prop( 'selected', true );

--- a/friends.php
+++ b/friends.php
@@ -36,6 +36,7 @@ require_once __DIR__ . '/feed-parsers/class-friends-feed-item.php';
 
 require_once __DIR__ . '/includes/class-friends-access-control.php';
 require_once __DIR__ . '/includes/class-friends-admin.php';
+require_once __DIR__ . '/includes/class-friends-automatic-status.php';
 require_once __DIR__ . '/includes/class-friends-blocks.php';
 require_once __DIR__ . '/includes/class-friends-feed.php';
 require_once __DIR__ . '/includes/class-friends-frontend.php';

--- a/includes/class-friends-automatic-status-list-table.php
+++ b/includes/class-friends-automatic-status-list-table.php
@@ -192,7 +192,9 @@ class Friends_Automatic_Status_List_Table extends WP_Posts_List_Table {
 
 		// Subtract post types that are not included in the admin all list.
 		foreach ( get_post_stati( array( 'show_in_admin_all_list' => false ) ) as $state ) {
-			$total_posts -= $num_posts->$state;
+			if ( isset( $num_posts->$state ) ) {
+				$total_posts -= $num_posts->$state;
+			}
 		}
 
 		if ( empty( $class ) && ( $this->is_base_request() || isset( $_REQUEST['all_posts'] ) ) ) {

--- a/includes/class-friends-automatic-status-list-table.php
+++ b/includes/class-friends-automatic-status-list-table.php
@@ -1,0 +1,325 @@
+<?php
+/**
+ * Friends_Automatic_Status_List_Table class
+ *
+ * @package Friends
+ */
+
+/**
+ * Class used to implement displaying automatic status posts in a list table.
+ *
+ * @see WP_Posts_List_Table
+ */
+class Friends_Automatic_Status_List_Table extends WP_Posts_List_Table {
+	/**
+	 * Constructor
+	 *
+	 * @param array $args Array of arguments.
+	 */
+	public function __construct( $args = array() ) {
+		parent::__construct(
+			array(
+				'plural' => 'posts',
+				'screen' => WP_Screen::get( 'edit' ),
+			)
+		);
+	}
+
+	/**
+	 * Prepares the list of items for displaying.
+	 */
+	public function prepare_items() {
+		global $mode, $avail_post_stati, $wp_query, $per_page;
+		$mode = 'excerpt';
+
+		$post_type = 'post';
+		$avail_post_stati = get_available_post_statuses( $post_type );
+		wp(
+			array(
+				'post_type'   => $post_type,
+				'post_status' => 'draft',
+				'post_format' => 'status',
+				'post_author' => get_current_user_id(),
+			)
+		);
+
+		$post_type = $this->screen->post_type;
+		$per_page  = $this->get_items_per_page( 'edit_' . $post_type . '_per_page' );
+
+		/** This filter is documented in wp-admin/includes/post.php */
+		$per_page = apply_filters( 'edit_posts_per_page', $per_page, $post_type );
+
+		$this->is_trash = isset( $_REQUEST['post_status'] ) && 'trash' === $_REQUEST['post_status'];
+	}
+
+	/**
+	 * Gets the post status counts.
+	 *
+	 * @param      string $post_type  The post type.
+	 *
+	 * @return     object  The counts.
+	 */
+	protected function get_post_status_counts( $post_type ) {
+		global $wpdb;
+
+		$counts = array();
+		$post_status_counts = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT posts.post_status, COUNT(posts.ID) AS count
+				FROM {$wpdb->posts} AS posts
+				JOIN {$wpdb->term_relationships} AS relationships
+				JOIN {$wpdb->term_taxonomy} AS taxonomy
+				JOIN {$wpdb->terms} AS terms
+
+				WHERE posts.post_author = %d
+				AND posts.post_type = %s
+				AND relationships.object_id = posts.ID
+				AND relationships.term_taxonomy_id = taxonomy.term_taxonomy_id
+				AND taxonomy.taxonomy = 'post_format'
+
+				AND terms.slug = 'post-format-status'
+
+				GROUP BY posts.post_status",
+				get_current_user_id(),
+				$post_type
+			)
+		);
+
+		foreach ( $post_status_counts as $row ) {
+			$counts[ $row->post_status ] = $row->count;
+		}
+		return (object) $counts;
+	}
+
+	/**
+	 * The no items text.
+	 */
+	public function no_items() {
+		esc_html_e( 'No unpublished automatically generated statuses found.' );
+	}
+
+	/**
+	 * Helper to create links to edit.php with params.
+	 *
+	 * @param string[] $args  Associative array of URL parameters for the link.
+	 * @param string   $label Link text.
+	 * @param string   $class Optional. Class attribute. Default empty string.
+	 * @return string The formatted link string.
+	 */
+	protected function get_edit_link( $args, $label, $class = '' ) {
+		$args = array_merge(
+			array(
+				'post_type'   => 'post',
+				'post_format' => 'status',
+				'post_author' => get_current_user_id(),
+			),
+			$args
+		);
+		$url = add_query_arg( $args, 'edit.php' );
+
+		$class_html   = '';
+		$aria_current = '';
+
+		if ( ! empty( $class ) ) {
+			$class_html = sprintf(
+				' class="%s"',
+				esc_attr( $class )
+			);
+
+			if ( 'current' === $class ) {
+				$aria_current = ' aria-current="page"';
+			}
+		}
+
+		return sprintf(
+			'<a href="%s"%s%s>%s</a>',
+			esc_url( $url ),
+			$class_html,
+			$aria_current,
+			$label
+		);
+	}
+
+	/**
+	 * Handles the title column output.
+	 *
+	 * @global string $mode List table view mode.
+	 *
+	 * @param WP_Post $post The current WP_Post object.
+	 */
+	public function column_title( $post ) {
+		global $mode;
+
+		if ( current_user_can( 'read_post', $post->ID ) ) {
+			echo wp_kses(
+				get_the_content(),
+				array(
+					'img' => array( 'src' => array() ),
+					'a'   => array( 'href' => array() ),
+				)
+			);
+		}
+
+		get_inline_data( $post );
+	}
+
+	/**
+	 * Gets the list of views available on this table.
+	 *
+	 * The format is an associative array:
+	 * - `'id' => 'link'`
+	 *
+	 * @return array
+	 */
+	protected function get_views() {
+		global $locked_post_status, $avail_post_stati;
+
+		$post_type = $this->screen->post_type;
+
+		if ( ! empty( $locked_post_status ) ) {
+			return array();
+		}
+
+		$status_links = array();
+		$num_posts    = $this->get_post_status_counts( $post_type );
+
+		$total_posts  = array_sum( (array) $num_posts );
+		$class        = '';
+
+		$current_user_id = get_current_user_id();
+		$all_args        = array( 'post_type' => $post_type );
+		$mine            = '';
+
+		// Subtract post types that are not included in the admin all list.
+		foreach ( get_post_stati( array( 'show_in_admin_all_list' => false ) ) as $state ) {
+			$total_posts -= $num_posts->$state;
+		}
+
+		if ( empty( $class ) && ( $this->is_base_request() || isset( $_REQUEST['all_posts'] ) ) ) {
+			$class = 'current';
+		}
+
+		$all_inner_html = sprintf(
+			/* translators: %s: Number of posts. */
+			_nx(
+				'All <span class="count">(%s)</span>',
+				'All <span class="count">(%s)</span>',
+				$total_posts,
+				'posts'
+			),
+			number_format_i18n( $total_posts )
+		);
+
+		$status_links['all'] = $this->get_edit_link( $all_args, $all_inner_html, $class );
+
+		if ( $mine ) {
+			$status_links['mine'] = $mine;
+		}
+
+		foreach ( get_post_stati( array( 'show_in_admin_status_list' => true ), 'objects' ) as $status ) {
+			$class = '';
+
+			$status_name = $status->name;
+
+			if ( ! in_array( $status_name, $avail_post_stati, true ) || empty( $num_posts->$status_name ) ) {
+				continue;
+			}
+
+			if ( isset( $_REQUEST['post_status'] ) && $status_name === $_REQUEST['post_status'] ) {
+				$class = 'current';
+			}
+
+			$status_args = array(
+				'post_status' => $status_name,
+				'post_type'   => $post_type,
+			);
+
+			$status_label = sprintf(
+				translate_nooped_plural( $status->label_count, $num_posts->$status_name ),
+				number_format_i18n( $num_posts->$status_name )
+			);
+
+			$status_links[ $status_name ] = $this->get_edit_link( $status_args, $status_label, $class );
+		}
+
+		if ( ! empty( $this->sticky_posts_count ) ) {
+			$class = ! empty( $_REQUEST['show_sticky'] ) ? 'current' : '';
+
+			$sticky_args = array(
+				'post_type'   => $post_type,
+				'show_sticky' => 1,
+			);
+
+			$sticky_inner_html = sprintf(
+				/* translators: %s: Number of posts. */
+				_nx(
+					'Sticky <span class="count">(%s)</span>',
+					'Sticky <span class="count">(%s)</span>',
+					$this->sticky_posts_count,
+					'posts'
+				),
+				number_format_i18n( $this->sticky_posts_count )
+			);
+
+			$sticky_link = array(
+				'sticky' => $this->get_edit_link( $sticky_args, $sticky_inner_html, $class ),
+			);
+
+			// Sticky comes after Publish, or if not listed, after All.
+			$split        = 1 + array_search( ( isset( $status_links['publish'] ) ? 'publish' : 'all' ), array_keys( $status_links ), true );
+			$status_links = array_merge( array_slice( $status_links, 0, $split ), $sticky_link, array_slice( $status_links, $split ) );
+		}
+		return $status_links;
+	}
+
+	/**
+	 * Displays the bulk actions dropdown.
+	 *
+	 * @param string $which The location of the bulk actions: 'top' or 'bottom'.
+	 */
+	protected function bulk_actions( $which = '' ) {
+		parent::bulk_actions( $which );
+		echo "\n";
+		submit_button( __( 'Bulk Publish', 'friends' ), 'primary', '', false, array( 'id' => 'friends-bulk-publish' ) );
+	}
+
+	/**
+	 * Retrieves the list of bulk actions available for this table.
+	 *
+	 * @return array
+	 */
+	protected function get_bulk_actions() {
+		$actions       = array();
+		$post_type_obj = get_post_type_object( $this->screen->post_type );
+
+		if ( current_user_can( $post_type_obj->cap->publish_posts ) ) {
+			$actions['publish'] = __( 'Publish' );
+		}
+
+		if ( current_user_can( $post_type_obj->cap->edit_posts ) ) {
+			if ( $this->is_trash ) {
+				$actions['untrash'] = __( 'Restore' );
+			} else {
+				$actions['edit'] = __( 'Edit' );
+			}
+		}
+
+		if ( current_user_can( $post_type_obj->cap->delete_posts ) ) {
+			if ( $this->is_trash || ! EMPTY_TRASH_DAYS ) {
+				$actions['delete'] = __( 'Delete permanently' );
+			} else {
+				$actions['trash'] = __( 'Move to Trash' );
+			}
+		}
+
+		return $actions;
+	}
+
+	/**
+	 * Generates the table navigation above or below the table
+	 *
+	 * @param string $which The location of the bulk actions: 'top' or 'bottom'.
+	 */
+	protected function display_tablenav( $which ) {
+	}
+}

--- a/includes/class-friends-automatic-status.php
+++ b/includes/class-friends-automatic-status.php
@@ -38,8 +38,32 @@ class Friends_Automatic_Status {
 	 */
 	private function register_hooks() {
 		add_action( 'friends_user_post_reaction', array( $this, 'post_reaction' ), 10, 2 );
+		add_action( 'admin_menu', array( $this, 'admin_menu' ), 20 );
 	}
 
+
+	public function admin_menu() {
+		$menu_title = __( 'Friends', 'friends' ) . $this->friends->admin->get_unread_badge();
+		$page_type = sanitize_title( $menu_title );
+
+		add_submenu_page(
+			'friends-settings',
+			__( 'Automatic Status', 'friends' ),
+			__( 'Automatic Status', 'friends' ),
+			'administrator',
+			'friends-auto-status',
+			array( $this, 'validate_drafts' )
+		);
+
+		if ( isset( $_GET['page'] ) && 0 === strpos( $_GET['page'], 'friends-auto-status' ) ) {
+			// add_submenu_page( 'friends-settings', __( 'Edit Post Collection', 'friends' ), __( 'Edit Post Collection', 'friends' ), Friends::REQUIRED_ROLE, 'friends-auto-status' . ( 'friends-auto-status' !== $_GET['page'] && isset( $_GET['user'] ) ? '&user=' . $_GET['user'] : '' ), array( $this, 'render_edit_post_collection' ) );
+			// add_action( 'load-' . $page_type . '_page_friends-auto-status', array( $this, 'process_edit_post_collection' ) );
+		}
+	}
+
+	public function validate_drafts() {
+		echo 1;
+	}
 	/**
 	 * Adds a status post.
 	 *

--- a/includes/class-friends-automatic-status.php
+++ b/includes/class-friends-automatic-status.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Friends Automatic Status
+ *
+ * This contains the functions for the Automatic Status.
+ *
+ * @package Friends
+ */
+
+/**
+ * This is the class for the Friends Plugin Automatic Status.
+ *
+ * @since 0.6
+ *
+ * @package Friends
+ * @author Alex Kirk
+ */
+class Friends_Automatic_Status {
+	/**
+	 * Contains a reference to the Friends class.
+	 *
+	 * @var Friends
+	 */
+	private $friends;
+
+	/**
+	 * Constructor
+	 *
+	 * @param Friends $friends A reference to the Friends object.
+	 */
+	public function __construct( Friends $friends ) {
+		$this->friends = $friends;
+		$this->register_hooks();
+	}
+
+	/**
+	 * Register the WordPress hooks
+	 */
+	private function register_hooks() {
+		add_action( 'friends_user_post_reaction', array( $this, 'post_reaction' ), 10, 2 );
+	}
+
+	/**
+	 * Adds a status post.
+	 *
+	 * @param      string $text   The text.
+	 *
+	 * @return     int|WP_Error  The post ID or a WP_Error.
+	 */
+	private function add_status( $text ) {
+		return wp_insert_post(
+			array(
+				'post_type'    => 'post',
+				'post_status'  => 'draft',
+				'tax_input'    => array( 'post_format' => 'status' ),
+				'post_content' => $text,
+			)
+		);
+	}
+
+	/**
+	 * Create a status based on a post reaction.
+	 *
+	 * @param      int    $post_id  The post ID.
+	 * @param      string $emoji    The emoji.
+	 */
+	public function post_reaction( $post_id, $emoji ) {
+		$post = get_post( $post_id );
+		$this->add_status(
+			sprintf(
+				// translators: %1$s is an emoji, %2$s is a linked post title.
+				__( 'I just reacted with %1$s on %2$s' ),
+				$emoji,
+				'<a href="' . esc_url( get_permalink( $post ) ) . '">' . esc_url( get_the_title( $post ) ) . '</a>'
+			)
+		);
+	}
+}

--- a/includes/class-friends-automatic-status.php
+++ b/includes/class-friends-automatic-status.php
@@ -96,7 +96,7 @@ class Friends_Automatic_Status {
 						)
 					),
 					/* translators: %s: Post title. */
-					esc_attr( sprintf( __( 'Publish &#8220;%s&#8221;' ), $title ) ),
+					esc_attr( sprintf( __( 'Publish &#8220;%s&#8221;' ), $post->title ) ),
 					__( 'Publish' )
 				);
 				return $actions;

--- a/includes/class-friends-automatic-status.php
+++ b/includes/class-friends-automatic-status.php
@@ -110,7 +110,7 @@ class Friends_Automatic_Status {
 		$post_type = 'post';
 		$post_type_object = get_post_type_object( $post_type );
 
-		$wp_list_table = new Friends_Automatic_Status_List_Table;
+		$wp_list_table = new Friends_Automatic_Status_List_Table();
 		$wp_list_table->prepare_items();
 
 		wp_enqueue_script( 'inline-edit-post' );
@@ -183,7 +183,7 @@ class Friends_Automatic_Status {
 				'post_type'    => 'post',
 				'post_status'  => 'draft',
 				'tax_input'    => array( 'post_format' => 'post-format-status' ),
-				'post_content' => $text,
+				'post_content' => '<!-- wp:paragraph -->' . PHP_EOL . '<p>' . $text . '</p>' . PHP_EOL . '<!-- /wp:paragraph -->',
 			)
 		);
 	}

--- a/includes/class-friends-automatic-status.php
+++ b/includes/class-friends-automatic-status.php
@@ -39,9 +39,12 @@ class Friends_Automatic_Status {
 	private function register_hooks() {
 		add_action( 'friends_user_post_reaction', array( $this, 'post_reaction' ), 10, 2 );
 		add_action( 'admin_menu', array( $this, 'admin_menu' ), 20 );
+		add_filter( 'handle_bulk_actions-edit-post', array( $this, 'bulk_publish' ), 10, 3 );
 	}
 
-
+	/**
+	 * Add the admin menu to the sidebar.
+	 */
 	public function admin_menu() {
 		$menu_title = __( 'Friends', 'friends' ) . $this->friends->admin->get_unread_badge();
 		$page_type = sanitize_title( $menu_title );
@@ -54,16 +57,119 @@ class Friends_Automatic_Status {
 			'friends-auto-status',
 			array( $this, 'validate_drafts' )
 		);
-
-		if ( isset( $_GET['page'] ) && 0 === strpos( $_GET['page'], 'friends-auto-status' ) ) {
-			// add_submenu_page( 'friends-settings', __( 'Edit Post Collection', 'friends' ), __( 'Edit Post Collection', 'friends' ), Friends::REQUIRED_ROLE, 'friends-auto-status' . ( 'friends-auto-status' !== $_GET['page'] && isset( $_GET['user'] ) ? '&user=' . $_GET['user'] : '' ), array( $this, 'render_edit_post_collection' ) );
-			// add_action( 'load-' . $page_type . '_page_friends-auto-status', array( $this, 'process_edit_post_collection' ) );
-		}
 	}
 
+	/**
+	 * This displays the Automatically Generated Statuses admin page.
+	 */
 	public function validate_drafts() {
-		echo 1;
+		add_filter(
+			'manage_edit-post_columns',
+			function( $columns ) {
+				unset( $columns['categories'] );
+				unset( $columns['tags'] );
+				unset( $columns['comments'] );
+				return $columns;
+			},
+			30,
+			3
+		);
+
+		add_filter(
+			'post_row_actions',
+			function( $actions, $post ) {
+				unset( $actions['view'], $actions['inline hide-if-no-js'] );
+				$actions['publish'] = sprintf(
+					'<a href="%s" aria-label="%s">%s</a>',
+					esc_url(
+						add_query_arg(
+							array(
+								'post_status'      => 'draft',
+								'post_format'      => 'status',
+								'post_type'        => 'post',
+								'_wpnonce'         => wp_create_nonce( 'bulk-posts' ),
+								'_wp_http_referer' => self_admin_url( 'admin.php?page=friends-auto-status' ),
+								'action'           => 'publish',
+								'post[]'           => $post->ID,
+							),
+							self_admin_url( 'edit.php' )
+						)
+					),
+					/* translators: %s: Post title. */
+					esc_attr( sprintf( __( 'Publish &#8220;%s&#8221;' ), $title ) ),
+					__( 'Publish' )
+				);
+				return $actions;
+			},
+			10,
+			2
+		);
+		_get_list_table( 'WP_Posts_List_Table' );
+		require_once __DIR__ . '/class-friends-automatic-status-list-table.php';
+
+		$post_type = 'post';
+		$post_type_object = get_post_type_object( $post_type );
+
+		$wp_list_table = new Friends_Automatic_Status_List_Table;
+		$wp_list_table->prepare_items();
+
+		wp_enqueue_script( 'inline-edit-post' );
+		wp_enqueue_script( 'heartbeat' );
+
+		$bulk_counts = array(
+			'updated'   => isset( $_REQUEST['updated'] ) ? absint( $_REQUEST['updated'] ) : 0,
+			'locked'    => isset( $_REQUEST['locked'] ) ? absint( $_REQUEST['locked'] ) : 0,
+			'deleted'   => isset( $_REQUEST['deleted'] ) ? absint( $_REQUEST['deleted'] ) : 0,
+			'trashed'   => isset( $_REQUEST['trashed'] ) ? absint( $_REQUEST['trashed'] ) : 0,
+			'untrashed' => isset( $_REQUEST['untrashed'] ) ? absint( $_REQUEST['untrashed'] ) : 0,
+		);
+
+		$bulk_messages             = array();
+		$bulk_messages['post']     = array(
+			/* translators: %s: Number of posts. */
+			'updated'   => _n( '%s post updated.', '%s posts updated.', $bulk_counts['updated'] ),
+			'locked'    => ( 1 === $bulk_counts['locked'] ) ? __( '1 post not updated, somebody is editing it.' ) :
+							/* translators: %s: Number of posts. */
+							_n( '%s post not updated, somebody is editing it.', '%s posts not updated, somebody is editing them.', $bulk_counts['locked'] ),
+			/* translators: %s: Number of posts. */
+			'deleted'   => _n( '%s post permanently deleted.', '%s posts permanently deleted.', $bulk_counts['deleted'] ),
+			/* translators: %s: Number of posts. */
+			'trashed'   => _n( '%s post moved to the Trash.', '%s posts moved to the Trash.', $bulk_counts['trashed'] ),
+			/* translators: %s: Number of posts. */
+			'untrashed' => _n( '%s post restored from the Trash.', '%s posts restored from the Trash.', $bulk_counts['untrashed'] ),
+		);
+		$bulk_messages = apply_filters( 'bulk_post_updated_messages', $bulk_messages, $bulk_counts );
+		$bulk_counts   = array_filter( $bulk_counts );
+
+		Friends::template_loader()->get_template_part( 'admin/automatic-status-list-table', false, compact( 'wp_list_table', 'post_type' ) );
 	}
+
+	/**
+	 * This implements bulk publishing for the Automatically Generated Statuses page.
+	 *
+	 * @param string $sendback The redirect URL.
+	 * @param string $doaction The action being taken.
+	 * @param array  $post_ids The items to take the action on.
+	 *
+	 * @return     string  A potentially modified redirect URL.
+	 */
+	public function bulk_publish( $sendback, $doaction, $post_ids ) {
+		if ( 'publish' !== $doaction ) {
+			return $sendback;
+		}
+
+		$done = array(
+			'published' => 0,
+		);
+		foreach ( $post_ids as $post_id ) {
+			wp_publish_post( $post_id );
+			$done['published']++;
+		}
+
+		$sendback = add_query_arg( $done, $sendback );
+		return $sendback;
+	}
+
 	/**
 	 * Adds a status post.
 	 *
@@ -76,7 +182,7 @@ class Friends_Automatic_Status {
 			array(
 				'post_type'    => 'post',
 				'post_status'  => 'draft',
-				'tax_input'    => array( 'post_format' => 'status' ),
+				'tax_input'    => array( 'post_format' => 'post-format-status' ),
 				'post_content' => $text,
 			)
 		);
@@ -90,12 +196,16 @@ class Friends_Automatic_Status {
 	 */
 	public function post_reaction( $post_id, $emoji ) {
 		$post = get_post( $post_id );
+		$title = get_the_title( $post );
+		if ( empty( $title ) ) {
+			$title = get_the_excerpt( $post );
+		}
 		$this->add_status(
 			sprintf(
 				// translators: %1$s is an emoji, %2$s is a linked post title.
 				__( 'I just reacted with %1$s on %2$s' ),
 				$emoji,
-				'<a href="' . esc_url( get_permalink( $post ) ) . '">' . esc_url( get_the_title( $post ) ) . '</a>'
+				'<a href="' . esc_url( get_permalink( $post ) ) . '">' . esc_html( $title ) . '</a>'
 			)
 		);
 	}

--- a/includes/class-friends-frontend.php
+++ b/includes/class-friends-frontend.php
@@ -670,6 +670,17 @@ class Friends_Frontend {
 		if ( $wp_query !== $query || $query->is_admin() || $query->is_home() ) {
 			return $query;
 		}
+
+		$pagename = '';
+		if ( isset( $wp_query->query['pagename'] ) ) {
+			$pagename = $wp_query->query['pagename'];
+		}
+
+		$pagename_parts = explode( '/', trim( $pagename, '/' ) );
+		if ( count( $pagename_parts ) > 0 && 'friends' !== $pagename_parts[0] ) {
+			return $query;
+		}
+
 		// Not available for the general public or friends.
 		$viewable = current_user_can( Friends::REQUIRED_ROLE );
 		if ( $query->is_feed() ) {
@@ -684,8 +695,10 @@ class Friends_Frontend {
 			}
 		}
 
-		if ( ! ( Friends::on_frontend() || $query->is_feed() ) || ! $viewable ) {
-			return $query;
+		if ( ! $viewable ) {
+			if ( ! Friends::on_frontend() && ! $query->is_feed() ) {
+				return $query;
+			}
 		}
 
 		// Super Admins cannot view other's friend pages.
@@ -716,11 +729,6 @@ class Friends_Frontend {
 		$query->is_comment_feed = false;
 		$query->set( 'pagename', null );
 
-		$pagename = '';
-		if ( isset( $wp_query->query['pagename'] ) ) {
-			$pagename = $wp_query->query['pagename'];
-		}
-		$pagename_parts = explode( '/', trim( $pagename, '/' ) );
 		if ( isset( $pagename_parts[1] ) ) {
 			if ( 'opml' === $pagename_parts[1] ) {
 				return $this->render_opml();

--- a/includes/class-friends-reactions.php
+++ b/includes/class-friends-reactions.php
@@ -212,8 +212,9 @@ class Friends_Reactions {
 
 		$post_id = intval( $_POST['post_id'] );
 		$available_emojis = self::get_available_emojis();
+		$emoji = self::validate_emoji( $_POST['reaction'] );
 
-		if ( ! self::validate_emoji( $_POST['reaction'] ) ) {
+		if ( ! $emoji ) {
 			// This emoji is not defined in emoji.json.
 			return new WP_Error( 'invalid-emoji', 'This emoji is unknown.' );
 		}
@@ -229,11 +230,11 @@ class Friends_Reactions {
 
 		if ( ! $term ) {
 			wp_set_object_terms( $post_id, $_POST['reaction'], $taxonomy, true );
+			do_action( 'friends_user_post_reaction', $post_id, $emoji );
 		} else {
 			wp_remove_object_terms( $post_id, $term->term_id, $taxonomy );
+			do_action( 'friends_user_post_undo_reaction', $post_id, $emoji );
 		}
-
-		do_action( 'friends_user_post_reaction', $post_id );
 
 		wp_send_json_success(
 			array(

--- a/includes/class-friends-rest.php
+++ b/includes/class-friends-rest.php
@@ -354,15 +354,16 @@ class Friends_REST {
 
 		return null;
 	}
-		/**
-		 * Notify the friend's site via REST about the accepted friend request.
-		 *
-		 * Accepting a friend request is simply setting the role to "friend".
-		 *
-		 * @param  int    $user_id   The user id.
-		 * @param  string $new_role  The new role.
-		 * @param  string $old_roles The old roles.
-		 */
+
+	/**
+	 * Notify the friend's site via REST about the accepted friend request.
+	 *
+	 * Accepting a friend request is simply setting the role to "friend".
+	 *
+	 * @param  int    $user_id   The user id.
+	 * @param  string $new_role  The new role.
+	 * @param  string $old_roles The old roles.
+	 */
 	public function notify_remote_friend_request_accepted( $user_id, $new_role, $old_roles ) {
 		if ( 'friend' !== $new_role && 'acquaintance' !== $new_role ) {
 			return;

--- a/includes/class-friends.php
+++ b/includes/class-friends.php
@@ -127,6 +127,7 @@ class Friends {
 		new Friends_Blocks( $this );
 		new Friends_Logging( $this );
 		new Friends_Shortcodes( $this );
+		new Friends_Automatic_Status( $this );
 		$this->register_hooks();
 		load_plugin_textdomain( 'friends', false, FRIENDS_PLUGIN_FILE . '/languages/' );
 		do_action( 'friends_init', $this );

--- a/templates/admin/automatic-status-list-table.php
+++ b/templates/admin/automatic-status-list-table.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * This template contains the Automatic Status list table.
+ *
+ * @version 1.0
+ * @package Friends
+ */
+
+// Much of this page has been adapted from wp-admin/edit.php.
+
+?><div class="wrap">
+<h1 class="wp-heading-inline">
+<?php
+esc_html_e( 'Automatically Generated Statuses', 'friends' );
+?>
+</h1>
+
+<hr class="wp-header-end">
+
+<p><?php esc_html_e( 'For certain actions that you take in the Friends plugin, a status post is created automatically. Here you can review them and publish them as you like.', 'friends' ); ?></p>
+
+<?php $args['wp_list_table']->views(); ?>
+
+<form id="posts-filter" method="get" action="edit.php">
+
+<input type="hidden" name="post_status" class="post_status_page" value="draft" />
+<input type="hidden" name="post_format" value="status" />
+<input type="hidden" name="post_type" class="post_type_page" value="<?php echo esc_attr( $args['post_type'] ); ?>" />
+
+
+<?php $args['wp_list_table']->display(); ?>
+
+</form>
+
+<?php
+if ( $args['wp_list_table']->has_items() ) {
+	$args['wp_list_table']->inline_edit();
+}
+?>
+
+</div>


### PR DESCRIPTION
This will automatically create new status posts based on an action. For example, if you 👍-react to a post, it will create a new post:

> I just reacted with 👍 on [Name of post](https://example.com)

It also adds a UI where you can quickly publish or delete these:

![Screenshot 2021-09-30 at 17 08 16](https://user-images.githubusercontent.com/203408/135483198-7d86e51e-6419-47d8-838d-a6d4e98ba974.png)


- [x] Post reactions
- [x] New friends or subscriptions