### PR TITLE
Suggest friends via the local blogroll

### DIFF
--- a/friends-admin.css
+++ b/friends-admin.css
@@ -122,6 +122,9 @@ span#friends_enable_retention_days_line, span#friends_enable_retention_number_li
 	display: block;
 }
 
+ul.friend-suggestions {
+	margin: 0;
+}
 ul.friend-suggestions li {
 	display: inline-block;
 	margin-right: 1em;

--- a/friends-admin.css
+++ b/friends-admin.css
@@ -121,3 +121,8 @@ span#friends_enable_retention_days_line, span#friends_enable_retention_number_li
 #wpadminbar li#wp-admin-bar-friends {
 	display: block;
 }
+
+ul.friend-suggestions li {
+	display: inline-block;
+	margin-right: 1em;
+}

--- a/friends-admin.js
+++ b/friends-admin.js
@@ -235,7 +235,7 @@ jQuery( function( $ ) {
 				search: search
 			} ).done( function( response ) {
 				if ( response.data ) {
-					$( 'tr.friend-suggestions' ).show().find( 'td' ).html( response.data.content ).show();
+					$( 'tr.friend-suggestions' ).show().find( 'div' ).html( response.data.content ).show();
 				} else {
 					$( 'tr.friend-suggestions' ).hide();
 				}

--- a/friends-admin.js
+++ b/friends-admin.js
@@ -213,4 +213,35 @@ jQuery( function( $ ) {
 		}
 	} );
 
+	$( document ).on( 'click', 'ul.friend-suggestions li a', function() {
+		event.preventDefault();
+		$( '#friend_url' ).val( this.href );
+	} );
+
+	var searchTimeout = null;
+	$( document ).on( 'keydown', '#friend_url', function() {
+		var search = this.value;
+		if ( ! search ) {
+			return;
+		}
+
+		if ( searchTimeout ) {
+			clearTimeout( searchTimeout );
+		}
+
+		searchTimeout = setTimeout( function() {
+			wp.ajax.post( 'friends_search_links', {
+				_ajax_nonce: $( 'ul.friend-suggestions' ).data( 'nonce' ),
+				search: search
+			} ).done( function( response ) {
+				if ( response.data ) {
+					$( 'ul.friend-suggestions' ).html( response.data.content );
+					$( 'ul.friend-suggestions' ).closest( 'tr' ).show();
+				} else {
+					$( 'ul.friend-suggestions' ).closest( 'tr' ).hide();
+				}
+			} );
+		}, 50 );
+	} );
+
 } );

