### PR TITLE
Add reaction links to header

### DIFF
--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -50,7 +50,7 @@ class Admin {
 		add_filter( 'the_title', array( $this, 'override_post_format_title' ), 10, 2 );
 		add_filter( 'get_edit_user_link', array( $this, 'admin_edit_user_link' ), 10, 2 );
 		add_action( 'admin_bar_menu', array( $this, 'admin_bar_friends_menu' ), 39 );
-		add_action( 'admin_bar_menu', array( $this, 'admin_bar_friends_new_content' ), 71 );
+		add_action( 'admin_bar_menu', array( $this, 'admin_bar_new_content' ), 71 );
 		add_action( 'wp_head', array( $this, 'admin_bar_mobile' ) );
 		add_action( 'current_screen', array( $this, 'register_help' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_scripts' ), 39 );
@@ -2229,11 +2229,11 @@ class Admin {
 	}
 
 	/**
-	 * Add a Friends menu to the New Content admin section
+	 * Add Friend entries to the New Content admin section
 	 *
 	 * @param  \WP_Admin_Bar $wp_menu The admin bar to modify.
 	 */
-	public function admin_bar_friends_new_content( \WP_Admin_Bar $wp_menu ) {
+	public function admin_bar_new_content( \WP_Admin_Bar $wp_menu ) {
 		if ( current_user_can( Friends::REQUIRED_ROLE ) ) {
 			$wp_menu->add_menu(
 				array(

--- a/includes/class-friends.php
+++ b/includes/class-friends.php
@@ -760,6 +760,10 @@ class Friends {
 			return $tax_query;
 		}
 
+		if ( ! empty( $tax_query ) ) {
+			$tax_query['relation'] = 'AND';
+		}
+
 		if ( 'standard' === $filter_by_post_format ) {
 			$formats = array();
 
@@ -770,28 +774,22 @@ class Friends {
 			}
 
 			if ( ! empty( $formats ) ) {
-				return array(
-					'relation' => 'AND',
-					array(
-						'operator' => 'NOT IN',
-						'taxonomy' => 'post_format',
-						'field'    => 'slug',
-						'terms'    => $formats,
-					),
+				$tax_query[] = array(
+					'operator' => 'NOT IN',
+					'taxonomy' => 'post_format',
+					'field'    => 'slug',
+					'terms'    => $formats,
 				);
 			}
-		}
-
-		return array_merge(
-			$tax_query,
-			array(
-				array(
+		} else {
+				$tax_query[] = array(
 					'taxonomy' => 'post_format',
 					'field'    => 'slug',
 					'terms'    => array( 'post-format-' . $filter_by_post_format ),
-				),
-			)
-		);
+				);
+		}
+
+		return $tax_query;
 	}
 
 	/**

--- a/includes/class-frontend.php
+++ b/includes/class-frontend.php
@@ -99,6 +99,16 @@ class Frontend {
 			'top'
 		);
 		add_rewrite_rule(
+			'friends/reaction/([0-9a-f]+)/?$',
+			'index.php?pagename=friends/reaction/$matches[1]',
+			'top'
+		);
+		add_rewrite_rule(
+			'friends/type/(' . implode( '|', get_post_format_slugs() ) . ')/?$',
+			'index.php?pagename=friends/type/$matches[1]',
+			'top'
+		);
+		add_rewrite_rule(
 			'friends/(.*)/(\d+)/?$',
 			'index.php?pagename=friends/$matches[1]&page=$matches[2]',
 			'top'
@@ -778,17 +788,19 @@ class Frontend {
 			if ( 'type' === $pagename_parts[1] && isset( $pagename_parts[2] ) ) {
 				$potential_post_format = $pagename_parts[2];
 			} elseif ( 'reaction' === $pagename_parts[1] && isset( $pagename_parts[2] ) ) {
-				$tax_query = array(
-					'relation' => 'AND',
-					array(
-						'taxonomy' => 'friend-reaction-' . get_current_user_id(),
-						'field'    => 'slug',
-						'terms'    => array( $pagename_parts[2] ),
-					),
-				);
-				$this->reaction = Reactions::validate_emoji( $pagename_parts[2] );
-				if ( ! $page_id && isset( $pagename_parts[2] ) && 'reaction' === $pagename_parts[2] && isset( $pagename_parts[3] ) ) {
-					$potential_post_format = $pagename_parts[3];
+				$this->reaction = Reactions::validate_emoji( urldecode( $pagename_parts[2] ) );
+				if ( $this->reaction ) {
+					$tax_query = array(
+						'relation' => 'AND',
+						array(
+							'taxonomy' => 'friend-reaction-' . get_current_user_id(),
+							'field'    => 'slug',
+							'terms'    => array( $pagename_parts[2] ),
+						),
+					);
+					if ( ! $page_id && isset( $pagename_parts[2] ) && 'reaction' === $pagename_parts[2] && isset( $pagename_parts[3] ) ) {
+						$potential_post_format = $pagename_parts[3];
+					}
 				}
 			} else {
 				$author = get_user_by( 'login', $pagename_parts[1] );

--- a/includes/class-user.php
+++ b/includes/class-user.php
@@ -775,7 +775,7 @@ class User extends \WP_User {
 	 * @return     string      The local friends page url.
 	 */
 	function get_local_friends_page_reaction_url( $slug ) {
-		return home_url( '/friends/' . $this->user_login . '/type/' . $slug . '/' );
+		return home_url( '/friends/' . $this->user_login . '/reaction' . $slug . '/' );
 	}
 
 	/**

--- a/includes/class-user.php
+++ b/includes/class-user.php
@@ -768,6 +768,17 @@ class User extends \WP_User {
 	}
 
 	/**
+	 * Gets the local friends page url for a reaction.
+	 *
+	 * @param      string $slug  The reaction slug.
+	 *
+	 * @return     string      The local friends page url.
+	 */
+	function get_local_friends_page_reaction_url( $slug ) {
+		return home_url( '/friends/' . $this->user_login . '/type/' . $slug . '/' );
+	}
+
+	/**
 	 * Gets the friend auth to be used as a GET parameter.
 	 *
 	 * @param      integer $validity  The validity in seconds.

--- a/templates/frontend/author-header.php
+++ b/templates/frontend/author-header.php
@@ -57,6 +57,10 @@ $args['friends']->frontend->link(
 	<a class="chip" href="<?php echo esc_attr( $args['friend_user']->get_local_friends_page_post_format_url( $post_format ) ); ?>"><?php echo esc_html( $args['friends']->get_post_format_plural_string( $post_format, $count ) ); ?></a>
 <?php endforeach; ?>
 
+<?php foreach ( Friends\Reactions::get_available_emojis() as $slug => $reaction ) : ?>
+	<a class="chip" href="<?php echo esc_attr( $args['friend_user']->get_local_friends_page_reaction_url( $slug ) ); ?>"><?php echo esc_html( $reaction->char ); ?></a>
+<?php endforeach; ?>
+
 <?php if ( $edit_user_link ) : ?>
 <a class="chip" href="<?php echo esc_attr( $edit_user_link ); ?>">
 	<?php echo esc_html( sprintf( /* translators: %s is the number of feeds */_n( '%s feed', '%s feeds', $active_feeds, 'friends' ), $active_feeds ) ); ?>

--- a/templates/frontend/main-feed-header.php
+++ b/templates/frontend/main-feed-header.php
@@ -72,7 +72,7 @@ if ( $args['friends']->frontend->reaction ) {
 <?php endforeach; ?>
 
 <?php foreach ( Friends\Reactions::get_available_emojis() as $slug => $reaction ) : ?>
-	<a class="chip" href="<?php echo esc_url( home_url( '/friends/reaction/' . $slug . '/' ) ); ?>"><?php echo esc_html( $reaction->char ); ?></a>
+	<a class="chip" href="<?php echo esc_url( home_url( '/friends/reaction' . $slug . '/' ) ); ?>"><?php echo esc_html( $reaction->char ); ?></a>
 <?php endforeach; ?>
 
 <a class="chip" href="<?php echo esc_attr( self_admin_url( 'admin.php?page=add-friend' ) ); ?>"><?php esc_html_e( 'Add New Friend', 'friends' ); ?></a>

--- a/templates/frontend/main-feed-header.php
+++ b/templates/frontend/main-feed-header.php
@@ -71,6 +71,10 @@ if ( $args['friends']->frontend->reaction ) {
 	<a class="chip" href="<?php echo esc_url( home_url( '/friends/type/' . $post_format . '/' ) ); ?>"><?php echo esc_html( $args['friends']->get_post_format_plural_string( $post_format, $count ) ); ?></a>
 <?php endforeach; ?>
 
+<?php foreach ( Friends\Reactions::get_available_emojis() as $slug => $reaction ) : ?>
+	<a class="chip" href="<?php echo esc_url( home_url( '/friends/reaction/' . $slug . '/' ) ); ?>"><?php echo esc_html( $reaction->char ); ?></a>
+<?php endforeach; ?>
+
 <a class="chip" href="<?php echo esc_attr( self_admin_url( 'admin.php?page=add-friend' ) ); ?>"><?php esc_html_e( 'Add New Friend', 'friends' ); ?></a>
 <a class="chip" href="<?php echo esc_attr( self_admin_url( 'admin.php?page=friends-settings' ) ); ?>"><?php /* phpcs:ignore WordPress.WP.I18n.MissingArgDomain */ esc_html_e( 'Settings' ); ?></a>
 <?php do_action( 'friends_main_feed_header' ); ?>

--- a/templates/frontend/no-posts.php
+++ b/templates/frontend/no-posts.php
@@ -17,5 +17,5 @@ if ( isset( $_GET['p'] ) && $_GET['p'] > 1 ) {
 		)
 	);
 } else {
-	esc_html_e( "Your friends haven't posted anything yet!", 'friends' );
+	esc_html_e( 'Unfortunately, we could not find a post.', 'friends' );
 }

--- a/templates/frontend/no-posts.php
+++ b/templates/frontend/no-posts.php
@@ -8,14 +8,6 @@
 
 if ( isset( $_GET['p'] ) && $_GET['p'] > 1 ) {
 	esc_html_e( 'No further posts of your friends could were found.', 'friends' );
-} elseif ( get_the_author() ) {
-	echo esc_html(
-		sprintf(
-		// translators: %s is the name of an author.
-			__( "%s hasn't posted anything yet!", 'friends' ),
-			get_the_author()
-		)
-	);
 } else {
 	esc_html_e( 'Unfortunately, we could not find a post.', 'friends' );
 }


### PR DESCRIPTION
In order to re-discover posts that you've reacted to, there are now emoji filters in the header, both for the main feed and for authors.

## Screenshots
![main-filter-reactions](https://user-images.githubusercontent.com/203408/168784163-8bb3552d-1603-4607-b697-d6fc7964f724.gif)


![filter-reactions](https://user-images.githubusercontent.com/203408/168784131-59b33189-5845-4107-8486-9fe407b4fbcb.gif)

