### PR TITLE
Add Reblogging and Announce support for ActivityPub

### DIFF
--- a/feed-parsers/class-feed-parser-activitypub.php
+++ b/feed-parsers/class-feed-parser-activitypub.php
@@ -1129,6 +1129,7 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 		update_post_meta( $post_id, 'reblog', $old_guid );
 		update_post_meta( $old_post_id, 'reblogged', $post_id );
 
+		// Todo: Only announce ActvityPub posts.
 		$this->announce( $old_guid );
 
 		wp_send_json_success(

--- a/feed-parsers/class-feed-parser-activitypub.php
+++ b/feed-parsers/class-feed-parser-activitypub.php
@@ -1110,7 +1110,7 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 		$reblog .= sprintf(
 			// translators: %s is a link.
 			__( 'Reblog via %s', 'friends' ),
-			'<a href="' . esc_url( $post->guid ) . '">' . esc_html( $author ) . '</a>',
+			'<a href="' . esc_url( $post->guid ) . '">' . esc_html( $author ) . '</a>'
 		);
 
 		$reblog .= PHP_EOL . '</p>' . PHP_EOL . '<!-- /wp:paragraph -->' . PHP_EOL;

--- a/friends.js
+++ b/friends.js
@@ -351,6 +351,25 @@
 		} );
 	} );
 
