### PR TITLE
Changed post title

### DIFF
--- a/includes/class-friends.php
+++ b/includes/class-friends.php
@@ -308,7 +308,7 @@ class Friends {
 		$content .= '</p>' . PHP_EOL . '<!-- /wp:friends/follow-me -->' . PHP_EOL;
 
 		$post_data = array(
-			'post_title'   => __( 'Welcome to my Friends Page', 'friends' ),
+			'post_title'   => __( 'Friends', 'friends' ),
 			'post_content' => $content,
 			'post_type'    => 'page',
 			'post_name'    => 'friends',


### PR DESCRIPTION
I feel that if the URL slug is going to be `friends` then the title should also be `Friends`, it isn't keeping in with the typical styling of other WordPress plugins, e.g. WooCommerce has a `Cart` or `My Account` instead of a `Welcome to Your Cart Page` or `Welcome to your My Account Page`. When scrolling through my sizeable list of Pages, I had to `CTRL+F` for `Friends` as it wasn't listed as what I expected it to be.

This also brings it more in line with concepts like a "Now page". More of a standard if you will.