### PR TITLE
Improve multisite behavior

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,9 @@
 		"wp-coding-standards/wpcs": "*",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.7.0"
 	},
+	"config": {
+		"allow-plugins": {}
+	},
 	"prefer-stable" : true,
 	"scripts": {
 		"lint7": [

--- a/friends-admin.js
+++ b/friends-admin.js
@@ -166,4 +166,51 @@ jQuery( function( $ ) {
 		$( this ).closest( 'div' ).find( 'select option[value=publish]' ).prop( 'selected', true );
 	} );
 
+	$( document ).on( 'click', 'a.friends-auth-link, button.comments.friends-auth-link', function() {
+		var $this = jQuery( this ), href = $this.attr( 'href' ), token = $this.data( 'token' );
+		if ( ! token ) {
+			return;
+		}
+
+		var parts = token.split( /-/ );
+		var now = new Date;
+		if ( now / 1000 > parts[1] ) {
+			wp.ajax.post( 'friends_refresh_link_token', {
+				_ajax_nonce: $this.data( 'nonce' ),
+				friend: $this.data( 'friend' ),
+				url: href
+			} ).done( function( response ) {
+				if ( response.data ) {
+					$this.data( 'token', response.data.token );
+				}
+			} );
+
+			alert( friends.text_link_expired );
+			return false;
+		}
+
+		if ( href && href.indexOf( 'friend_auth=' ) < 0 ) {
+			var hash = href.indexOf( '#' );
+			if ( hash >= 0 ) {
+				hash = href.substr( hash );
+				href = href.substr( 0, href.length - hash.length );
+			} else {
+				hash = '';
+			}
+
+			if ( href.indexOf( '?' ) >= 0 ) {
+				href += '&';
+			} else {
+				href += '?';
+			}
+			href += 'friend_auth=' + token + hash;
+			$this.attr( 'href', href );
+		}
+
+		if ( $this.is( 'button' ) ) {
+			location.href = href;
+			return false;
+		}
+	} );
+
 } );

