### PR TITLE
Add outbox support

### DIFF
--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -1579,15 +1579,18 @@ class Admin {
 				}
 
 				$avatar = null;
+				$description = null;
 				foreach ( $feeds as $feed_details ) {
-					if ( ! empty( $feed_details['avatar'] ) ) {
+					if ( ! $avatar && ! empty( $feed_details['avatar'] ) ) {
 						$avatar = $feed_details['avatar'];
-						break;
+					}
+					if ( ! $description && ! empty( $feed_details['description'] ) ) {
+						$description = $feed_details['description'];
 					}
 				}
 
 				if ( ! $friend_user || is_wp_error( $friend_user ) ) {
-					$friend_user = User::create( $friend_user_login, 'subscription', $friend_url, $friend_display_name, $avatar );
+					$friend_user = User::create( $friend_user_login, 'subscription', $friend_url, $friend_display_name, $avatar, $description );
 				}
 
 				return $this->process_admin_add_friend_response( $friend_user, $vars );
@@ -1644,15 +1647,18 @@ class Admin {
 			}
 
 			$avatar = null;
+			$description = null;
 			foreach ( $feeds as $feed_details ) {
-				if ( ! empty( $feed_details['avatar'] ) ) {
+				if ( ! $avatar && ! empty( $feed_details['avatar'] ) ) {
 					$avatar = $feed_details['avatar'];
-					break;
+				}
+				if ( ! $description && ! empty( $feed_details['description'] ) ) {
+					$description = $feed_details['description'];
 				}
 			}
 
 			if ( ! $friend_user || is_wp_error( $friend_user ) ) {
-				$friend_user = User::create( $friend_user_login, 'subscription', $friend_url, $friend_display_name, $avatar );
+				$friend_user = User::create( $friend_user_login, 'subscription', $friend_url, $friend_display_name, $avatar, $description );
 			}
 
 			return $this->process_admin_add_friend_response( $friend_user, $vars );
@@ -1774,7 +1780,7 @@ class Admin {
 				foreach ( $items as $item ) {
 					$title = $item->title;
 					if ( 'status' === $item->post_format ) {
-						$title = $item->content;
+						$title = strip_tags( $item->content );
 					}
 					?>
 					<li><a href="<?php echo esc_url( $item->permalink ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( $item->date ); ?></a> (author: <?php echo esc_html( $item->author ); ?>, type: <?php echo esc_html( $item->post_format ); ?>):

--- a/includes/class-user.php
+++ b/includes/class-user.php
@@ -43,10 +43,11 @@ class User extends \WP_User {
 	 *                                   to create the user.
 	 * @param      string $display_name  The user's display name.
 	 * @param      string $icon_url      The user_icon_url URL.
+	 * @param      string $description   A description for the user.
 	 *
 	 * @return     User|\WP_Error  The created user or an error.
 	 */
-	public static function create( $user_login, $role, $url, $display_name = null, $icon_url = null ) {
+	public static function create( $user_login, $role, $url, $display_name = null, $icon_url = null, $description = null ) {
 		$role_rank = array_flip(
 			array(
 				'subscription',
@@ -88,6 +89,7 @@ class User extends \WP_User {
 			'display_name' => $display_name,
 			'first_name'   => $display_name,
 			'nickname'     => $display_name,
+			'description'  => $description,
 			'user_url'     => $url,
 			'user_pass'    => wp_generate_password( 256 ),
 			'role'         => $role,
@@ -97,6 +99,8 @@ class User extends \WP_User {
 
 		$friend_user = new User( $friend_id );
 		$friend_user->update_user_icon_url( $icon_url );
+
+		do_action( 'friends_after_create_friend_user', $friend_user );
 		return $friend_user;
 	}
 


### PR DESCRIPTION
Fixes #136.

This allows ActivityPub feeds to be previewed and pulls in the last couple of messages.

<img width="915" alt="Screenshot 2023-01-04 at 07 51 15" src="https://user-images.githubusercontent.com/203408/210499691-a776188f-dd4f-405f-9d1f-b934e5c8827f.png">

This also adds support for populating the user description through the ActivityPub summary.