### PR TITLE
Read blog comments inline

### DIFF
--- a/friends.js
+++ b/friends.js
@@ -184,19 +184,25 @@
 		if ( e.metaKey || e.altKey || e.shiftKey ) {
 			return;
 		}
+
 		var $this = $( this );
-		wp.ajax.send( 'friends-load-comments', {
-			data: {
-				_ajax_nonce: $this.data( 'nonce' ),
-				post_id: $this.data( 'id' ),
-			},
-			success: function( comments ) {
-				$this.closest( 'article' ).find( '.comments-content' ).html( comments );
-			},
-			error: function( message ) {
-				$this.closest( 'article' ).find( '.comments-content' ).html( message );
-			}
-		} );
+		var content = $this.closest( 'article' ).find( '.comments-content' );
+		if ( content.data( 'loaded' ) ) {
+			content.toggle();
+		} else {
+			wp.ajax.send( 'friends-load-comments', {
+				data: {
+					_ajax_nonce: $this.data( 'nonce' ),
+					post_id: $this.data( 'id' ),
+				},
+				success: function( comments ) {
+					content.html( comments ).data( 'loaded', true );
+				},
+				error: function( message ) {
+					content.html( message );
+				}
+			} );
+		}
 		return false;
 	} );
 

--- a/friends.js
+++ b/friends.js
@@ -192,7 +192,7 @@
 		} else {
 			wp.ajax.send( 'friends-load-comments', {
 				data: {
-					_ajax_nonce: $this.data( 'nonce' ),
+					_ajax_nonce: $this.data( 'cnonce' ),
 					post_id: $this.data( 'id' ),
 				},
 				success: function( comments ) {

--- a/friends.js
+++ b/friends.js
@@ -163,7 +163,7 @@
 
 	$document.on( 'click', 'a.collapse-post', function() {
 		var contents = $( this ).closest( 'article' ).find( 'div.card-body' );
-		if ( contents.is(':visible') ) {
+		if ( contents.is( ':visible' ) ) {
 			contents.hide();
 			$( this ).find( 'i' ).removeClass( 'dashicons-fullscreen-exit-alt' ).addClass( 'dashicons-fullscreen-alt' );
 		} else {
@@ -175,7 +175,28 @@
 	} );
 
 	$document.on( 'dblclick', 'a.collapse-post', function() {
-		$('a.collapse-post').trigger('click');
+		// Collapse-toggle all visible.
+		$( 'a.collapse-post' ).trigger( 'click' );
+		return false;
+	} );
+
+	$document.on( 'click', 'article a.comments', function( e ) {
+		if ( e.metaKey || e.altKey || e.shiftKey ) {
+			return;
+		}
+		var $this = $( this );
+		wp.ajax.send( 'friends-load-comments', {
+			data: {
+				_ajax_nonce: $this.data( 'nonce' ),
+				post_id: $this.data( 'id' ),
+			},
+			success: function( comments ) {
+				$this.closest( 'article' ).find( '.comments-content' ).html( comments );
+			},
+			error: function( message ) {
+				$this.closest( 'article' ).find( '.comments-content' ).html( message );
+			}
+		} );
 		return false;
 	} );
 

--- a/includes/class-frontend.php
+++ b/includes/class-frontend.php
@@ -80,6 +80,7 @@ class Frontend {
 		add_action( 'wp_ajax_friends-change-post-format', array( $this, 'ajax_change_post_format' ) );
 		add_action( 'wp_ajax_friends-load-next-page', array( $this, 'ajax_load_next_page' ) );
 		add_action( 'wp_ajax_friends-autocomplete', array( $this, 'ajax_autocomplete' ) );
+		add_action( 'wp_ajax_friends-load-comments', array( $this, 'ajax_load_comments' ) );
 		add_action( 'wp_untrash_post_status', array( $this, 'untrash_post_status' ), 10, 3 );
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 		add_action( 'wp_enqueue_scripts', array( $this, 'dequeue_scripts' ), 99999 );
@@ -280,15 +281,18 @@ class Frontend {
 
 		if ( ! current_user_can( Friends::REQUIRED_ROLE, $post_id ) ) {
 			wp_send_json_error();
+			exit;
 		}
 
 		$post_formats = get_post_format_strings();
 		if ( ! isset( $post_formats[ $post_format ] ) ) {
 			wp_send_json_error();
+			exit;
 		}
 
 		if ( ! set_post_format( $post_id, $post_format ) ) {
 			wp_send_json_error();
+			exit;
 		}
 
 		wp_send_json_success();
@@ -371,6 +375,7 @@ class Frontend {
 		$query_vars = stripslashes( $_POST['query_vars'] );
 		if ( sha1( wp_salt( 'nonce' ) . $query_vars ) !== $_POST['qv_sign'] ) {
 			wp_send_json_error();
+			exit;
 		}
 		$query_vars = unserialize( $query_vars );
 		$query_vars['paged'] = intval( $_POST['page'] ) + 1;
@@ -407,6 +412,55 @@ class Frontend {
 		}
 
 		wp_send_json_success( implode( PHP_EOL, $results ) );
+
+	}
+
+	/**
+	 * The Ajax function to load comments.
+	 */
+	function ajax_load_comments() {
+		if ( ! isset( $_POST['post_id'] ) || ! intval( $_POST['post_id'] ) ) {
+			wp_send_json_error();
+			exit;
+		}
+
+		$post_id = intval( $_POST['post_id'] );
+		check_ajax_referer( "comments-$post_id" );
+
+		$comments_url = trailingslashit( get_permalink( $post_id ) ) . 'feed/';
+		$comments = $this->friends->feed->preview( 'simplepie', $comments_url );
+		if ( is_wp_error( $comments ) || ! is_array( $comments ) ) {
+			wp_send_json_error( '<small>' . __( 'Unforunately, comments were not available via RSS.', 'friends' ) . '</small>' );
+			exit;
+		}
+
+		$template_loader = Friends::template_loader();
+		ob_start();
+		?>
+		<h5><?php esc_html_e( 'Comments' ); /* phpcs:ignore WordPress.WP.I18n.MissingArgDomain */ ?></h5>
+		<?php
+		foreach ( $comments as $comment ) {
+			$template_loader->get_template_part(
+				'frontend/parts/comment',
+				null,
+				array(
+					'author'       => $comment->author,
+					'date'         => $comment->date,
+					'permalink'    => $comment->permalink,
+					'post_content' => $comment->post_content,
+				)
+			);
+
+		}
+		?>
+		<p>
+		<a href="<?php echo esc_url( get_comments_link( $post_id ) ); ?>"><?php esc_html_e( 'Leave a Comment' );  /* phpcs:ignore WordPress.WP.I18n.MissingArgDomain */ ?></a>
+		</p>
+		<?php
+		$content = ob_get_contents();
+		ob_end_clean();
+
+		wp_send_json_success( $content );// phpcs:ignore WordPress.WP.I18n.MissingArgDomain
 
 	}
 
@@ -490,6 +544,7 @@ class Frontend {
 					'data-nonce'  => array(),
 					'data-token'  => array(),
 					'data-friend' => array(),
+					'data-id'     => array(),
 				),
 				'span' => array( 'class' => array() ),
 			)
@@ -528,7 +583,7 @@ class Frontend {
 
 		$link = '<a href="' . esc_url( $url ) . '"';
 		foreach ( $html_attributes as $name => $value ) {
-			if ( ! in_array( $name, array( 'title', 'target', 'rel', 'class', 'style', 'data-nonce', 'data-token', 'data-friend' ) ) ) {
+			if ( ! in_array( $name, array( 'title', 'target', 'rel', 'class', 'style', 'data-nonce', 'data-token', 'data-friend', 'data-id' ) ) ) {
 				continue;
 			}
 			$link .= ' ' . $name . '="' . esc_attr( $value ) . '"';

--- a/templates/frontend/parts/comment.php
+++ b/templates/frontend/parts/comment.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * This template contains a comment for an article on /friends/.
+ *
+ * @version 1.0
+ * @package Friends
+ */
+
+?>
+<div class="comment">
+	<div class="comment-meta mb-1" style="font-size: 90%">
+	<strong><?php echo esc_html( $args['author'] ); ?></strong>
+	<a href="<?php echo esc_attr( $args['permalink'] ); ?>" title="<?php echo esc_attr( $args['date'] ); ?>'">
+	<?php
+	echo esc_html(
+		/* translators: %s is a time span */
+		sprintf( __( '%s ago' ), human_time_diff( strtotime( $args['date'] ) ) ) // phpcs:ignore WordPress.WP.I18n.MissingArgDomain
+	);
+	?>
+	</a>
+	</div>
+	<blockquote class="comment-content">
+		<?php echo wp_kses_post( $args['post_content'] ); ?>
+	</blockquote>
+</div>

--- a/templates/frontend/parts/comments-content.php
+++ b/templates/frontend/parts/comments-content.php
@@ -1,0 +1,9 @@
+<?php
+/**
+ * This template contains the comments content in the footer for an article on /friends/.
+ *
+ * @version 1.0
+ * @package Friends
+ */
+
+?><footer class="comments-content card-footer"></footer>

--- a/templates/frontend/parts/comments.php
+++ b/templates/frontend/parts/comments.php
@@ -13,7 +13,7 @@ $args['friends']->frontend->link(
 		'class'          => 'comments btn ml-1',
 		'dashicon_front' => 'admin-comments',
 		'data-id'        => get_the_ID(),
-		'data-nonce'     => wp_create_nonce( 'comments-' . get_the_ID() ),
+		'data-cnonce'    => wp_create_nonce( 'comments-' . get_the_ID() ),
 	)
 );
 

--- a/templates/frontend/parts/comments.php
+++ b/templates/frontend/parts/comments.php
@@ -12,5 +12,8 @@ $args['friends']->frontend->link(
 	array(
 		'class'          => 'comments btn ml-1',
 		'dashicon_front' => 'admin-comments',
+		'data-id'        => get_the_ID(),
+		'data-nonce'     => wp_create_nonce( 'comments-' . get_the_ID() ),
 	)
 );
+

--- a/templates/frontend/parts/footer.php
+++ b/templates/frontend/parts/footer.php
@@ -16,3 +16,6 @@
 		?>
 	<?php endif; ?>
 </footer>
+<?php
+
+Friends\Friends::template_loader()->get_template_part( 'frontend/parts/comments-content', null, $args );

--- a/templates/frontend/parts/header.php
+++ b/templates/frontend/parts/header.php
@@ -40,8 +40,8 @@ $override_author_name = apply_filters( 'friends_override_author_name', '', $auth
 		<?php
 		echo wp_kses(
 			sprintf(
-			// translators: %1$s is a date or relative time, %2$s is a site name or domain.
-				__( '%1$s on %2$s', 'friends' ),
+				// translators: %1$s is a date or relative time, %2$s is a site name or domain.
+				_x( '%1$s on %2$s', 'at-date-on-post', 'friends' ),
 				'<a href="' . esc_attr( $friend_user->get_local_friends_page_url() . get_the_ID() . '/' ) . '" title="' . get_the_time( 'r' ) . '">' .
 				/* translators: %s is a time span */ sprintf( __( '%s ago' ), human_time_diff( get_post_time( 'U', true ) ) ) . // phpcs:ignore WordPress.WP.I18n.MissingArgDomain
 				'</a>',


### PR DESCRIPTION
With this you can read comments for supported sites (i.e. WordPress, where the comments feed is available by appending `feed/` to the article URL) right inside the friends UI. Later, we'll want to allow subscribing to that feed to enable #62.

### Screenshot
![read-comments-inline](https://user-images.githubusercontent.com/203408/167644492-67e49555-2cee-4368-9602-18cb1be8e1fc.gif)