--- a/includes/class-access-control.php
+++ b/includes/class-access-control.php
@@ -297,11 +297,15 @@ class Access_Control {
 		if ( ! in_array( $cap, array( Friends::REQUIRED_ROLE, 'friend', 'acquaintance', 'pending_friend_request', 'friend_request', 'subscription' ) ) ) {
 			return $caps;
 		}
-		if ( ! is_super_admin( $user_id ) ) {
+		if ( is_multisite() && ! is_super_admin( $user_id ) ) {
 			return $caps;
 		}
 
 		$user = get_user_by( 'id', $user_id );
+		if ( ! $user ) {
+			return $caps;
+		}
+
 		foreach ( $user->roles as $role ) {
 			// If they have the role we are checking for, we'll respond with unmapped caps.
 			if ( $cap === $role ) {

--- a/includes/class-access-control.php
+++ b/includes/class-access-control.php
@@ -294,10 +294,10 @@ class Access_Control {
 	 * @return     array
 	 */
 	public function strict_friend_checking_for_super_admin( $caps, $cap, $user_id, $args ) {
-		if ( ! in_array( $cap, array( Friends::REQUIRED_ROLE, 'friend', 'acquaintance', 'pending_friend_request', 'friend_request', 'subscription' ) ) ) {
+		if ( ! in_array( $cap, array( 'friend', 'acquaintance', 'pending_friend_request', 'friend_request', 'subscription' ) ) ) {
 			return $caps;
 		}
-		if ( is_multisite() && ! is_super_admin( $user_id ) ) {
+		if ( ! is_multisite() || ! is_super_admin( $user_id ) ) {
 			return $caps;
 		}
 

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -904,10 +904,6 @@ class Admin {
 			wp_die( esc_html__( 'Invalid user ID.' ) ); // phpcs:ignore WordPress.WP.I18n.MissingArgDomain
 		}
 
-		if ( is_multisite() && is_super_admin( $_GET['user'] ) ) {
-			wp_die( esc_html__( 'Invalid user ID.' ) ); // phpcs:ignore WordPress.WP.I18n.MissingArgDomain
-		}
-
 		if (
 			! $friend->has_cap( 'friend_request' ) &&
 			! $friend->has_cap( 'pending_friend_request' ) &&
@@ -1367,7 +1363,6 @@ class Admin {
 				$friend_url = 'https://' . $friend_url;
 			}
 		}
-
 		$friend_user_login = User::get_user_login_for_url( $friend_url );
 		$friend_display_name = User::get_display_name_for_url( $friend_url );
 
@@ -1629,8 +1624,12 @@ class Admin {
 					?>
 					<div id="message" class="updated notice is-dismissible"><p>
 						<?php
+						$message = $response->get_error_message();
+						if ( $response->get_error_data() ) {
+							$message .= ' (' . $response->get_error_data() . ')';
+						}
 						echo wp_kses(
-							$response->get_error_message(),
+							$message,
 							array(
 								'strong' => array(),
 								'a'      => array(
@@ -1825,10 +1824,6 @@ class Admin {
 		}
 
 		if ( is_multisite() ) {
-			if ( is_super_admin( $user->ID ) ) {
-				return $actions;
-			}
-
 			// phpcs:ignore WordPress.WP.I18n.MissingArgDomain
 			$actions = array_merge( array( 'edit' => '<a href="' . esc_url( self_admin_url( 'admin.php?page=edit-friend&user=' . $user->ID ) ) . '">' . __( 'Edit' ) . '</a>' ), $actions );
 		}

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -2383,9 +2383,9 @@ class Admin {
 		return $tests;
 	}
 
-	public function get_missing_friend_roles() {
+	public function get_missing_friends_plugin_roles() {
 		$missing = array();
-		foreach ( Friends::get_friend_roles() as $role ) {
+		foreach ( Friends::get_friends_plugin_roles() as $role ) {
 			if ( ! get_role( $role ) ) {
 				$missing[] = $role;
 			}
@@ -2409,13 +2409,13 @@ class Admin {
 				sprintf(
 					// translators: %s is a list of roles.
 					__( 'These are the roles required for the friends plugin: %s', 'friends' ),
-					implode( ', ', Friends::get_friend_roles() )
+					implode( ', ', Friends::get_friends_plugin_roles() )
 				) .
 				'</p>',
 			'test'        => 'friends-roles',
 		);
 
-		$missing_friend_roles = $this->get_missing_friend_roles();
+		$missing_friend_roles = $this->get_missing_friends_plugin_roles();
 		if ( ! empty( $missing_friend_roles ) ) {
 
 			$result['label'] = sprintf(
@@ -2445,7 +2445,7 @@ class Admin {
 	}
 
 	public function site_health_debug( $debug_info ) {
-		$missing_friend_roles = $this->get_missing_friend_roles();
+		$missing_friend_roles = $this->get_missing_friends_plugin_roles();
 		$debug_info['friends'] = array(
 			'label'  => __( 'Friends', 'friends' ),
 			'fields' => array(
@@ -2462,7 +2462,7 @@ class Admin {
 					'value' => empty( $missing_friend_roles ) ? sprintf(
 						// translators: %s is a list of roles.
 						__( 'All roles found: %s', 'friends' ),
-						implode( ', ', Friends::get_friend_roles() )
+						implode( ', ', Friends::get_friends_plugin_roles() )
 					) : implode( ', ', $missing_friend_roles ), // phpcs:ignore WordPress.WP.I18n.MissingArgDomain
 				),
 				'main_user' => array(

--- a/includes/class-blocks.php
+++ b/includes/class-blocks.php
@@ -379,7 +379,7 @@ class Blocks {
 			);
 
 			if ( ! empty( $friends_base_url_endpoints ) ) {
-				header( 'Location: ' . $url . '?add-friend=' . home_url() );
+				header( 'Location: ' . $url . '?add-friend=' . urlencode( home_url() ) );
 				exit;
 			}
 		}

--- a/includes/class-feed.php
+++ b/includes/class-feed.php
@@ -759,12 +759,13 @@ class Feed {
 		$response = wp_safe_remote_get(
 			$url,
 			array(
-				'timeout'     => 20,
+				'timeout'     => apply_filters( 'friends_http_timeout', 20 ),
 				'redirection' => 1,
 			)
 		);
 
 		if ( is_wp_error( $response ) ) {
+			$response->add_data( $url );
 			return $response;
 		}
 

--- a/includes/class-feed.php
+++ b/includes/class-feed.php
@@ -765,7 +765,7 @@ class Feed {
 		);
 
 		if ( is_wp_error( $response ) ) {
-			return array();
+			return $response;
 		}
 
 		if ( 200 === wp_remote_retrieve_response_code( $response ) ) {
@@ -889,7 +889,7 @@ class Feed {
 
 			if ( $has_friends_plugin ) {
 				// Prefer the main RSS feed.
-				if ( 'feed' === trim( $path, '/' ) ) {
+				if ( '/feed' === substr( '/' . trim( $path, '/' ), -5 ) ) {
 					$available_feeds[ $link_url ]['post-format'] = 'autodetect';
 					$autoselected = true;
 				}

--- a/includes/class-friends.php
+++ b/includes/class-friends.php
@@ -204,6 +204,11 @@ class Friends {
 	 * Create the Friend user roles
 	 */
 	private static function setup_roles() {
+		$friend = get_role( 'friend3' );
+		if ( ! $friend ) {
+			_x( 'Friend3', 'User role', 'friends' );
+			$friend = add_role( 'friend3', 'Friend3' );
+		}
 		$friend = get_role( 'friend' );
 		if ( ! $friend ) {
 			_x( 'Friend', 'User role', 'friends' );
@@ -325,6 +330,15 @@ class Friends {
 		}
 
 		return $translations;
+	}
+
+	/**
+	 * Gets the friend roles.
+	 *
+	 * @return     array  The friend roles.
+	 */
+	public static function get_friend_roles() {
+		return array( 'friend', 'acquaintance', 'pending_friend_request', 'friend_request', 'subscription' );
 	}
 
 	/**

--- a/includes/class-friends.php
+++ b/includes/class-friends.php
@@ -467,7 +467,10 @@ class Friends {
 	public static function get_main_friend_user_id() {
 		$main_user_id = get_option( 'friends_main_user_id' );
 
-		if ( false === $main_user_id || ( is_multisite() && ! is_user_member_of_blog( $main_user_id, get_current_blog_id() ) ) ) {
+		if (
+			false === $main_user_id
+			|| ( is_multisite() && ! is_user_member_of_blog( $main_user_id, get_current_blog_id() ) )
+		) {
 			$users = User_Query::all_admin_users();
 			foreach ( $users->get_results() as $user ) {
 				$main_user_id = $user->ID;

--- a/includes/class-friends.php
+++ b/includes/class-friends.php
@@ -470,7 +470,7 @@ class Friends {
 	public static function get_main_friend_user_id() {
 		$main_user_id = get_option( 'friends_main_user_id' );
 
-		if ( false === $main_user_id ) {
+		if ( false === $main_user_id || ( is_multisite() && ! is_user_member_of_blog( $main_user_id, get_current_blog_id() ) ) ) {
 			$users = User_Query::all_admin_users();
 			foreach ( $users->get_results() as $user ) {
 				$main_user_id = $user->ID;

--- a/includes/class-friends.php
+++ b/includes/class-friends.php
@@ -369,15 +369,12 @@ class Friends {
 					self::activate_for_blog();
 					restore_current_blog();
 				}
-				return;
+			} elseif ( current_user_can( 'activate_plugins' ) ) {
+				self::activate_for_blog();
 			}
-
-			// Proceed to activate just for this site.
-		}
-
-		if ( ! current_user_can( 'activate_plugins' ) ) {
 			return;
 		}
+
 		self::activate_for_blog();
 	}
 

--- a/includes/class-friends.php
+++ b/includes/class-friends.php
@@ -333,11 +333,11 @@ class Friends {
 	}
 
 	/**
-	 * Gets the friend roles.
+	 * Gets the roles that the plugin uses.
 	 *
-	 * @return     array  The friend roles.
+	 * @return     array  The roles.
 	 */
-	public static function get_friend_roles() {
+	public static function get_friends_plugin_roles() {
 		return array( 'friend', 'acquaintance', 'pending_friend_request', 'friend_request', 'subscription' );
 	}
 

--- a/includes/class-frontend.php
+++ b/includes/class-frontend.php
@@ -732,11 +732,6 @@ class Frontend {
 			return $query;
 		}
 
-		// Super Admins cannot view other's friend pages.
-		if ( is_multisite() && is_super_admin( get_current_user_id() ) && ! is_user_member_of_blog( get_current_user_id(), get_current_blog_id() ) ) {
-			return $query;
-		}
-
 		switch_to_locale( get_user_locale() );
 		$page_id = get_query_var( 'page' );
 

--- a/includes/class-messages.php
+++ b/includes/class-messages.php
@@ -43,7 +43,7 @@ class Messages {
 	private function register_hooks() {
 		add_action( 'init', array( $this, 'register_custom_post_type' ) );
 		add_filter( 'friends_unread_count', array( $this, 'friends_unread_messages_count' ) );
-		add_action( 'friends_menu_top', array( $this, 'friends_add_menu_unread_messages' ) );
+		add_action( 'friends_own_site_menu_top', array( $this, 'friends_add_menu_unread_messages' ) );
 		add_action( 'wp_ajax_friends-mark-read', array( $this, 'mark_message_read' ) );
 		add_action( 'rest_api_init', array( $this, 'add_rest_routes' ) );
 		add_action( 'friends_author_header', array( $this, 'friends_author_header' ), 10, 2 );

--- a/includes/class-user-query.php
+++ b/includes/class-user-query.php
@@ -55,9 +55,9 @@ class User_Query extends \WP_User_Query {
 	 * Gets all friends.
 	 */
 	public static function all_friends() {
-		static $all_friends;
-		if ( ! self::$cache || ! isset( $all_friends ) ) {
-			$all_friends = new self(
+		static $all_friends = array();
+		if ( ! self::$cache || ! isset( $all_friends[ get_current_blog_id() ] ) ) {
+			$all_friends[ get_current_blog_id() ] = new self(
 				array(
 					'role__in' => array( 'friend', 'acquaintance' ),
 					'order'    => 'ASC',
@@ -65,16 +65,16 @@ class User_Query extends \WP_User_Query {
 				)
 			);
 		}
-		return $all_friends;
+		return $all_friends[ get_current_blog_id() ];
 	}
 
 	/**
 	 * Gets all friends.
 	 */
 	public static function all_friends_subscriptions() {
-		static $all_friends;
-		if ( ! self::$cache || ! isset( $all_friends ) ) {
-			$all_friends = new self(
+		static $all_friends_subscriptions = array();
+		if ( ! self::$cache || ! isset( $all_friends_subscriptions[ get_current_blog_id() ] ) ) {
+			$all_friends_subscriptions[ get_current_blog_id() ] = new self(
 				array(
 					'role__in' => array( 'friend', 'acquaintance', 'pending_friend_request', 'subscription' ),
 					'order'    => 'ASC',
@@ -82,7 +82,7 @@ class User_Query extends \WP_User_Query {
 				)
 			);
 		}
-		return $all_friends;
+		return $all_friends_subscriptions[ get_current_blog_id() ];
 	}
 
 	/**
@@ -108,9 +108,9 @@ class User_Query extends \WP_User_Query {
 	 * Gets all friend requests.
 	 */
 	public static function all_friend_requests() {
-		static $all_friend_requests;
-		if ( ! self::$cache || ! isset( $all_friend_requests ) ) {
-			$all_friend_requests = new self(
+		static $all_friend_requests = array();
+		if ( ! self::$cache || ! isset( $all_friend_requests[ get_current_blog_id() ] ) ) {
+			$all_friend_requests[ get_current_blog_id() ] = new self(
 				array(
 					'role'    => 'friend_request',
 					'order'   => 'ASC',
@@ -118,16 +118,16 @@ class User_Query extends \WP_User_Query {
 				)
 			);
 		}
-		return $all_friend_requests;
+		return $all_friend_requests[ get_current_blog_id() ];
 	}
 
 	/**
 	 * Gets all subscriptions.
 	 */
 	public static function all_subscriptions() {
-		static $all_subscriptions;
-		if ( ! self::$cache || ! isset( $all_subscriptions ) ) {
-			$all_subscriptions = new self(
+		static $all_subscriptions = array();
+		if ( ! self::$cache || ! isset( $all_subscriptions[ get_current_blog_id() ] ) ) {
+			$all_subscriptions[ get_current_blog_id() ] = new self(
 				array(
 					'role__in' => array( 'pending_friend_request', 'subscription' ),
 					'order'    => 'ASC',
@@ -135,7 +135,7 @@ class User_Query extends \WP_User_Query {
 				)
 			);
 		}
-		return $all_subscriptions;
+		return $all_subscriptions[ get_current_blog_id() ];
 	}
 
 	/**

--- a/includes/class-user.php
+++ b/includes/class-user.php
@@ -240,10 +240,6 @@ class User extends \WP_User {
 	public function __get( $key ) {
 		if ( 'user_url' === $key && empty( $this->data->user_url ) && is_multisite() ) {
 			$site = get_active_blog_for_user( $this->ID );
-			if ( ! $site ) {
-				var_dump( $this->ID );
-				exit;
-			}
 			// Ensure we're using the same URL protocol.
 			$this->data->user_url = set_url_scheme( $site->siteurl );
 			return $this->data->user_url;

--- a/includes/class-user.php
+++ b/includes/class-user.php
@@ -170,7 +170,7 @@ class User extends \WP_User {
 			return false;
 		}
 
-		// If the friend was added via URL.
+		// Let's find the user that is associated with that blog.
 		switch_to_blog( $site_id );
 		$friend_user_id = Friends::get_main_friend_user_id();
 		restore_current_blog();

--- a/templates/admin/edit-friend.php
+++ b/templates/admin/edit-friend.php
@@ -78,7 +78,7 @@ $has_last_log = false;
 											?>
 										</option>
 									<?php endif; ?>
-								</select> <a href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'wp_http_referer', urlencode( wp_unslash( $_SERVER['REQUEST_URI'] ) ), self_admin_url( 'admin.php?page=add-friend&parser=' . urlencode( $feed->get_parser() ) . '&feed=' . urlencode( $term_id ) . '&preview=' . urlencode( $feed->get_url() ) ) ), 'preview-feed' ) ); ?>" class="preview-parser" target="_blank" rel="noopener noreferrer"><?php esc_attr_e( 'Preview', 'friends' ); ?></a></td>
+								</select> <a href="<?php echo esc_url( wp_nonce_url( add_query_arg( '_wp_http_referer', urlencode( wp_unslash( $_SERVER['REQUEST_URI'] ) ), self_admin_url( 'admin.php?page=add-friend&parser=' . urlencode( $feed->get_parser() ) . '&feed=' . urlencode( $term_id ) . '&preview=' . urlencode( $feed->get_url() ) ) ), 'preview-feed' ) ); ?>" class="preview-parser" target="_blank" rel="noopener noreferrer"><?php esc_attr_e( 'Preview', 'friends' ); ?></a></td>
 								<td><select name="feeds[<?php echo esc_attr( $term_id ); ?>][post-format]" aria-label="<?php /* phpcs:ignore WordPress.WP.I18n.MissingArgDomain */ esc_attr_e( 'Post Format' ); ?>">
 									<?php foreach ( $args['post_formats'] as $format => $title ) : ?>
 										<option value="<?php echo esc_attr( $format ); ?>"<?php selected( $format, $feed->get_post_format() ); ?>><?php echo esc_html( $title ); ?></option>
@@ -102,7 +102,7 @@ $has_last_log = false;
 								<?php foreach ( $args['registered_parsers'] as $slug => $parser_name ) : ?>
 									<option value="<?php echo esc_attr( $slug ); ?>"><?php echo esc_html( strip_tags( $parser_name ) ); ?></option>
 								<?php endforeach; ?>
-							</select> <a href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'wp_http_referer', urlencode( wp_unslash( $_SERVER['REQUEST_URI'] ) ), self_admin_url( 'admin.php?page=add-friend&parser=&preview=' ) ), 'preview-feed' ) ); ?>" class="preview-parser" target="_blank" rel="noopener noreferrer"><?php esc_attr_e( 'Preview', 'friends' ); ?></a></td>
+							</select> <a href="<?php echo esc_url( wp_nonce_url( add_query_arg( '_wp_http_referer', urlencode( wp_unslash( $_SERVER['REQUEST_URI'] ) ), self_admin_url( 'admin.php?page=add-friend&parser=&preview=' ) ), 'preview-feed' ) ); ?>" class="preview-parser" target="_blank" rel="noopener noreferrer"><?php esc_attr_e( 'Preview', 'friends' ); ?></a></td>
 							<td><select name="feeds[new][post-format]" aria-label="<?php /* phpcs:ignore WordPress.WP.I18n.MissingArgDomain */ esc_attr_e( 'Post Format' ); ?>">
 								<?php foreach ( $args['post_formats'] as $format => $title ) : ?>
 									<option value="<?php echo esc_attr( $format ); ?>"><?php echo esc_html( $title ); ?></option>
@@ -226,21 +226,21 @@ $has_last_log = false;
 					<?php echo esc_html( $args['friend']->get_role_name() ); ?>
 					<?php if ( $args['friend']->has_cap( 'friend_request' ) ) : ?>
 						<p class="description">
-							<a href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'wp_http_referer', urlencode( wp_unslash( $_SERVER['REQUEST_URI'] ) ), self_admin_url( 'admin.php?page=edit-friend&user=' . $args['friend']->ID ) ), 'accept-friend-request-' . $args['friend']->ID, 'accept-friend-request' ) ); ?>"><?php esc_html_e( 'Accept Friend Request', 'friends' ); ?></a>
+							<a href="<?php echo esc_url( wp_nonce_url( add_query_arg( '_wp_http_referer', urlencode( wp_unslash( $_SERVER['REQUEST_URI'] ) ), self_admin_url( 'admin.php?page=edit-friend&user=' . $args['friend']->ID ) ), 'accept-friend-request-' . $args['friend']->ID, 'accept-friend-request' ) ); ?>"><?php esc_html_e( 'Accept Friend Request', 'friends' ); ?></a>
 						</p>
 					<?php elseif ( $args['friend']->has_cap( 'pending_friend_request' ) ) : ?>
 						<p class="description">
-							<a href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'wp_http_referer', urlencode( wp_unslash( $_SERVER['REQUEST_URI'] ) ), self_admin_url( 'admin.php?page=edit-friend&user=' . $args['friend']->ID ) ), 'add-friend-' . $args['friend']->ID, 'add-friend' ) ); ?>"><?php esc_html_e( 'Resend Friend Request', 'friends' ); ?></a>
+							<a href="<?php echo esc_url( wp_nonce_url( add_query_arg( '_wp_http_referer', urlencode( wp_unslash( $_SERVER['REQUEST_URI'] ) ), self_admin_url( 'admin.php?page=edit-friend&user=' . $args['friend']->ID ) ), 'add-friend-' . $args['friend']->ID, 'add-friend' ) ); ?>"><?php esc_html_e( 'Resend Friend Request', 'friends' ); ?></a>
 						</p>
 					<?php elseif ( $args['friend']->has_cap( 'subscription' ) ) : ?>
 						<p class="description">
-							<a href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'wp_http_referer', urlencode( wp_unslash( $_SERVER['REQUEST_URI'] ) ), self_admin_url( 'admin.php?page=edit-friend&user=' . $args['friend']->ID ) ), 'add-friend-' . $args['friend']->ID, 'add-friend' ) ); ?>"><?php esc_html_e( 'Send Friend Request', 'friends' ); ?></a>
+							<a href="<?php echo esc_url( wp_nonce_url( add_query_arg( '_wp_http_referer', urlencode( wp_unslash( $_SERVER['REQUEST_URI'] ) ), self_admin_url( 'admin.php?page=edit-friend&user=' . $args['friend']->ID ) ), 'add-friend-' . $args['friend']->ID, 'add-friend' ) ); ?>"><?php esc_html_e( 'Send Friend Request', 'friends' ); ?></a>
 						</p>
 					<?php elseif ( $args['friend']->has_cap( 'acquaintance' ) ) : ?>
 						<p class="description">
 							<?php
 							// translators: %s is a friend role.
-							echo wp_kses( sprintf( __( 'Change to %s.', 'friends' ), '<a href="' . esc_url( wp_nonce_url( add_query_arg( 'wp_http_referer', urlencode( wp_unslash( $_SERVER['REQUEST_URI'] ) ), self_admin_url( 'admin.php?page=edit-friend&user=' . $args['friend']->ID ) ), 'change-to-friend-' . $args['friend']->ID, 'change-to-friend' ) ) . '">' . __( 'Friend', 'friends' ) . '</a>' ), array( 'a' => array( 'href' => array() ) ) );
+							echo wp_kses( sprintf( __( 'Change to %s.', 'friends' ), '<a href="' . esc_url( wp_nonce_url( add_query_arg( '_wp_http_referer', urlencode( wp_unslash( $_SERVER['REQUEST_URI'] ) ), self_admin_url( 'admin.php?page=edit-friend&user=' . $args['friend']->ID ) ), 'change-to-friend-' . $args['friend']->ID, 'change-to-friend' ) ) . '">' . __( 'Friend', 'friends' ) . '</a>' ), array( 'a' => array( 'href' => array() ) ) );
 							?>
 							<?php esc_html_e( 'An Acquaintance has friend status but cannot read private posts.', 'friends' ); ?>
 						</p>
@@ -248,7 +248,7 @@ $has_last_log = false;
 						<p class="description">
 						<?php
 							// translators: %s is a friend role.
-						echo wp_kses( sprintf( __( 'Change to %s.', 'friends' ), '<a href="' . esc_url( wp_nonce_url( add_query_arg( 'wp_http_referer', urlencode( wp_unslash( $_SERVER['REQUEST_URI'] ) ), self_admin_url( 'admin.php?page=edit-friend&user=' . $args['friend']->ID ) ), 'change-to-restricted-friend-' . $args['friend']->ID, 'change-to-restricted-friend' ) ) . '">' . __( 'Acquaintance', 'friends' ) . '</a>' ), array( 'a' => array( 'href' => array() ) ) );
+						echo wp_kses( sprintf( __( 'Change to %s.', 'friends' ), '<a href="' . esc_url( wp_nonce_url( add_query_arg( '_wp_http_referer', urlencode( wp_unslash( $_SERVER['REQUEST_URI'] ) ), self_admin_url( 'admin.php?page=edit-friend&user=' . $args['friend']->ID ) ), 'change-to-restricted-friend-' . $args['friend']->ID, 'change-to-restricted-friend' ) ) . '">' . __( 'Acquaintance', 'friends' ) . '</a>' ), array( 'a' => array( 'href' => array() ) ) );
 						?>
 							<?php esc_html_e( 'An Acquaintance has friend status but cannot read private posts.', 'friends' ); ?>
 						</p>
@@ -259,7 +259,7 @@ $has_last_log = false;
 				<th scope="row"><?php esc_html_e( 'New Post Notification', 'friends' ); ?></th>
 				<td>
 					<?php if ( get_user_option( 'friends_no_new_post_notification' ) ) : ?>
-						<span class="description"><?php esc_html_e( 'You have generally disabled new post notifications for yourself.', 'friends' ); ?> <a href="<?php echo esc_url( add_query_arg( 'wp_http_referer', urlencode( wp_unslash( $_SERVER['REQUEST_URI'] ) ), self_admin_url( 'admin.php?page=friends-settings' ) ) ); ?>"><?php esc_html_e( 'Change this setting', 'friends' ); ?></a></span>
+						<span class="description"><?php esc_html_e( 'You have generally disabled new post notifications for yourself.', 'friends' ); ?> <a href="<?php echo esc_url( add_query_arg( '_wp_http_referer', urlencode( wp_unslash( $_SERVER['REQUEST_URI'] ) ), self_admin_url( 'admin.php?page=friends-settings' ) ) ); ?>"><?php esc_html_e( 'Change this setting', 'friends' ); ?></a></span>
 					<?php else : ?>
 					<fieldset>
 						<label for="friends_new_post_notification">
@@ -281,7 +281,7 @@ $has_last_log = false;
 								sprintf(
 									// translators: %s is a URL.
 									__( 'Send me an e-mail for posts of this friend if matches one of <a href="%s">my keywords</a>', 'friends' ),
-									esc_url( add_query_arg( 'wp_http_referer', urlencode( wp_unslash( $_SERVER['REQUEST_URI'] ) ), self_admin_url( 'admin.php?page=friends-settings' ) ) )
+									esc_url( add_query_arg( '_wp_http_referer', urlencode( wp_unslash( $_SERVER['REQUEST_URI'] ) ), self_admin_url( 'admin.php?page=friends-settings' ) ) )
 								)
 							);
 							?>

--- a/templates/admin/select-feeds.php
+++ b/templates/admin/select-feeds.php
@@ -162,7 +162,7 @@ foreach ( $args['feeds'] as $feed_url => $details ) {
 									// translators: 1: is a link to a feed with its name as text, 2: url for a preview, 3: a select dropdown with post formats.
 										__( 'Subscribe %1$s (<a href=%2$s>preview</a>) as %3$s', 'friends' ),
 										'<a href="' . esc_attr( $feed_url ) . '" target="_blank" rel="noopener noreferrer">' . esc_html( $details['title'] ) . '</a>',
-										'"' . esc_url( wp_nonce_url( add_query_arg( 'wp_http_referer', urlencode( wp_unslash( $_SERVER['REQUEST_URI'] ) ), self_admin_url( 'admin.php?page=add-friend&parser=' . urlencode( $details['parser'] ) . '&preview=' . urlencode( $feed_url ) ) ), 'preview-feed' ) ) . '" target="_blank"',
+										'"' . esc_url( wp_nonce_url( add_query_arg( '_wp_http_referer', urlencode( wp_unslash( $_SERVER['REQUEST_URI'] ) ), self_admin_url( 'admin.php?page=add-friend&parser=' . urlencode( $details['parser'] ) . '&preview=' . urlencode( $feed_url ) ) ), 'preview-feed' ) ) . '" target="_blank"',
 										'</label>' . $select
 									),
 									array(

--- a/templates/admin/select-feeds.php
+++ b/templates/admin/select-feeds.php
@@ -49,13 +49,23 @@ foreach ( $args['feeds'] as $feed_url => $details ) {
 			<tr>
 				<th scope="row"><label for="user_login"><?php esc_html_e( 'Display Name', 'friends' ); ?></label></th>
 				<td>
+				<?php if ( ! empty( $args['friends_multisite_display_name'] ) ) : ?>
+					<?php echo esc_html( $args['friends_multisite_display_name'] ); ?>
+					<input type="hidden" id="user_login" name="display_name" value="<?php echo esc_attr( $args['friend_display_name'] ); ?>" />
+				<?php else : ?>
 					<input type="text" id="user_login" name="display_name" value="<?php echo esc_attr( $args['friend_display_name'] ); ?>" required placeholder="" class="regular-text" />
+				<?php endif; ?>
 				</td>
 			</tr>
 			<tr>
 				<th scope="row"><label for="user_login"><?php esc_html_e( 'Username', 'friends' ); ?></label></th>
 				<td>
-					<input type="text" id="user_login" name="user_login" value="<?php echo esc_attr( $args['friend_user_login'] ); ?>" required placeholder="" class="regular-text" />
+					<?php if ( ! empty( $args['friends_multisite_user_login'] ) ) : ?>
+						<?php echo esc_html( $args['friends_multisite_user_login'] ); ?>
+						<input type="hidden" id="user_login" name="user_login" value="<?php echo esc_attr( $args['friends_multisite_user_login'] ); ?>" />
+					<?php else : ?>
+						<input type="text" id="user_login" name="user_login" value="<?php echo esc_attr( $args['friend_user_login'] ); ?>" required placeholder="" class="regular-text" />
+					<?php endif; ?>
 				</td>
 			</tr>
 			<?php if ( $args['friends_plugin'] ) : ?>

--- a/tests/test-messages.php
+++ b/tests/test-messages.php
@@ -42,7 +42,7 @@ class MessagesTest extends \WP_UnitTestCase {
 			array(
 				'user_login' => 'me.local',
 				'user_email' => 'me@example.org',
-				'role'       => 'administrator',
+				'role'       => 'friend',
 				'user_url'   => 'https://me.local',
 			)
 		);


### PR DESCRIPTION
This PR attempts to improve the plugin's behavior when running inside multisite environments.

## Problem
The Friends plugin was designed for allowing unrelated sites across the web to communicate with each other and establish authentication against each other. They communicate via REST API and represent each other with locally created users. The content for the other sites is downloaded via feeds and assigned to these representative users with a custom post type `friend_post_cache`.

While this generally works in a multisite context, there are a few things that don't fit the environment well:
- The super admin role has every permission on any site, even if it hasn't been assigned to it. This makes the plugins reliance on user roles fail (for example, it always has the "friend" capability even if it is not a friend of the site).
- It is pointless to create a user to represent the other site, since that other user is on the same multisite (=database) already. This is not only for superflous redundancy reasons. Normally, there is a user created [by deriving a username from the URL](https://github.com/akirk/friends/blob/1f40bd9c80b639931663df79ef80219854ab16d4/includes/class-user.php#L109), but it two friends befriend the same person on the same blog, the same username is shared already resulting a clash. Thus we could equally well use the original user.
- Sub-directory multisites are different once again for discovering if a user's URL resides on the local multisite environment.

## Solution
This PR addresses the above in the following ways:
- [Super admins no longer have all capabilities when queried for the desired roles](https://github.com/akirk/friends/blob/3ace50e4950e91782f5d31334a7c2a3791c73488/includes/class-access-control.php#L296)
- [Multisite users are detected and reused](https://github.com/akirk/friends/blob/3ace50e4950e91782f5d31334a7c2a3791c73488/includes/class-user.php#L160)
- [It fixes inconsistency for the Friends menu in the admin bar](https://github.com/akirk/friends/blob/3ace50e4950e91782f5d31334a7c2a3791c73488/includes/class-admin.php#L2061) when visiting other sites on the same multisite (for example the friend requests notification remains).
- [It adds the ability to rerun the activation routines via the Site Health check](https://github.com/akirk/friends/pull/107/files#diff-db3d12ea3f712106d1a00b2a24269b6b6cd61de9c05d1bb5d4bd5e4d45765505R2432) in case the Friend roles were not created (see #96).

This has been hard to represent in unit tests but those covering the general behavior still work. I've done a lot of manual testing to ensure that this doesn't break existing flows.

Refs #96, #99.