### PR TITLE
Unhook the parser included with ActivityPub 0.14

### DIFF
--- a/feed-parsers/class-feed-parser-activitypub.php
+++ b/feed-parsers/class-feed-parser-activitypub.php
@@ -538,7 +538,7 @@ class Feed_Parser_ActivityPub extends Feed_Parser {
 
 	public function replace_with_links( $result ) {
 		$users = $this->get_possible_mentions();
-		if ( isset( $users[ $result[0] ] ) ) {
+		if ( class_exists( '\\Activitypub\\Mention' ) && isset( $users[ $result[0] ] ) ) {
 			return \Activitypub\Mention::replace_with_links( array( $users[ $result[0] ] ) );
 		}
 

--- a/friends.php
+++ b/friends.php
@@ -120,14 +120,21 @@ add_action(
 add_action(
 	'friends_load_parsers',
 	function( \Friends\Feed $friends_feed ) {
-		if ( class_exists( 'Friends_Feed_Parser_ActivityPub' ) ) {
-			// Was included in ActivityPub 0.14.
-			return;
-		}
-
 		if ( ! class_exists( '\Activitypub\Activitypub' ) ) {
 			// ActivityPub plugin not active.
 			return;
+		}
+
+		global $wp_filter;
+		if ( isset( $wp_filter['friends_load_parsers']->callbacks[10] ) && class_exists( '\\ReflectionFunction' ) ) {
+			// Unhook the parser from ActivityPub 0.14.
+			foreach ( $wp_filter['friends_load_parsers']->callbacks[10] as $key => $hook ) {
+				$r = new \ReflectionFunction( $hook['function'] );
+				if ( \str_ends_with( $r->getFileName(), 'activitypub.php' ) ) {
+					remove_filter( 'friends_load_parsers', $hook['function'], 10 );
+					break;
+				}
+			}
 		}
 
 		require_once __DIR__ . '/feed-parsers/class-feed-parser-activitypub.php';


### PR DESCRIPTION
Work around this fatal in PHP8 that the incompatible declaration causes, see https://github.com/akirk/friends/pull/142#issuecomment-1367720928.

```
PHP Fatal error:  Declaration of Activitypub\\Friends_Feed_Parser_ActivityPub::fetch_feed($url)
must be compatible with Friends\\Feed_Parser::fetch_feed($url, ?Friends\\User_Feed $user_feed = null)
in wp-content/plugins/activitypub/integration/class-friends-feed-parser-activitypub.php on line 137
```

cc @gbraad