### PR TITLE
Don't let the Post Kinds plugin interfere with the friends query

### DIFF
--- a/includes/class-frontend.php
+++ b/includes/class-frontend.php
@@ -930,6 +930,9 @@ class Frontend {
 			return $query;
 		}
 
+		// Don't let the Post Kinds plugin interfere with this query.
+		remove_action( 'pre_get_posts', array( 'Kind_Taxonomy', 'kind_firehose_query' ), 99 );
+
 		switch_to_locale( get_user_locale() );
 		$page_id = get_query_var( 'page' );
 


### PR DESCRIPTION
This addresses the problem in #162 where the Post Kinds plugin interferes with the Friends plugin if you select any of these options:

![Screenshot 2023-01-10 at 11 19 00](https://user-images.githubusercontent.com/203408/211524638-b89fc3e0-bc5a-4aa0-989b-c37264f41e95.png)

then on the `/friends/` page no posts would be found even if they are there (as the status bubble denotes):
![Screenshot 2023-01-10 at 11 19 36](https://user-images.githubusercontent.com/203408/211524865-d3eeac26-bd84-40d5-9cd6-7f1901bcdca1.png)
