### PR TITLE
Retrieve avatar via ActivityPub

### DIFF
--- a/friends-admin.js
+++ b/friends-admin.js
@@ -301,4 +301,26 @@ jQuery( function ( $ ) {
 			}
 		}
 	);
+
+	$( document ).on( 'click', 'a.set-avatar', function () {
+		const url = $( this ).find( 'img' ).prop( 'src' );
+		if ( ! url ) {
+			return;
+		}
+		$.post(
+			friends.ajax_url,
+			{
+				user: $( this ).data( 'id' ),
+				avatar: url,
+				_ajax_nonce: $( this ).data( 'nonce' ),
+				action: 'friends_set_avatar',
+			},
+			function ( response ) {
+				if ( response.success ) {
+					window.location.reload();
+				}
+			}
+		);
+		return false;
+	} );
 } );

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -1077,7 +1077,7 @@ class Admin {
 		$friend = new User( $user_id );
 		$url = $friend->update_user_icon_url( $_POST['avatar'] );
 
-		if ( is_wp_error( $url ) ) {
+		if ( ! $url || is_wp_error( $url ) ) {
 			wp_send_json_error( $url );
 			exit;
 		}

--- a/includes/class-feed.php
+++ b/includes/class-feed.php
@@ -1095,6 +1095,20 @@ class Feed {
 	}
 
 	/**
+	 * Gets the actual feed parser parser.
+	 *
+	 * @param      string $parser  The parser slug.
+	 *
+	 * @return     Feed_Parser  The actual parser.
+	 */
+	public function get_feed_parser( $parser ) {
+		if ( ! isset( $this->parsers[ $parser ] ) ) {
+			return null;
+		}
+		return $this->parsers[ $parser ];
+	}
+
+	/**
 	 * Gets the registered parser.
 	 *
 	 * @param      string $parser  The parser slug.

--- a/includes/class-user.php
+++ b/includes/class-user.php
@@ -617,22 +617,8 @@ class User extends \WP_User {
 		}
 
 		if ( $user_icon_url && Friends::check_url( $user_icon_url ) ) {
-			if ( $this->has_cap( 'friend' ) || $this->has_cap( 'pending_friend_request' ) || $this->has_cap( 'friend_request' ) || $this->has_cap( 'subscription' ) ) {
-				$icon_host_parts = array_reverse( explode( '.', parse_url( strtolower( $user_icon_url ), PHP_URL_HOST ) ) );
-				if ( 'gravatar.com' === $icon_host_parts[1] . '.' . $icon_host_parts[0] ) {
-					update_user_option( $this->ID, 'friends_user_icon_url', $user_icon_url );
-					return $user_icon_url;
-				}
-
-				$user_host_parts = array_reverse( explode( '.', parse_url( strtolower( $this->user_url ), PHP_URL_HOST ) ) );
-				if ( $user_host_parts[1] . '.' . $user_host_parts[0] === $icon_host_parts[1] . '.' . $icon_host_parts[0] ) {
-					update_user_option( $this->ID, 'friends_user_icon_url', $user_icon_url );
-					return $user_icon_url;
-				}
-			} elseif ( $this->has_cap( 'subscription' ) ) {
-				update_user_option( $this->ID, 'friends_user_icon_url', $user_icon_url );
-				return $user_icon_url;
-			}
+			update_user_option( $this->ID, 'friends_user_icon_url', $user_icon_url );
+			return $user_icon_url;
 		}
 
 		return false;

--- a/templates/admin/edit-friend.php
+++ b/templates/admin/edit-friend.php
@@ -16,6 +16,7 @@
 				<?php echo get_avatar( $args['friend']->ID ); ?>
 			</td>
 			</tr>
+			<?php do_action( 'friends_edit_friend_after_avatar', $args['friend'] ); ?>
 			<tr>
 				<th><label for="friends_display_name"><?php esc_html_e( 'Display Name', 'friends' ); ?></label></th>
 				<td><input type="text" name="friends_display_name" id="friends_display_name" value="<?php echo esc_attr( $args['friend']->display_name ); ?>" class="regular-text" /> <p class="description"><?php esc_html_e( 'Careful, your friend can discover this.', 'friends' ); ?></p></td>

--- a/tests/test-activitypub.php
+++ b/tests/test-activitypub.php
@@ -263,6 +263,27 @@ class ActivityPubTest extends Friends_TestCase_Cache_HTTP {
 
 	/**
 	 * Test whether the example domains are skipped.
+	 */
+	public function test_feed_details() {
+		$friends = Friends::get_instance();
+		$friend = new User( $this->friend_id );
+		$feeds = $friend->get_feeds();
+		$feed = array_pop( $feeds );
+		$parser = $friends->feed->get_feed_parser( $feed->get_parser() );
+
+		$details = $parser->update_feed_details(
+			array(
+				'url' => $feed->get_url(),
+			)
+		);
+
+		$this->assertEquals( 'https://mastodon.local/users/akirk', $details['url'] );
+		$this->assertEquals( 'Alex Kirk', $details['title'] );
+		$this->assertEquals( 'https://mastodon.local/users/akirk.png', $details['avatar'] );
+	}
+
+	/**
+	 * Test whether the example domains are skipped.
 	 *
 	 * @param string $actor The actor.
 	 * @param string $domain The domain.
@@ -322,6 +343,10 @@ class ActivityPubTest extends Friends_TestCase_Cache_HTTP {
 		self::$users[ $this->actor ] = array(
 			'url'  => $this->actor,
 			'name' => $this->friend_name,
+			'icon' => array(
+				'type' => 'Image',
+				'url'  => $this->actor . '.png',
+			),
 		);
 		self::$users['https://mastodon.local/@akirk'] = self::$users[ $this->actor ];
 


### PR DESCRIPTION
Fixes #139.

This will use an avatar from ActivityPub when available:
![avatar-new-user](https://user-images.githubusercontent.com/203408/210030662-f9f14d25-c6ab-48c5-90d6-305bda397729.gif)

You can also update an avatar from ActivityPub (as it will not (yet?) update the avatar automatically when a user changes it):
![update-avatar](https://user-images.githubusercontent.com/203408/210030684-64b78f77-08a8-4d73-b34d-3ecaa2321a78.gif)
