### PR TITLE
Global Keyword Matcher

### DIFF
--- a/friends-admin.js
+++ b/friends-admin.js
@@ -156,4 +156,10 @@ jQuery( function( $ ) {
 		return false;
 	} );
 
+	$(document).on( 'click', '#admin-add-keyword', function() {
+		$( '#keyword-notifications' ).append( '<li>' + $( '#keyword-template' ).html().replace( /\[0\]/g, '[' + $( '#keyword-notifications li' ).length + ']' ) );
+		$( '#keyword-notifications input:last ' ).focus()
+		return false;
+	} );
+
 } );

--- a/includes/class-friends-admin.php
+++ b/includes/class-friends-admin.php
@@ -1868,8 +1868,7 @@ class Friends_Admin {
 		if ( get_user_option( 'friends_unobtrusive_badge' ) ) {
 			return ' (' . $unread_count . ')';
 		}
-
-		$unread_badge = ' <div class="wp-core-ui wp-ui-notification friends-open-requests" style="display: inline; font-size: 90%; padding: .1em .5em .1em .4em; border-radius: 50%;background-color: #d54e21; color: #fff;"><span aria-hidden="true">' . $unread_count . '</span><span class="screen-reader-text">';
+		$unread_badge = ' <div class="wp-core-ui wp-ui-notification friends-open-requests" style="display: inline; font-size: 11px; padding: .1em .5em .1em .4em; border-radius: 9px; background-color: #d63638; color: #fff; text-align: center; height: 18px"><span aria-hidden="true">' . $unread_count . '</span><span class="screen-reader-text">';
 		// translators: %s is the number of unread items.
 		$unread_badge .= sprintf( _n( '%s unread item', '%s unread items', $unread_count, 'friends' ), $unread_count );
 		$unread_badge .= '</span></div>';

--- a/includes/class-friends-feed.php
+++ b/includes/class-friends-feed.php
@@ -446,15 +446,13 @@ class Friends_Feed {
 	 * @return     array  The notification keywords.
 	 */
 	public static function get_active_notification_keywords() {
-		static $active_keywords;
-		if ( ! isset( $active_keywords ) ) {
-			$active_keywords = array();
-			foreach ( self::get_all_notification_keywords() as $entry ) {
-				if ( $entry['enabled'] ) {
-					$active_keywords[] = $entry['keyword'];
-				}
+		$active_keywords = array();
+		foreach ( self::get_all_notification_keywords() as $entry ) {
+			if ( $entry['enabled'] ) {
+				$active_keywords[] = $entry['keyword'];
 			}
 		}
+
 		return $active_keywords;
 	}
 

--- a/includes/class-friends-messages.php
+++ b/includes/class-friends-messages.php
@@ -431,7 +431,6 @@ class Friends_Messages {
 		if ( ! $friend_user->has_cap( self::get_minimum_cap() ) ) {
 			return new WP_Error( 'not-a-friend', __( 'You cannot send messages to this user.', 'friends' ) );
 		}
-		var_dump( $message );
 		if ( ! trim( $message ) ) {
 			return new WP_Error( 'empty-message', __( 'You cannot send empty messages.', 'friends' ) );
 		}

--- a/templates/admin/edit-friend.php
+++ b/templates/admin/edit-friend.php
@@ -271,6 +271,25 @@ $has_last_log = false;
 				</td>
 			</tr>
 			<tr>
+				<th scope="row"><?php esc_html_e( 'Keyword Notification', 'friends' ); ?></th>
+				<td>
+					<fieldset>
+						<label for="friends_keyword_notification">
+							<input name="friends_keyword_notification" type="checkbox" id="friends_keyword_notification" value="1" <?php checked( '1', ! get_user_option( 'friends_no_keyword_notification_' . $args['friend']->ID ) ); ?> />
+							<?php
+							echo wp_kses_post(
+								sprintf(
+									// translators: %s is a URL.
+									__( 'Send me an e-mail for posts of this friend if matches one of <a href="%s">my keywords</a>', 'friends' ),
+									esc_url( add_query_arg( 'wp_http_referer', urlencode( wp_unslash( $_SERVER['REQUEST_URI'] ) ), self_admin_url( 'admin.php?page=friends-settings' ) ) )
+								)
+							);
+							?>
+						</label>
+					</fieldset>
+				</td>
+			</tr>
+			<tr>
 				<th scope="row"><?php esc_html_e( 'Rules', 'friends' ); ?></th>
 				<td><a href="<?php echo esc_url( self_admin_url( 'admin.php?page=edit-friend-rules&user=' . $args['friend']->ID ) ); ?>">
 					<?php

--- a/templates/admin/notification-manager.php
+++ b/templates/admin/notification-manager.php
@@ -7,8 +7,26 @@
  */
 
 if ( $args['no_new_post_notification'] ) : ?>
-	<span class="description"><?php esc_html_e( 'You have generally disabled new post notifications for yourself.', 'friends' ); ?> <a href="<?php echo esc_url( $args['friends_settings_url'] ); ?>"><?php esc_html_e( 'Change setting', 'friends' ); ?></a></span>
+	<p class="description"><?php esc_html_e( 'You have generally disabled new post notifications for yourself.', 'friends' ); ?> <a href="<?php echo esc_url( $args['friends_settings_url'] ); ?>"><?php esc_html_e( '(Edit)' ); ?></a></p>
 <?php endif; ?>
+
+<p class="description">
+	<?php
+	if ( $args['active_keywords'] ) {
+		echo esc_html(
+			sprintf(
+				// translators: %1$s is the number of active keywords, %2$s is the list of those keywords.
+				_n( 'There is %1$s active keyword: %2$s', 'There are %1$s active keywords: %2$s', count( $args['active_keywords'] ), 'friends' ),
+				count( $args['active_keywords'] ),
+				esc_html( implode( ', ', $args['active_keywords'] ) )
+			)
+		);
+	} else {
+		esc_html_e( 'No notification keywords have been specified.', 'friends' );
+	}
+	?>
+	<a href="<?php echo esc_url( $args['friends_settings_url'] ); ?>"><?php esc_html_e( '(Edit)' ); ?></a>
+</p>
 
 <form method="post">
 	<?php wp_nonce_field( 'notification-manager' ); ?>
@@ -16,8 +34,9 @@ if ( $args['no_new_post_notification'] ) : ?>
 		<thead>
 			<tr>
 				<th class="column-primary column-friend"><?php esc_html_e( 'Friend', 'friends' ); ?></th>
-				<th class="column-friends-page-feeds"><?php esc_html_e( 'Show on friends page' ); ?></th>
-				<th class="column-email-notification"><?php esc_html_e( 'E-Mail Notification' ); ?></th>
+				<th class="column-friends-page-feeds"><?php esc_html_e( 'Show on friends page', 'friends' ); ?></th>
+				<th class="column-email-notification"><?php esc_html_e( 'E-Mail Notification', 'friends' ); ?></th>
+				<th class="column-email-notification"><?php esc_html_e( 'Keyword Notification', 'friends' ); ?></th>
 				<?php do_action( 'friends_notification_manager_header' ); ?>
 			</tr>
 		</thead>
@@ -33,6 +52,10 @@ if ( $args['no_new_post_notification'] ) : ?>
 					</td>
 					<td class="column-email-notification">
 						<input name="new_post_notification[<?php echo esc_attr( $friend_user->ID ); ?>]" type="checkbox" id="friends_new_post_notification" value="1" <?php checked( '1', ! get_user_option( 'friends_no_new_post_notification_' . $friend_user->ID ) ); ?> <?php echo $args['no_new_post_notification'] ? 'disabled="disabled"' : ''; ?>
+						/>
+					</td>
+					<td class="column-keyword-notification">
+						<input name="keyword_notification[<?php echo esc_attr( $friend_user->ID ); ?>]" type="checkbox" id="friends_keyword_notification" value="1" <?php checked( '1', ! get_user_option( 'friends_no_keyword_notification_' . $friend_user->ID ) ); ?> <?php echo $args['no_keyword_notification'] ? 'disabled="disabled"' : ''; ?>
 						/>
 					</td>
 				<?php do_action( 'friends_notification_manager_row', $friend_user ); ?>

--- a/templates/admin/settings.php
+++ b/templates/admin/settings.php
@@ -124,7 +124,33 @@ do_action( 'friends_settings_before_form' );
 							<?php esc_html_e( 'New Posts', 'friends' ); ?>
 						</label>
 					</fieldset>
-				<p class="description"><?php esc_html_e( 'You can also change this setting for each friend separately.', 'friends' ); ?></p>
+					<p class="description"><?php esc_html_e( 'You can also change this setting for each friend separately.', 'friends' ); ?></p>
+				</td>
+			</tr>
+			<tr>
+				<th scope="row">
+				<?php
+				esc_html_e( 'Keyword Notifications', 'friends' );
+				?>
+				</th>
+				<td>
+					<fieldset>
+
+						<ol id="keyword-notifications">
+							<li id="keyword-template" style="display: none">
+								<input type="checkbox" name="notification_keywords_enabled[0]" value="1" checked />
+								<input type="text" name="notification_keywords[0]" value="" placeholder="<?php esc_html_e( 'Keyword (regex allowed)', 'friends' ); ?>">
+							</li>
+						<?php foreach ( $args['notification_keywords'] as $i => $entry ) : ?>
+							<li>
+								<input type="checkbox" name="notification_keywords_enabled[<?php echo esc_attr( $i + 1 ); ?>]" value="1" <?php checked( $entry['enabled'] ); ?> />
+								<input type="text" name="notification_keywords[<?php echo esc_attr( $i + 1 ); ?>]" value="<?php echo esc_attr( $entry['keyword'] ); ?>" placeholder="<?php esc_html_e( 'Keyword (regex allowed)', 'friends' ); ?>">
+							</li>
+						<?php endforeach; ?>
+						</ol>
+						<a href="" id="admin-add-keyword"><?php esc_html_e( 'Add a notification keyword', 'friends' ); ?></a>
+					</fieldset>
+					<p class="description"><?php esc_html_e( 'Empty keywords will be deleted after saving. You can temporarily disable them with the checkbox.', 'friends' ); ?></p>
 				</td>
 			</tr>
 			<tr>
@@ -240,7 +266,7 @@ do_action( 'friends_settings_before_form' );
 						}
 						?>
 						</ol>
-						<a href="" id="admin-add-emoji"><?php esc_html_e( 'Add an emoji' ); ?></a>
+						<a href="" id="admin-add-emoji"><?php esc_html_e( 'Add an emoji', 'friends' ); ?></a>
 						<?php Friends::template_loader()->get_template_part( 'admin/reactions-picker' ); ?>
 					</fieldset>
 				</td>

--- a/templates/email/keyword-match-post.php
+++ b/templates/email/keyword-match-post.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * This template contains the HTML for the New Friend Post notification e-mail.
+ *
+ * @version 1.0
+ * @package Friends
+ */
+
+$override_author_name = apply_filters( 'friends_override_author_name', '', $args['author']->display_name, $args['post']->ID );
+
+?>
+<div class="post-meta">
+	<strong>
+		<?php
+		echo esc_html(
+			// translators: %s is a keyword string specified by the user.
+			sprintf( __( 'Keyword matched: %s', 'friends' ), $args['keyword'] )
+		);
+		?>
+	</strong>
+	<a href="<?php echo esc_attr( $args['author']->get_local_friends_page_url() ); ?>" class="author">
+		<strong><?php echo esc_html( $args['author']->display_name ); ?></strong>
+		<?php if ( $override_author_name && trim( str_replace( $override_author_name, '', $args['author']->display_name ) ) === $args['author']->display_name ) : ?>
+			– <?php echo esc_html( $override_author_name ); ?>
+		<?php endif; ?>
+	</a>
+	<?php if ( '' !== trim( $args['post']->post_title ) ) : ?>
+		<h2><a href="<?php the_permalink( $args['post'] ); ?>"><?php echo esc_html( $args['post']->post_title ); ?></a></h2>
+	<?php endif; ?>
+</div>
+
+<div class="post-content">
+<?php
+	echo wp_kses_post( apply_filters( 'friends_rewrite_mail_html', $args['post']->post_content ) );
+?>
+</div>
+
+<div class="post-footer">
+	<a href="<?php echo esc_url( $args['author']->get_local_friends_page_url( $args['post']->ID ) ); ?>#respond" class="btn">
+		<?php
+			esc_html_e( 'Reply', 'friends' );
+		?>
+	</a>
+	<a href="<?php echo esc_url( $args['author']->get_local_friends_page_url( $args['post']->ID ) ); ?>" class="btn noborder">
+		<?php
+			esc_html_e( 'View on your friends page', 'friends' );
+		?>
+	</a>
+	<p class="permalink">
+	<?php
+	echo wp_kses(
+		sprintf(
+		// translators: %s is a URL.
+			__( 'Published at %s', 'friends' ),
+			'<a href="' . esc_url( get_permalink( $args['post'] ) ) . '">' . esc_html( get_permalink( $args['post'] ) ) . '</a></strong>'
+		),
+		array( 'a' => array( 'href' => array() ) )
+	);
+	?>
+	</p>
+</div>
+
+<div class="subscription-settings">
+	<hr>
+	<?php
+	printf(
+		// translators: %1$s is a URL, %2$s is a URL, %3$s is a username, %4$s is a URL.
+		__( 'Manage your <a href=%1$s>global notification settings</a>, <a href=%2$s>change notifications for %3$s</a>, or <a href=%4$s>muffle posts like these</a>.', 'friends' ),
+		'"' . esc_url( self_admin_url( 'admin.php?page=friends-settings' ) ) . '"',
+		'"' . esc_url( self_admin_url( 'admin.php?page=edit-friend&user=' . $args['author']->ID ) ) . '"',
+		'<em>' . esc_html( $args['author']->display_name ) . '</em>',
+		'"' . esc_url( self_admin_url( 'admin.php?page=edit-friend-rules&user=' . $args['author']->ID . '&post=' . $args['post']->ID ) ) . '"'
+	);
+	?>
+</div>

--- a/templates/email/keyword-match-post.text.php
+++ b/templates/email/keyword-match-post.text.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * This template contains the HTML for the New Friend Post notification e-mail.
+ *
+ * @version 1.0
+ * @package Friends
+ */
+
+$ensure_linebreaks     = preg_replace( '/\<br(\s*)?\/?\>/i', PHP_EOL, $args['post']->post_content );
+$plain_text            = strip_tags( $ensure_linebreaks );
+$normalized_whitespace = preg_replace( '/(' . PHP_EOL . '\s*' . PHP_EOL . ')+/m', PHP_EOL . PHP_EOL, $plain_text );
+$quoted_text           = '> ' . str_replace( PHP_EOL, PHP_EOL . '> ', trim( $normalized_whitespace ) );
+
+// translators: %s is a keyword string specified by the user.
+printf( __( 'Keyword matched: %s', 'friends' ), $args['keyword'] );
+
+echo PHP_EOL, PHP_EOL;
+
+echo $quoted_text;
+
+echo PHP_EOL, PHP_EOL;
+
+printf(
+	// translators: %1$s is a username, %2$s is a URL.
+	__( 'This post was published by your friend %1$s at %2$s', 'friends' ),
+	$args['author']->display_name,
+	get_permalink( $args['post'] )
+);
+
+echo PHP_EOL;
+printf(
+	// translators: %s is a URL.
+	__( 'You can also view this post on your friends page: %s', 'friends' ),
+	$args['author']->get_local_friends_page_url( $args['post']->ID )
+);
+echo PHP_EOL, PHP_EOL;
+
+printf(
+	// translators: %s is a URL.
+	__( 'Manage your subscription settings at %s', 'friends' ),
+	$args['author']->display_name,
+	self_admin_url( 'admin.php?page=friends-settings' )
+);
+echo PHP_EOL;
+
+printf(
+	// translators: %1$s is a username, %2$s is a URL.
+	__( 'Or just unsubscribe from %1$s\'s posts at %2$s', 'friends' ),
+	$args['author']->display_name,
+	self_admin_url( 'admin.php?page=edit-friend&user=' . $args['author']->ID )
+);

--- a/tests/test-notifications.php
+++ b/tests/test-notifications.php
@@ -94,7 +94,7 @@ class Friends_NotificationTest extends WP_UnitTestCase {
 
 		$friends   = Friends::get_instance();
 		$new_items = $friends->feed->process_incoming_feed_items( $parser->process_items( $feed->get_items(), $user_feed->get_url() ), $user_feed, Friends::CPT );
-		$friends->feed->notify_about_new_friend_posts( $user, $new_items );
+		$friends->feed->notify_about_new_posts( $user, $new_items );
 	}
 
 	/**
@@ -136,7 +136,7 @@ class Friends_NotificationTest extends WP_UnitTestCase {
 
 		$friends   = Friends::get_instance();
 		$new_items = $friends->feed->process_incoming_feed_items( $parser->process_items( $feed->get_items(), $user_feed->get_url() ), $user_feed, Friends::CPT );
-		$friends->feed->notify_about_new_friend_posts( $user, $new_items );
+		$friends->feed->notify_about_new_posts( $user, $new_items );
 	}
 
 	/**
@@ -242,5 +242,75 @@ class Friends_NotificationTest extends WP_UnitTestCase {
 		$me = new Friend_User( $me_id );
 		$me->set_role( 'friend' );
 		do_action( 'notify_accepted_friend_request', $me );
+	}
+
+	/**
+	 * Test notifications of a keyword in a post.
+	 */
+	public function test_notify_keyword() {
+		$that = $this;
+		add_filter(
+			'notify_user_about_keyword_post',
+			function( $do_send ) use ( $that ) {
+				$that->assertTrue( $do_send );
+				return $do_send;
+			},
+			10
+		);
+		add_filter(
+			'notify_user_about_friend_post',
+			function( $do_send ) use ( $that ) {
+				// This should be never reached because the notification above happened.
+				$that->assertTrue( false );
+				return $do_send;
+			},
+			10
+		);
+		$keyword = 'private';
+		add_filter(
+			'friends_send_mail',
+			function( $do_send, $to, $subject, $message, $headers ) use ( $that, $keyword ) {
+				// translators: %s is a keyword string specified by the user.
+				$keyword_title = sprintf( __( 'Keyword matched: %s', 'friends' ), $keyword );
+				// translators: %1$s is the site name, %2$s is the subject.
+				$that->assertEquals( $subject, sprintf( _x( '[%1$s] %2$s', 'email subject', 'friends' ), 'friend.local', $keyword_title ) );
+				$that->assertEquals( $to, WP_TESTS_EMAIL );
+				$that->assertTrue( $do_send );
+				return false;
+			},
+			10,
+			5
+		);
+		$friends = Friends::get_instance();
+		fetch_feed( null ); // load SimplePie.
+		update_option( 'home', 'http://me.local' );
+		update_option(
+			'friends_notification_keywords',
+			array(
+				array(
+					'enabled' => true,
+					'keyword' => $keyword,
+				),
+			)
+		);
+
+		$file = new SimplePie_File( __DIR__ . '/data/friend-feed-1-private-post.rss' );
+		$parser = new Friends_Feed_Parser_SimplePie;
+
+		$user = new Friend_User( $this->friend_id );
+		$term = new WP_Term(
+			(object) array(
+				'url' => $user->user_url . '/feed/',
+			)
+		);
+		$user_feed = new Friend_User_Feed( $term, $user );
+
+		$feed = new SimplePie();
+		$feed->set_file( $file );
+		$feed->init();
+
+		$friends   = Friends::get_instance();
+		$new_items = $friends->feed->process_incoming_feed_items( $parser->process_items( $feed->get_items(), $user_feed->get_url() ), $user_feed, Friends::CPT );
+		$friends->feed->notify_about_new_posts( $user, $new_items );
 	}
 }


### PR DESCRIPTION
This adds a feature that allows you to get notification e-mails for any keyword (or regex) you want. An important use case for this is mentions. Therefor a (disabled) default setting for this is the `home_url()`.

### Screenshots
You specify your keywords on the settings page:
<img width="921" alt="Screenshot 2022-01-18 at 16 58 43" src="https://user-images.githubusercontent.com/203408/149973005-487ea8a9-c5c1-47c0-abee-35887f8e9f7d.png">

The Notification manager also lists them:
<img width="934" alt="Screenshot 2022-01-18 at 16 58 20" src="https://user-images.githubusercontent.com/203408/149973026-975c7b61-cb3b-439b-9a51-d60e36f46448.png">

Setting for an individual friend:
<img width="781" alt="Screenshot 2022-01-18 at 16 59 11" src="https://user-images.githubusercontent.com/203408/149973038-47999668-b734-4679-a5fd-d6049c3cc95c.png">

### Testing
This adds one unit test covering this.