+	/* ActivityPub */
+	$( function () {
+		$document.on( 'click', 'a.friends-activitypub-reblog', function () {
+			const $this = $( this );
+			wp.ajax.send( 'friends-activitypub-reblog', {
+				data: {
+					_ajax_nonce: $this.data( 'nonce' ),
+					post_id: $this.data( 'id' ),
+				},
+				success() {
+					$this
+						.find( 'i.friends-reblog-status' )
+						.addClass( 'dashicons dashicons-saved' );
+				},
+			} );
+			return false;
+		} );
+	} );
+
 	$document.on( 'click', 'a.send-new-message', function () {
 		$( '#friends-send-new-message' )
 			.toggle()

--- a/friends.js
+++ b/friends.js
@@ -353,9 +353,9 @@
 
 	/* ActivityPub */
 	$( function () {
-		$document.on( 'click', 'a.friends-activitypub-reblog', function () {
+		$document.on( 'click', 'a.friends-reblog', function () {
 			const $this = $( this );
-			wp.ajax.send( 'friends-activitypub-reblog', {
+			wp.ajax.send( 'friends-reblog', {
 				data: {
 					_ajax_nonce: $this.data( 'nonce' ),
 					post_id: $this.data( 'id' ),

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -895,6 +895,7 @@ class Admin {
 		);
 		wp_die();
 	}
+
 	public function render_friends_list() {
 		Friends::template_loader()->get_template_part(
 			'admin/settings-header',

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -39,7 +39,7 @@ class Admin {
 	 * Register the WordPress hooks
 	 */
 	private function register_hooks() {
-		add_action( 'admin_menu', array( $this, 'register_admin_menu' ) );
+		add_action( 'admin_menu', array( $this, 'admin_menu' ) );
 		add_action( 'friends_own_site_menu_top', array( $this, 'friends_add_menu_open_friend_request' ), 10, 2 );
 		add_filter( 'users_list_table_query_args', array( $this, 'allow_role_multi_select' ) );
 		add_filter( 'user_row_actions', array( get_called_class(), 'user_row_actions' ), 10, 2 );
@@ -106,7 +106,7 @@ class Admin {
 	/**
 	 * Registers the admin menus
 	 */
-	public function register_admin_menu() {
+	public function admin_menu() {
 		if ( isset( $_REQUEST['rerun-activate'] ) && isset( $_REQUEST['_wpnonce'] ) && wp_verify_nonce( $_REQUEST['_wpnonce'], 'friends-settings' ) ) {
 			Friends::activate_plugin();
 			wp_safe_redirect( add_query_arg( array( 'reran-activation' => 'friends' ), wp_get_referer() ) );
@@ -128,15 +128,14 @@ class Admin {
 		add_submenu_page( 'friends', __( 'Add New Friend', 'friends' ), __( 'Add New Friend', 'friends' ), $required_role, 'add-friend', array( $this, 'render_admin_add_friend' ) );
 		add_action( 'load-' . $page_type . '_page_friends-settings', array( $this, 'process_admin_settings' ) );
 
+		add_submenu_page( 'friends', __( 'Friends &amp; Requests', 'friends' ), __( 'Friends &amp; Requests', 'friends' ), $required_role, 'friends-list', array( $this, 'render_friends_list' ) );
+
 		if ( $this->friends_unread_friend_request_count( 0 ) > 0 ) {
 			add_submenu_page( 'friends', __( 'Friend Requests', 'friends' ), __( 'Friend Requests', 'friends' ) . $unread_badge, $required_role, 'friends-list-requests', array( $this, 'render_friends_list' ) );
 		} elseif ( isset( $_GET['page'] ) && 'friends-list-requests' === $_GET['page'] ) {
 			// Don't show a no permission page but redirect to the friends list.
-			wp_safe_redirect( self_admin_url( 'admin.php?page=friends-list' ) );
-			exit;
+			add_submenu_page( 'friends', __( 'Friend Requests', 'friends' ), __( 'Friend Requests', 'friends' ) . $unread_badge, $required_role, 'friends-list-requests', array( $this, 'render_friends_list' ) );
 		}
-
-		add_submenu_page( 'friends', __( 'Friends &amp; Requests', 'friends' ), __( 'Friends &amp; Requests', 'friends' ), $required_role, 'friends-list', array( $this, 'render_friends_list' ) );
 
 		if ( isset( $_GET['page'] ) && 'friends-refresh' === $_GET['page'] ) {
 			add_submenu_page( 'friends', __( 'Refresh', 'friends' ), __( 'Refresh', 'friends' ), $required_role, 'friends-refresh', array( $this, 'admin_refresh_friend_posts' ) );
@@ -897,8 +896,20 @@ class Admin {
 		wp_die();
 	}
 	public function render_friends_list() {
+		Friends::template_loader()->get_template_part(
+			'admin/settings-header',
+			null,
+			array(
+				'menu'   => array(
+					__( 'Your Friends & Subscriptions', 'friends' ) => 'friends-list',
+					__( 'Your Friend Requests', 'friends' ) => 'friends-list-requests',
+				),
+				'active' => $_GET['page'],
+				'title'  => __( 'Friends', 'friends' ),
+			)
+		);
+
 		if ( isset( $_GET['page'] ) && 'friends-list-requests' === $_GET['page'] ) {
-			echo '<div class="wrap"><h3>' . esc_html__( 'Your Friend Requests', 'friends' ) . '</h3>';
 			echo '<p>';
 			echo wp_kses(
 				sprintf(
@@ -916,7 +927,6 @@ class Admin {
 			echo '</p>';
 			$query = User_Query::all_friend_requests();
 		} else {
-			echo '<div class="wrap"><h3>' . esc_html__( 'Your Friends & Subscriptions', 'friends' ) . '</h3>';
 			$query = User_Query::all_associated_users();
 		}
 
@@ -953,7 +963,8 @@ class Admin {
 				'friends' => $query->get_results(),
 			)
 		);
-		echo '</div>';
+
+		Friends::template_loader()->get_template_part( 'admin/settings-footer' );
 	}
 
 	/**

--- a/includes/class-automatic-status.php
+++ b/includes/class-automatic-status.php
@@ -55,7 +55,6 @@ class Automatic_Status {
 	 * Add the admin menu to the sidebar.
 	 */
 	public function admin_menu() {
-		$required_role = Friends::required_menu_role();
 		$unread_badge = $this->friends->admin->get_unread_badge();
 
 		$menu_title = __( 'Friends', 'friends' ) . $unread_badge;

--- a/includes/class-frontend.php
+++ b/includes/class-frontend.php
@@ -1003,6 +1003,7 @@ class Frontend {
 			// Show your own posts on the status feed.
 			$post_types[] = 'post';
 		}
+
 		$query->set( 'post_type', $post_types );
 		$query->set( 'tax_query', $tax_query );
 

--- a/includes/class-frontend.php
+++ b/includes/class-frontend.php
@@ -81,6 +81,9 @@ class Frontend {
 		add_action( 'wp_ajax_friends-autocomplete', array( $this, 'ajax_autocomplete' ) );
 		add_action( 'wp_ajax_friends-star', array( $this, 'ajax_star_friend_user' ) );
 		add_action( 'wp_ajax_friends-load-comments', array( $this, 'ajax_load_comments' ) );
+		add_action( 'wp_ajax_friends-reblog', array( $this, 'wp_ajax_reblog' ) );
+		add_action( 'friends_post_footer_first', array( $this, 'reblog_button' ) );
+		add_filter( 'friends_reblog', array( get_called_class(), 'reblog' ), 10, 2 );
 		add_action( 'wp_untrash_post_status', array( $this, 'untrash_post_status' ), 10, 3 );
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 		add_action( 'wp_enqueue_scripts', array( $this, 'dequeue_scripts' ), 99999 );
@@ -266,6 +269,76 @@ class Frontend {
 	 */
 	private function get_minimal_query_vars( $query_vars ) {
 		return array_filter( array_intersect_key( $query_vars, array_flip( array( 'p', 'page_id', 'pagename', 'author', 'author__not_in', 'post_type', 'post_status', 'posts_per_page', 'order', 'tax_query' ) ) ) );
+	}
+
+
+	public function wp_ajax_reblog() {
+		if ( ! current_user_can( Friends::REQUIRED_ROLE ) ) {
+			wp_send_json_error( 'error' );
+		}
+
+		$post = get_post( $_POST['post_id'] );
+		if ( ! $post || ! Friends::check_url( $post->guid ) ) {
+			wp_send_json_error( 'unknown-post', array( 'guid' => $post->guid ) );
+		}
+
+		$ret = apply_filters( 'friends_reblog', null, $post );
+		if ( ! $ret || is_wp_error( $ret ) ) {
+			wp_send_json_error( 'error' );
+		}
+
+		wp_send_json_success(
+			array(
+				'post_id' => $post->ID,
+			)
+		);
+	}
+
+	public function reblog_button() {
+		$button_label = apply_filters( 'friends_reblog_button_label', _x( 'Reblog', 'button', 'friends' ) );
+
+		Friends::template_loader()->get_template_part(
+			'frontend/parts/reblog-button',
+			null,
+			array(
+				'button-label' => $button_label,
+			)
+		);
+	}
+
+	public static function reblog( $ret, $post ) {
+		$author = get_post_meta( $post->ID, 'author', true );
+		if ( ! $author ) {
+			$friend = new User( $post->post_author );
+			$author = $friend->display_name;
+		}
+
+		$old_guid = $post->guid;
+		$old_post_id = $post->ID;
+
+		$post_format = get_post_format( $post );
+
+		$reblog  = '<!-- wp:paragraph -->' . PHP_EOL . '<p >';
+		$reblog .= sprintf(
+			// translators: %s is a link.
+			__( 'Reblog via %s', 'friends' ),
+			'<a href="' . esc_url( $post->guid ) . '">' . esc_html( $author ) . '</a>'
+		);
+
+		$reblog .= PHP_EOL . '</p>' . PHP_EOL . '<!-- /wp:paragraph -->' . PHP_EOL;
+
+		unset( $post->ID, $post->guid, $post->name, $post->post_date, $post->post_date_gmt, $post->post_modified, $post->post_modified_gmt );
+		$post->post_author = get_current_user_id();
+		$post->post_status = 'publish';
+		$post->post_type = 'post';
+		$post->post_content = $reblog . $post->post_content;
+		$post_id = wp_insert_post( $post );
+
+		set_post_format( $post_id, $post_format );
+		update_post_meta( $post_id, 'reblog', $old_guid );
+		update_post_meta( $old_post_id, 'reblogged', $post_id );
+
+		return true;
 	}
 
 	/**

--- a/templates/admin/activitypub-settings.php
+++ b/templates/admin/activitypub-settings.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * This template contains the Friends Settings.
+ *
+ * @package Friends
+ */
+
+?>
+<form method="post">
+	<?php wp_nonce_field( 'friends-activitypub-settings' ); ?>
+	<table class="form-table">
+		<tbody>
+			<tr>
+				<th scope="row"><?php esc_html_e( 'Boosts', 'friends' ); ?></th>
+				<td>
+					<fieldset>
+						<label for="activitypub_reblog">
+							<input name="activitypub_reblog" type="checkbox" id="activitypub_reblog" value="1" <?php checked( $args['reblog'] ); ?> />
+							<?php esc_html_e( 'When you boost a status, also reblog it.', 'friends' ); ?>
+						</label>
+					</fieldset>
+					<p class="description"><?php esc_html_e( 'If unchecked, the boosting will only happen via ActivityPub.', 'friends' ); ?></p>
+				</td>
+			</tr>
+		</tbody>
+	</table>
+
+	<p class="submit">
+		<input type="submit" id="submit" class="button button-primary" value="<?php /* phpcs:ignore WordPress.WP.I18n.MissingArgDomain */ esc_html_e( 'Save Changes' ); ?>">
+	</p>
+</form>
+<?php

--- a/templates/frontend/activitypub-announce.php
+++ b/templates/frontend/activitypub-announce.php
@@ -11,7 +11,7 @@ if ( get_the_author_meta( 'ID' ) === get_current_user_id() ) {
 }
 ?>
 <a tabindex="0" href="#" data-id="<?php echo esc_attr( get_the_ID() ); ?>" class="btn ml-1 friends-activitypub-reblog has-icon-right">
-	<i class="dashicons dashicons-controls-repeat"></i> <?php echo esc_html( _x( 'Reblog', 'button', 'friends' ) ); ?>
+	<i class="dashicons dashicons-controls-repeat"></i> <?php echo esc_html( $args['button-label'] ); ?>
 	<?php if ( get_post_meta( get_the_ID(), 'reblogged', true ) ) : ?>
 		<i class="friends-reblog-status dashicons dashicons-saved"></i>
 	<?php else : ?>

--- a/templates/frontend/activitypub-announce.php
+++ b/templates/frontend/activitypub-announce.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This template contains the activitypub announce section.
+ *
+ * @version 1.0
+ * @package Friends
+ */
+
+if ( get_the_author_meta( 'ID' ) === get_current_user_id() ) {
+	return;
+}
+?>
+<a tabindex="0" href="#" data-id="<?php echo esc_attr( get_the_ID() ); ?>" class="btn ml-1 friends-activitypub-reblog has-icon-right">
+	<i class="dashicons dashicons-controls-repeat"></i> <?php echo esc_html( _x( 'Reblog', 'button', 'friends' ) ); ?>
+	<?php if ( get_post_meta( get_the_ID(), 'reblogged', true ) ) : ?>
+		<i class="friends-reblog-status dashicons dashicons-saved"></i>
+	<?php else : ?>
+		<i class="friends-reblog-status"></i>
+	<?php endif; ?>
+</a>

--- a/templates/frontend/parts/reblog-button.php
+++ b/templates/frontend/parts/reblog-button.php
@@ -10,7 +10,7 @@ if ( get_the_author_meta( 'ID' ) === get_current_user_id() ) {
 	return;
 }
 ?>
-<a tabindex="0" href="#" data-id="<?php echo esc_attr( get_the_ID() ); ?>" class="btn ml-1 friends-activitypub-reblog has-icon-right">
+<a tabindex="0" href="#" data-id="<?php echo esc_attr( get_the_ID() ); ?>" class="btn ml-1 friends-reblog has-icon-right">
 	<i class="dashicons dashicons-controls-repeat"></i> <?php echo esc_html( $args['button-label'] ); ?>
 	<?php if ( get_post_meta( get_the_ID(), 'reblogged', true ) ) : ?>
 		<i class="friends-reblog-status dashicons dashicons-saved"></i>


### PR DESCRIPTION
This adds a button "Reblog" to each item. Depending on the setting (see below), it will post the same post under your own name on your blog, and if the post is on ActivityPub, it will announce = boost it there.

### ActivityPub Settings

This adds a new ActivityPub settings page that allows to disable the automatic creation of a reblog post:

![Screenshot 2023-03-23 at 16 57 54](https://user-images.githubusercontent.com/203408/227262933-5805f8da-de46-4291-9f18-946416873af8.png)

#### Different buttons

If it is a post that came in via ActivityPub, then it can be either this
![Screenshot 2023-03-23 at 18 00 21](https://user-images.githubusercontent.com/203408/227280316-2e492d11-93f1-454c-b560-4f699a8f8047.png)

or this, depending on the setting above.
![Screenshot 2023-03-23 at 18 00 33](https://user-images.githubusercontent.com/203408/227280522-a01422a5-1ba5-46a9-af68-d82353027498.png)

If it is a plain blog post, you get a reblog button:
![Screenshot 2023-03-23 at 18 01 23](https://user-images.githubusercontent.com/203408/227280607-0b58fc75-e469-4136-949a-f9e3b3db7a9b.png)

Reblogged/boosted posts will be annotated with a checkmark:

![Screenshot 2023-03-23 at 18 06 02](https://user-images.githubusercontent.com/203408/227280831-225ad938-f188-4121-a602-b0c1300e366f.png)



Fixes #186.