### PR TITLE
Update composer dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,12 +31,6 @@
 		],
 		"test": [
 			"@php ./vendor/phpunit/phpunit/phpunit --no-coverage"
-		],
-		"install-codestandards": [
-		    "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run"
-        ],
-        "post-install-cmd": [
-            "@install-codestandards"
 		]
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,8 @@
 		"dealerdirect/phpcodesniffer-composer-installer": "*",
 		"object-calisthenics/phpcs-calisthenics-rules": "*",
 		"phpcompatibility/php-compatibility": "*",
-		"wp-coding-standards/wpcs": "*"
+		"wp-coding-standards/wpcs": "*",
+		"yoast/phpunit-polyfills": "*"
 	},
 	"config": {
 		"allow-plugins": {

--- a/composer.json
+++ b/composer.json
@@ -1,13 +1,10 @@
 {
 	"name": "akirk/friends",
 	"require-dev": {
-		"squizlabs/php_codesniffer": "*",
-		"wp-phpunit/wp-phpunit": "*",
-		"yoast/phpunit-polyfills": "^1.0",
-		"phpunit/phpunit": "^5.7.21 || ^6.5 || ^7.5",
+		"dealerdirect/phpcodesniffer-composer-installer": "*",
+		"object-calisthenics/phpcs-calisthenics-rules": "*",
 		"phpcompatibility/php-compatibility": "*",
-		"wp-coding-standards/wpcs": "*",
-		"dealerdirect/phpcodesniffer-composer-installer": "^0.7.0"
+		"wp-coding-standards/wpcs": "*"
 	},
 	"config": {
 		"allow-plugins": {
@@ -33,6 +30,12 @@
 		],
 		"test": [
 			"@php ./vendor/phpunit/phpunit/phpunit --no-coverage"
+		],
+		"install-codestandards": [
+		    "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run"
+        ],
+        "post-install-cmd": [
+            "@install-codestandards"
 		]
 	}
 }


### PR DESCRIPTION
Before this the checks started to fail with this error:
```
dealerdirect/phpcodesniffer-composer-installer contains a Composer plugin which is blocked by your allow-plugins config. You may add it to the list if you consider it safe. You can run "composer config --no-plugins allow-plugins.dealerdirect/phpcodesniffer-composer-installer [true|false]" to enable it (true) or disable it explicitly and suppress this exception (false) See https://getcomposer.org/allow-plugins
```