--- a/friends-admin.js
+++ b/friends-admin.js
@@ -231,14 +231,13 @@ jQuery( function( $ ) {
 
 		searchTimeout = setTimeout( function() {
 			wp.ajax.post( 'friends_search_links', {
-				_ajax_nonce: $( 'ul.friend-suggestions' ).data( 'nonce' ),
+				_ajax_nonce: $( 'tr.friend-suggestions' ).data( 'nonce' ),
 				search: search
 			} ).done( function( response ) {
 				if ( response.data ) {
-					$( 'ul.friend-suggestions' ).html( response.data.content );
-					$( 'ul.friend-suggestions' ).closest( 'tr' ).show();
+					$( 'tr.friend-suggestions' ).show().find( 'td' ).html( response.data.content ).show();
 				} else {
-					$( 'ul.friend-suggestions' ).closest( 'tr' ).hide();
+					$( 'tr.friend-suggestions' ).hide();
 				}
 			} );
 		}, 50 );

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -863,8 +863,7 @@ class Admin {
 			'admin/links',
 			null,
 			array(
-				'skip_ul' => true,
-				'links'   => $links,
+				'links' => $links,
 			)
 		);
 		$content = ob_get_contents();

--- a/templates/admin/add-friend.php
+++ b/templates/admin/add-friend.php
@@ -7,6 +7,7 @@
  */
 
 $quick_subscribe = _x( 'Quick Subscribe', 'button', 'friends' );
+
 $links = get_bookmarks(
 	array(
 		'orderby' => 'updated',
@@ -36,16 +37,26 @@ $links = get_bookmarks(
 					</p>
 				</td>
 			</tr>
-			<tr class="friend-suggestions" data-nonce="<?php echo esc_attr( wp_create_nonce( 'friends-links' ) ); ?>" style="display: <?php echo empty( $links ) ? 'none' : 'table-row'; ?>">
+			<tr class="friend-suggestions" data-nonce="<?php echo esc_attr( wp_create_nonce( 'friends-links' ) ); ?>">
 				<th scope="row"><?php esc_html_e( 'Suggestions', 'friends' ); ?></label></th>
 				<td>
-					<?php
-					if ( ! empty( $links ) ) {
-						Friends\Friends::template_loader()->get_template_part( 'admin/links', null, array( 'links' => $links ) );
-					}
-					?>
+					<div>
+						<?php
+						if ( empty( $links ) ) {
+							esc_html_e( 'No suggestions available. You can import an OPML.', 'friends' );
+						} else {
+							Friends\Friends::template_loader()->get_template_part( 'admin/links', null, array( 'links' => $links ) );
+						}
+						?>
+					</div>
 					<p class="description" id="friend-suggestions">
-
+						<?php
+						printf(
+							// translators: %s is a URL.
+							__( 'You can manage the available suggestions in the <a href="%s">Link Manager</a>.', 'friends' ),
+							esc_url( self_admin_url( 'link-manager.php' ) )
+						);
+						?>
 					</p>
 				</td>
 			</tr>

--- a/templates/admin/add-friend.php
+++ b/templates/admin/add-friend.php
@@ -7,6 +7,12 @@
  */
 
 $quick_subscribe = _x( 'Quick Subscribe', 'button', 'friends' );
+$links = get_bookmarks(
+	array(
+		'orderby' => 'updated',
+		'limit'   => 15,
+	)
+);
 
 ?><div class="wrap"><form method="post">
 	<?php wp_nonce_field( 'add-friend' ); ?>
@@ -30,23 +36,13 @@ $quick_subscribe = _x( 'Quick Subscribe', 'button', 'friends' );
 					</p>
 				</td>
 			</tr>
+			<tr class="friend-suggestions" data-nonce="<?php echo esc_attr( wp_create_nonce( 'friends-links' ) ); ?>" style="display: <?php echo empty( $links ) ? 'none' : 'table-row'; ?>">
 				<th scope="row"><?php esc_html_e( 'Suggestions', 'friends' ); ?></label></th>
 				<td>
 					<?php
-
-					Friends\Friends::template_loader()->get_template_part(
-						'admin/links',
-						null,
-						array(
-							'links' => get_bookmarks(
-								array(
-									'orderby' => 'updated',
-									'limit'   => 15,
-								)
-							),
-						)
-					);
-
+					if ( ! empty( $links ) ) {
+						Friends\Friends::template_loader()->get_template_part( 'admin/links', null, array( 'links' => $links ) );
+					}
 					?>
 					<p class="description" id="friend-suggestions">
 

--- a/templates/admin/add-friend.php
+++ b/templates/admin/add-friend.php
@@ -24,9 +24,32 @@ $quick_subscribe = _x( 'Quick Subscribe', 'button', 'friends' );
 			<tr>
 				<th scope="row"><label for="friend_url"><?php esc_html_e( 'Site', 'friends' ); ?></label></th>
 				<td>
-					<input type="text" autofocus id="friend_url" name="friend_url" value="<?php echo esc_attr( $args['friend_url'] ); ?>" required placeholder="<?php esc_attr_e( 'Enter URL', 'friends' ); ?>" class="regular-text" />
+					<input type="text" autofocus id="friend_url" name="friend_url" value="<?php echo esc_attr( $args['friend_url'] ); ?>" required placeholder="<?php esc_attr_e( 'Enter URL or search suggestions', 'friends' ); ?>" class="regular-text" />
 					<p class="description" id="friend_url-description">
 						<?php esc_html_e( "In the next step we'll give you a selection of available feeds.", 'friends' ); ?>
+					</p>
+				</td>
+			</tr>
+				<th scope="row"><?php esc_html_e( 'Suggestions', 'friends' ); ?></label></th>
+				<td>
+					<?php
+
+					Friends\Friends::template_loader()->get_template_part(
+						'admin/links',
+						null,
+						array(
+							'links' => get_bookmarks(
+								array(
+									'orderby' => 'updated',
+									'limit'   => 15,
+								)
+							),
+						)
+					);
+
+					?>
+					<p class="description" id="friend-suggestions">
+
 					</p>
 				</td>
 			</tr>
@@ -48,5 +71,4 @@ $quick_subscribe = _x( 'Quick Subscribe', 'button', 'friends' );
 			</tr>
 		</tbody>
 	</table>
-
 </form>

--- a/templates/admin/links.php
+++ b/templates/admin/links.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * This template contains the links results
+ *
+ * @version 1.0
+ * @package Friends
+ */
+
+if ( ! isset( $args['skip_ul'] ) ) {
+	?><ul class="friend-suggestions" data-nonce="<?php echo esc_attr( wp_create_nonce( 'friends-links' ) ); ?>">
+	<?php
+}
+
+if ( empty( $args['links'] ) ) {
+	?>
+	<li>Nothing found.</li>
+	<?php
+}
+foreach ( $args['links'] as $link ) {
+	?>
+	<li>
+	<a href="<?php echo esc_url( $link->link_url ); ?>"><?php echo esc_html( $link->link_name ); ?></a>
+	<?php
+
+	if ( ! empty( $link->link_description ) ) {
+		echo ' (' . esc_html( $link->link_description ) . ') ';
+	}
+	?>
+	</li>
+	<?php
+}
+if ( ! isset( $args['skip_ul'] ) ) {
+	?>
+</ul>
+	<?php
+}

--- a/templates/admin/links.php
+++ b/templates/admin/links.php
@@ -6,10 +6,9 @@
  * @package Friends
  */
 
-if ( ! isset( $args['skip_ul'] ) ) {
-	?><ul class="friend-suggestions" data-nonce="<?php echo esc_attr( wp_create_nonce( 'friends-links' ) ); ?>">
-	<?php
-}
+?>
+<ul class="friend-suggestions"">
+<?php
 
 if ( empty( $args['links'] ) ) {
 	?>
@@ -29,8 +28,6 @@ foreach ( $args['links'] as $link ) {
 	</li>
 	<?php
 }
-if ( ! isset( $args['skip_ul'] ) ) {
-	?>
+
+?>
 </ul>
-	<?php
-}


### PR DESCRIPTION
This adds a suggestion function to the add friends form like this:
![search-blogroll](https://user-images.githubusercontent.com/203408/165969044-b0dcbb2a-84e1-46f7-ad2f-42490db23815.gif)

Internally it uses the (deprecated, see this link how to re-activate) [Blogroll](https://codex.wordpress.org/Links_Manager) functionality of WordPress so that you can use [OPML Import](https://wordpress.org/plugins/opml-importer/) to import an OPML file into the suggestion list.

You can then also use the Link Manager to administer your list of suggestions.

<img width="872" alt="Screenshot 2022-04-29 at 17 00 32" src="https://user-images.githubusercontent.com/203408/165970919-3fc4eb2c-56a4-42fc-b4e2-9a89ae6b9e02.png">

Developing this further, it would make sense to build tools to import your friends' friends, or from sources like listed in #95. I've arrived at the above list by exporting a bunch of blogs from refined.blog via OPML and then importing them with the importer linked above.