### PR TITLE
Add global retention settings

### DIFF
--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -341,7 +341,7 @@ class Admin {
 			if ( ! $friend_user || is_wp_error( $friend_user ) || ! $friend_user->can_refresh_feeds() ) {
 				wp_die( esc_html__( 'Invalid user ID.' ) ); // phpcs:ignore WordPress.WP.I18n.MissingArgDomain
 			}
-			$friend_user->retrieve_posts();
+			$friend_user->retrieve_posts_from_active_feeds();
 		} else {
 			$this->friends->feed->retrieve_friend_posts();
 		}

--- a/includes/class-feed.php
+++ b/includes/class-feed.php
@@ -1088,7 +1088,7 @@ class Feed {
 		if ( ( 'friend' === $new_role || 'acquaintance' === $new_role ) && apply_filters( 'friends_immediately_fetch_feed', true ) ) {
 			update_user_option( $user_id, 'friends_new_friend', true );
 			$friend = new User( $user_id );
-			$friend->retrieve_posts();
+			$friend->retrieve_posts_from_active_feeds();
 		}
 	}
 

--- a/includes/class-friends.php
+++ b/includes/class-friends.php
@@ -9,6 +9,8 @@
 
 namespace Friends;
 
+use stdClass;
+
 /**
  * This is the class for the Friends Plugin.
  *
@@ -746,6 +748,89 @@ class Friends {
 		}
 
 		return $counts;
+	}
+
+	/**
+	 * Get the retention by number of posts.
+	 *
+	 * @return int The retention by number of posts.
+	 */
+	public static function get_retention_number() {
+		$number = get_option( 'friends_retention_number' );
+		if ( $number <= 0 ) {
+			return 2000;
+		}
+
+		return $number;
+	}
+
+	/**
+	 * Get the retention by days of posts.
+	 *
+	 * @return int The retention by days of posts.
+	 */
+	public static function get_retention_days() {
+		$days = get_option( 'friends_retention_days' );
+		if ( $days <= 0 ) {
+			return 30;
+		}
+
+		return $days;
+	}
+
+
+
+	/**
+	 * Gets the post stats.
+	 *
+	 * @return     object  The post stats.
+	 */
+	public static function get_post_stats() {
+		global $wpdb;
+		$post_stats = $wpdb->get_row(
+			$wpdb->prepare(
+				'SELECT SUM(
+				LENGTH( ID ) +
+				LENGTH( post_author ) +
+				LENGTH( post_date ) +
+				LENGTH( post_date_gmt ) +
+				LENGTH( post_content ) +
+				LENGTH( post_title ) +
+				LENGTH( post_excerpt ) +
+				LENGTH( post_status ) +
+				LENGTH( comment_status ) +
+				LENGTH( ping_status ) +
+				LENGTH( post_password ) +
+				LENGTH( post_name ) +
+				LENGTH( to_ping ) +
+				LENGTH( pinged ) +
+				LENGTH( post_modified ) +
+				LENGTH( post_modified_gmt ) +
+				LENGTH( post_content_filtered ) +
+				LENGTH( post_parent ) +
+				LENGTH( guid ) +
+				LENGTH( menu_order ) +
+				LENGTH( post_type ) +
+				LENGTH( post_mime_type ) +
+				LENGTH( comment_count )
+				) AS total_size,
+				COUNT(*) as post_count
+			FROM ' . $wpdb->posts . ' WHERE post_type IN ( ' . implode( ', ', array_fill( 0, count( Friends::get_frontend_post_types() ), '%s' ) ) . ' )',
+				Friends::get_frontend_post_types()
+			),
+			ARRAY_A
+		);
+		$post_stats['earliest_post_date'] = mysql2date(
+			'U',
+			$wpdb->get_var(
+				$wpdb->prepare(
+					"SELECT MIN(post_date) FROM $wpdb->posts WHERE post_status = 'publish' AND post_type IN ( " . implode( ', ', array_fill( 0, count( Friends::get_frontend_post_types() ), '%s' ) ) . ' )',
+					Friends::get_frontend_post_types()
+				)
+			)
+		);
+
+		return $post_stats;
 	}
 
 	/**

--- a/includes/class-rest.php
+++ b/includes/class-rest.php
@@ -218,7 +218,10 @@ class REST {
 		}
 		$friend_user->update_user_icon_url( $request->get_param( 'icon_url' ) );
 		$friend_user->update_user_option( 'friends_future_out_token', $request->get_param( 'key' ) );
-		$friend_user->update_user_option( 'friends_request_message', mb_substr( $request->get_param( 'message' ), 0, 2000 ) );
+		$message = $request->get_param( 'message' );
+		if ( is_string( $message ) ) {
+			$friend_user->update_user_option( 'friends_request_message', mb_substr( $message, 0, 2000 ) );
+		}
 
 		$request_id = wp_generate_password( 128, false );
 		$friend_user->update_user_option( 'friends_request_id', $request_id );

--- a/includes/class-user.php
+++ b/includes/class-user.php
@@ -368,86 +368,102 @@ class User extends \WP_User {
 	 *
 	 * @return array The new posts.
 	 */
-	public function retrieve_posts() {
+	public function retrieve_posts_from_active_feeds() {
+		return $this->retrieve_posts_from_feeds( $this->get_active_feeds() );
+	}
+
+	/**
+	 * Retrieve the posts for these user feeds
+	 *
+	 * @param      array $feeds  The feeds to retrieve from.
+	 *
+	 * @return array The new posts.
+	 */
+	public function retrieve_posts_from_feeds( array $feeds ) {
 		$friends = Friends::get_instance();
 		$new_posts = array();
-		foreach ( $this->get_active_feeds() as $feed ) {
+		foreach ( $feeds as $feed ) {
 			$posts = $friends->feed->retrieve_feed( $feed );
 			if ( ! is_wp_error( $posts ) ) {
 				$new_posts = array_merge( $new_posts, $posts );
 			}
 		}
 
-		$this->delete_outdated_posts();
-		return $new_posts;
+		$deleted_posts = $this->delete_outdated_posts();
+
+		return array_values( array_diff( $new_posts, $deleted_posts ) );
 	}
 
 	/**
 	 * Delete posts the user decided to automatically delete.
 	 */
 	public function delete_outdated_posts() {
-		$count = 0;
-		$date_before = false;
-		if ( $this->is_retention_days_enabled() ) {
-			$date_before = gmdate( 'Y-m-d H:i:s', strtotime( '-' . ( $this->get_retention_days() * 24 ) . 'hours' ) );
-		} elseif ( get_option( 'friends_enable_retention_days' ) ) {
-			$date_before = gmdate( 'Y-m-d H:i:s', strtotime( '-' . ( Friends::get_retention_days() * 24 ) . 'hours' ) );
-		}
+		$deleted_posts = array();
+
 		$args = array(
-			'post_type'  => Friends::CPT,
-			'author'     => $this->ID,
-			'nopaging'   => true,
-			'date_query' => array(
-				'before' => $date_before,
-			),
+			'post_type' => Friends::CPT,
+			'author'    => $this->ID,
 		);
 
-		$query = new \WP_Query( $args );
-
-		while ( $query->have_posts() ) {
-			$count ++;
-			$query->the_post();
-			if ( apply_filters( 'friends_debug', false ) && ! wp_doing_cron() ) {
-				echo 'Deleting ', get_the_ID(), '<br/>';
-			}
-			wp_delete_post( get_the_ID(), true );
+		if ( $this->is_retention_days_enabled() ) {
+			$args['date_query'] = array(
+				'before' => gmdate( 'Y-m-d H:i:s', strtotime( '-' . ( $this->get_retention_days() * 24 ) . 'hours' ) ),
+			);
+		} elseif ( get_option( 'friends_enable_retention_days' ) ) {
+			$args['date_query'] = array(
+				'before' => gmdate( 'Y-m-d H:i:s', strtotime( '-' . ( Friends::get_retention_days() * 24 ) . 'hours' ) ),
+			);
 		}
 
-		if ( $this->is_retention_number_enabled() ) {
-			$args = array(
-				'post_type' => Friends::CPT,
-				'author'    => $this->ID,
-				'offset'    => $this->get_retention_number(),
-			);
-
+		if ( isset( $args['date_query'] ) ) {
 			$query = new \WP_Query( $args );
 
 			while ( $query->have_posts() ) {
-				$count ++;
 				$query->the_post();
+				$post_id = get_the_ID();
+
 				if ( apply_filters( 'friends_debug', false ) && ! wp_doing_cron() ) {
-					echo 'Deleting ', get_the_ID(), '<br/>';
+					echo 'Deleting ', esc_html( $post_id ), '<br/>';
 				}
-				wp_delete_post( get_the_ID(), true );
+				wp_delete_post( $post_id, true );
+				$deleted_posts[] = $post_id;
+			}
+		}
+
+		unset( $args['date_query'] );
+		$args['orderby'] = 'date';
+		$args['order'] = 'asc';
+		if ( $this->is_retention_number_enabled() ) {
+			$args['offset'] = $this->get_retention_number();
+			$query = new \WP_Query( $args );
+
+			while ( $query->have_posts() ) {
+				$query->the_post();
+				$post_id = get_the_ID();
+
+				if ( apply_filters( 'friends_debug', false ) && ! wp_doing_cron() ) {
+					echo 'Deleting ', esc_html( $post_id ), '<br/>';
+				}
+				wp_delete_post( $post_id, true );
+				$deleted_posts[] = $post_id;
 			}
 		}
 
 		// Global setting.
 		if ( get_option( 'friends_enable_retention_number' ) ) {
-			$args = array(
-				'post_type' => Friends::CPT,
-				'offset'    => Friends::get_retention_number(),
-			);
-
+			unset( $args['author'] );
+			$args['offset'] = Friends::get_retention_number();
 			$query = new \WP_Query( $args );
 
 			while ( $query->have_posts() ) {
-				$count ++;
 				$query->the_post();
+				$post_id = get_the_ID();
+
 				if ( apply_filters( 'friends_debug', false ) && ! wp_doing_cron() ) {
-					echo 'Deleting ', get_the_ID(), '<br/>';
+					echo 'Deleting ', esc_html( $post_id ), '<br/>';
 				}
-				wp_delete_post( get_the_ID(), true );
+				wp_delete_post( $post_id, true );
+				$deleted_posts[] = $post_id;
 			}
 		}
 
@@ -462,13 +478,17 @@ class User extends \WP_User {
 		$query = new \WP_Query( $args );
 
 		while ( $query->have_posts() ) {
-			$count ++;
 			$query->the_post();
-			if ( apply_filters( 'friends_debug', false ) ) {
-				echo 'Deleting ', get_the_ID(), '<br/>';
+			$post_id = get_the_ID();
+
+			if ( apply_filters( 'friends_debug', false ) && ! wp_doing_cron() ) {
+				echo 'Deleting ', esc_html( $post_id ), '<br/>';
 			}
-			wp_delete_post( get_the_ID(), true );
+			wp_delete_post( $post_id, true );
+			$deleted_posts[ $post_id ] = $post_id;
 		}
+
+		return $deleted_posts;
 	}
 
 	/**

--- a/templates/admin/edit-feeds.php
+++ b/templates/admin/edit-feeds.php
@@ -254,7 +254,11 @@ $has_last_log = false;
 						esc_html_e( 'If you need to limit the amount of space, choose one of the options above (they can be combined).', 'friends' );
 						echo ' ';
 						esc_html_e( 'The next auto-delete will kick in when refreshing the feeds of this friend.', 'friends' );
-						echo ' ';
+						?>
+					</p>
+					</p>
+					<p class="description">
+						<?php
 						esc_html_e( 'Lower global settings have preceedence over the friend settings.', 'friends' );
 						?>
 					</p>

--- a/templates/admin/edit-feeds.php
+++ b/templates/admin/edit-feeds.php
@@ -132,14 +132,14 @@ $has_last_log = false;
 					<a href="<?php echo esc_url( $args['friend']->get_local_friends_page_url() ); ?>">
 						<?php
 						// translators: %d is the number of posts.
-						echo esc_html( sprintf( _n( 'View %d post', 'View %d posts', $args['friend_posts'], 'friends' ), $args['friend_posts'] ) );
+						echo esc_html( sprintf( _n( 'View %d post', 'View %d posts', $args['post_count'], 'friends' ), $args['post_count'] ) );
 						?>
 					</a>
 					<?php if ( apply_filters( 'friends_debug', false ) ) : ?>
 						| <a href="<?php echo esc_url( self_admin_url( 'edit.php?post_type=' . Friends\Friends::CPT . '&author=' . $args['friend']->ID ) ); ?>">
 							<?php
 							// translators: %d is the number of posts.
-							echo esc_html( sprintf( _n( 'View %d cached post', 'View %d cached posts', $args['friend_posts'], 'friends' ), $args['friend_posts'] ) );
+							echo esc_html( sprintf( _n( 'View %d cached post', 'View %d cached posts', $args['post_count'], 'friends' ), $args['post_count'] ) );
 							?>
 						</a>
 
@@ -179,6 +179,25 @@ $has_last_log = false;
 									),
 								)
 							);
+							echo '. ';
+							echo esc_html(
+								sprintf(
+								// translators: %s is a date.
+									__( 'Earliest post: %s', 'friends' ),
+									/* phpcs:ignore WordPress.WP.I18n.MissingArgDomain */ date_i18n( __( 'F j, Y' ), $args['earliest_post_date'] )
+								)
+							);
+							if ( $args['global_retention_days_enabled'] ) {
+								echo '. ';
+								echo esc_html(
+									sprintf(
+									// translators: %s is a number of days.
+										__( 'Global setting: %s days', 'friends' ),
+										number_format_i18n( $args['global_retention_days'] )
+									)
+								);
+							}
+
 							?>
 							</span>
 						</div>
@@ -204,6 +223,16 @@ $has_last_log = false;
 									),
 								)
 							);
+							if ( $args['global_retention_number_enabled'] ) {
+								echo '. ';
+								echo esc_html(
+									sprintf(
+										// translators: %s is a number.
+										__( 'Global setting: %s posts', 'friends' ),
+										number_format_i18n( $args['global_retention_number'] )
+									)
+								);
+							}
 							?>
 							</span>
 						</div>
@@ -212,11 +241,21 @@ $has_last_log = false;
 						<?php
 						echo esc_html(
 							sprintf(
-							// translators: %s is a size in bytes or kilo bytes (kB).
-								__( 'Currently the posts use %s of disk space. If you need to limit the amount of space, choose one of the options above (they can be combined). The next auto-delete will kick in when refreshing the feeds of this friend.', 'friends' ),
+								// translators: %s is a size in bytes or kilo bytes (kB).
+								__( 'Currently the posts use %s of disk space.', 'friends' ),
 								size_format( $args['total_size'], 1 )
 							)
 						);
+						?>
+					</p>
+					<p class="description">
+						<?php
+						echo ' ';
+						esc_html_e( 'If you need to limit the amount of space, choose one of the options above (they can be combined).', 'friends' );
+						echo ' ';
+						esc_html_e( 'The next auto-delete will kick in when refreshing the feeds of this friend.', 'friends' );
+						echo ' ';
+						esc_html_e( 'Lower global settings have preceedence over the friend settings.', 'friends' );
 						?>
 					</p>
 				</td>

--- a/templates/admin/edit-friend.php
+++ b/templates/admin/edit-friend.php
@@ -82,14 +82,14 @@
 					<a href="<?php echo esc_url( $args['friend']->get_local_friends_page_url() ); ?>">
 						<?php
 						// translators: %d is the number of posts.
-						echo esc_html( sprintf( _n( 'View %d post', 'View %d posts', $args['friend_posts'], 'friends' ), $args['friend_posts'] ) );
+						echo esc_html( sprintf( _n( 'View %d post', 'View %d posts', $args['post_count'], 'friends' ), $args['post_count'] ) );
 						?>
 					</a>
 					<?php if ( apply_filters( 'friends_debug', false ) ) : ?>
 						| <a href="<?php echo esc_url( self_admin_url( 'edit.php?post_type=' . Friends\Friends::CPT . '&author=' . $args['friend']->ID ) ); ?>">
 							<?php
 							// translators: %d is the number of posts.
-							echo esc_html( sprintf( _n( 'View %d cached post', 'View %d cached posts', $args['friend_posts'], 'friends' ), $args['friend_posts'] ) );
+							echo esc_html( sprintf( _n( 'View %d cached post', 'View %d cached posts', $args['post_count'], 'friends' ), $args['post_count'] ) );
 							?>
 						</a>
 

--- a/templates/admin/settings.php
+++ b/templates/admin/settings.php
@@ -203,10 +203,104 @@ do_action( 'friends_settings_before_form' );
 					</p>
 				</td>
 			</tr>
-			<?php
-			if ( current_user_can( 'manage_options' ) ) :
-				;
-				?>
+			<tr>
+				<th><?php esc_html_e( 'Retention', 'friends' ); ?></th>
+				<td>
+					<fieldset>
+						<div>
+							<input type="checkbox" name="friends_enable_retention_days" id="friends_enable_retention_days" value="1" <?php checked( '1', $args['retention_days_enabled'] ); ?> />
+							<span id="friends_enable_retention_days_line" class="<?php echo esc_attr( $args['retention_days_enabled'] ? '' : 'disabled' ); ?>">
+							<?php
+							echo wp_kses(
+								sprintf(
+									// translators: %s is an input field that allows specifying a number.
+									__( 'Only keep posts for %s days', 'friends' ),
+									'<input type="number" min="1" id="friends_retention_days" name="friends_retention_days" value="' . esc_attr( $args['retention_days'] ) . '"' . ( $args['retention_days_enabled'] ? '' : ' disabled="disabled"' ) . ' size="3">'
+								),
+								array(
+									'input' => array(
+										'type'     => array(),
+										'min'      => array(),
+										'id'       => array(),
+										'name'     => array(),
+										'value'    => array(),
+										'size'     => array(),
+										'disabled' => array(),
+									),
+								)
+							);
+							echo '. ';
+							echo esc_html(
+								sprintf(
+								// translators: %s is a date.
+									__( 'Earliest post: %s', 'friends' ),
+									/* phpcs:ignore WordPress.WP.I18n.MissingArgDomain */ date_i18n( __( 'F j, Y' ), $args['earliest_post_date'] )
+								)
+							);
+							?>
+							</span>
+						</div>
+						<div>
+							<input type="checkbox" name="friends_enable_retention_number" id="friends_enable_retention_number" value="1" <?php checked( '1', $args['retention_number_enabled'] ); ?> />
+							<span id="friends_enable_retention_number_line" class="<?php echo esc_attr( $args['retention_number_enabled'] ? '' : 'disabled' ); ?>">
+							<?php
+							echo wp_kses(
+								sprintf(
+									// translators: %s is an input field that allows specifying a number.
+									__( 'Only keep the last %s posts', 'friends' ),
+									'<input type="number" min="1" id="friends_retention_number" name="friends_retention_number" value="' . esc_attr( $args['retention_number'] ) . '"' . ( $args['retention_number_enabled'] ? '' : ' disabled="disabled"' ) . ' size="3">'
+								),
+								array(
+									'input' => array(
+										'type'     => array(),
+										'min'      => array(),
+										'id'       => array(),
+										'name'     => array(),
+										'value'    => array(),
+										'size'     => array(),
+										'disabled' => array(),
+									),
+								)
+							);
+							echo '. ';
+							echo esc_html(
+								sprintf(
+								// translators: %s is a date.
+									__( 'Current number of posts: %s', 'friends' ),
+									number_format_i18n( $args['post_count'] )
+								)
+							);
+							?>
+							</span>
+						</div>
+					</fieldset>
+					<p class="description">
+						<?php
+						echo esc_html(
+							sprintf(
+								// translators: %s is a size in bytes or kilo bytes (kB).
+								__( 'Currently the posts use %s of disk space.', 'friends' ),
+								size_format( $args['total_size'], 1 )
+							)
+						);
+						?>
+					</p>
+					<p class="description">
+						<?php
+						echo ' ';
+						esc_html_e( 'If you need to limit the amount of space, choose one of the options above (they can be combined).', 'friends' );
+						echo ' ';
+						esc_html_e( 'The next auto-delete will kick in when refreshing the feeds.', 'friends' );
+						?>
+					</p>
+					<p class="description">
+						<?php
+						esc_html_e( 'You can also specify this for individual friends.', 'friends' );
+						?>
+					</p>
+				</td>
+			</tr>
+			<?php if ( current_user_can( 'manage_options' ) ) : ?>
 			<tr>
 				<th scope="row"><?php esc_html_e( 'Post Formats', 'friends' ); ?></th>
 				<td>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -49,6 +49,7 @@ ob_start();
 // Start up the WP testing environment.
 require $_tests_dir . '/includes/bootstrap.php';
 require __DIR__ . '/class-friends-testcase-cache-http.php';
+require __DIR__ . '/class-feed-parser-local-file.php';
 Friends\Friends::activate_plugin();
 ob_end_clean();
 

--- a/tests/class-feed-parser-local-file.php
+++ b/tests/class-feed-parser-local-file.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Friends Parser Tester
+ *
+ * This is a class that helps with testing feed parsers.
+ *
+ * @since @2.1.5
+ *
+ * @package Friends
+ * @author Alex Kirk
+ */
+
+namespace Friends;
+
+/**
+ * This is the class for testing feed parsing.
+ */
+class Feed_Parser_Local_File extends Feed_Parser_SimplePie {
+	/**
+	 * Constructor.
+	 *
+	 * @param      Feed $friends_feed  The friends feed.
+	 */
+	public function __construct( Feed $friends_feed ) {
+	}
+
+	public function fetch_feed( $url, User_Feed $user_feed = null ) {
+		$file = new \SimplePie_File( $url );
+		$feed = new \SimplePie();
+		$feed->set_file( $file );
+		$feed->init();
+
+		return $this->process_items( $feed->get_items(), $url );
+	}
+
+}

--- a/tests/data/friend-feed-10-posts.rss
+++ b/tests/data/friend-feed-10-posts.rss
@@ -1,0 +1,58 @@
+<?xml version="1.0"?>
+<rss version="2.0">
+	<channel>
+		<title>friend.local</title>
+		<link>http://friend.local</link>
+		<description>My friend's site</description>
+		<item>
+			<title>First Post</title>
+			<link>http://friend.local/2023/01/01/first-post</link>
+			<description>This is the first post content.</description>
+		</item>
+		<item>
+			<title>Second Post</title>
+			<link>http://friend.local/2023/01/02/second-post</link>
+			<description>This is the second post content.</description>
+		</item>
+		<item>
+			<title>Third Post</title>
+			<link>http://friend.local/2023/01/03/third-post</link>
+			<description>This is the third post content.</description>
+		</item>
+		<item>
+			<title>Fourth Post</title>
+			<link>http://friend.local/2023/01/04/fourth-post</link>
+			<description>This is the fourth post content.</description>
+		</item>
+		<item>
+			<title>Fifth Post</title>
+			<link>http://friend.local/2023/01/05/fifth-post</link>
+			<description>This is the fifth post content.</description>
+		</item>
+		<item>
+			<title>Sixth Post</title>
+			<link>http://friend.local/2023/01/06/sixth-post</link>
+			<description>This is the sixth post content.</description>
+		</item>
+		<item>
+			<title>Seventh Post</title>
+			<link>http://friend.local/2023/01/07/seventh-post</link>
+			<description>This is the seventh post content.</description>
+		</item>
+		<item>
+			<title>Eighth Post</title>
+			<link>http://friend.local/2023/01/08/eighth-post</link>
+			<description>This is the eighth post content.</description>
+		</item>
+		<item>
+			<title>Ninth Post</title>
+			<link>http://friend.local/2023/01/09/ninth-post</link>
+			<description>This is the ninth post content.</description>
+		</item>
+		<item>
+			<title>Tenth Post</title>
+			<link>http://friend.local/2023/01/10/tenth-post</link>
+			<description>This is the tenth post content.</description>
+		</item>
+	</channel>
+</rss>

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -131,7 +131,7 @@ class APITest extends \WP_UnitTestCase {
 	 */
 	public function test_get_non_friend_posts() {
 		$friend_user = new User( $this->friend_id );
-		$posts = $friend_user->retrieve_posts();
+		$posts = $friend_user->retrieve_posts_from_active_feeds();
 		$this->assertCount( 1, $posts );
 	}
 
@@ -141,7 +141,7 @@ class APITest extends \WP_UnitTestCase {
 	public function test_get_friend_posts() {
 		wp_set_current_user( $this->user_id );
 		$friend_user = new User( $this->friend_id );
-		$posts = $friend_user->retrieve_posts();
+		$posts = $friend_user->retrieve_posts_from_active_feeds();
 		$this->assertCount( 2, $posts );
 	}
 }

--- a/tests/test-feed.php
+++ b/tests/test-feed.php
@@ -598,12 +598,22 @@ class FeedTest extends \WP_UnitTestCase {
 		$count = wp_count_posts( Friends::CPT );
 		$this->assertEquals( 10, $count->publish );
 
-		// No new items but one more than we had.
+		$user->set_retention_number( 5 );
+		// Nothing should change since it's not enabled.
 		$feed_parsing_test->send( $feed );
 		$new_items = $feed_parsing_test->current();
 		$this->assertCount( 0, $new_items );
 		wp_cache_delete( _count_posts_cache_key( Friends::CPT, '' ), 'counts' );
 		$count = wp_count_posts( Friends::CPT );
-		$this->assertEquals( 9, $count->publish );
+		$this->assertEquals( 10, $count->publish );
+
+		$user->set_retention_number_enabled( true );
+		// Now the number should go down to 5.
+		$feed_parsing_test->send( $feed );
+		$new_items = $feed_parsing_test->current();
+		$this->assertCount( 0, $new_items );
+		wp_cache_delete( _count_posts_cache_key( Friends::CPT, '' ), 'counts' );
+		$count = wp_count_posts( Friends::CPT );
+		$this->assertEquals( 5, $count->publish );
 	}
 }

--- a/tests/test-feed.php
+++ b/tests/test-feed.php
@@ -133,30 +133,27 @@ class FeedTest extends \WP_UnitTestCase {
 	/**
 	 * Common code for testing parsing a feed.
 	 *
-	 * @param      \SimplePie_File $file  A SimplePie File.
-	 * @param      User            $user   The optional user, otherwise the friend_id will be used.
+	 * @param      string $file  A SimplePie File.
+	 * @param      User   $user   The optional user, otherwise the friend_id will be used.
 	 */
-	private function feed_parsing_test( \SimplePie_File $file, User $user = null ) {
-		$parser = new Feed_Parser_SimplePie;
-
+	private function feed_parsing_test( $file, User $user = null ) {
 		if ( is_null( $user ) ) {
 			$user = new User( $this->friend_id );
 		}
-		$term = new \WP_Term(
-			(object) array(
-				'url' => $user->user_url . '/feed/',
-			)
-		);
-		$user_feed = new User_Feed( $term, $user );
-
 		$friends = Friends::get_instance();
+		$friends->feed->register_parser( 'local', new Feed_Parser_Local_File( $friends->feed ) );
 
-		$feed = new \SimplePie();
 		do {
-			$feed->set_file( $file );
-			$feed->init();
+			if ( ! isset( $feeds[ $file ] ) ) {
+				$feeds[ $file ] = User_Feed::save(
+					$user,
+					$file,
+					array( 'parser' => 'local' )
+				);
+			}
+			$user_feed = $feeds[ $file ];
 
-			$new_items = $friends->feed->process_incoming_feed_items( $parser->process_items( $feed->get_items(), $user_feed->get_url() ), $user_feed );
+			$new_items = $user->retrieve_posts_from_feeds( array( $user_feed ) );
 			$file = ( yield $new_items );
 		} while ( $file );
 	}
@@ -165,7 +162,7 @@ class FeedTest extends \WP_UnitTestCase {
 	 * Test parsing a feed.
 	 */
 	public function test_parse_feed() {
-		$feed_1_private_post = new \SimplePie_File( __DIR__ . '/data/friend-feed-1-private-post.rss' );
+		$feed_1_private_post = __DIR__ . '/data/friend-feed-1-private-post.rss';
 		$feed_parsing_test = $this->feed_parsing_test( $feed_1_private_post );
 
 		$new_items = $feed_parsing_test->current();
@@ -182,7 +179,7 @@ class FeedTest extends \WP_UnitTestCase {
 	 * Test parsing a feed with ampersand URLs.
 	 */
 	public function test_parse_feed_with_url_ampersand() {
-		$feed_url_ampersand = new \SimplePie_File( __DIR__ . '/data/friend-feed-url-ampersand.rss' );
+		$feed_url_ampersand = __DIR__ . '/data/friend-feed-url-ampersand.rss';
 		$feed_parsing_test = $this->feed_parsing_test( $feed_url_ampersand );
 
 		$new_items = $feed_parsing_test->current();
@@ -199,7 +196,7 @@ class FeedTest extends \WP_UnitTestCase {
 	 * Test parsing a feed with identical posts.
 	 */
 	public function test_parse_feed_with_identical_posts() {
-		$identical_posts = new \SimplePie_File( __DIR__ . '/data/friend-feed-identical-posts.rss' );
+		$identical_posts = __DIR__ . '/data/friend-feed-identical-posts.rss';
 		$feed_parsing_test = $this->feed_parsing_test( $identical_posts );
 
 		$new_items = $feed_parsing_test->current();
@@ -216,7 +213,7 @@ class FeedTest extends \WP_UnitTestCase {
 	 * Test parsing a feed with identical posts after the fold.
 	 */
 	public function test_parse_feed_with_identical_posts_after_fold() {
-		$identical_posts_after_fold = new \SimplePie_File( __DIR__ . '/data/friend-feed-identical-posts-after-fold.rss' );
+		$identical_posts_after_fold = __DIR__ . '/data/friend-feed-identical-posts-after-fold.rss';
 		$feed_parsing_test = $this->feed_parsing_test( $identical_posts_after_fold );
 
 		$new_items = $feed_parsing_test->current();
@@ -275,7 +272,7 @@ class FeedTest extends \WP_UnitTestCase {
 	}
 
 	public function test_feed_item_revisions_modified_content() {
-		$feed_1_public_post = new \SimplePie_File( __DIR__ . '/data/friend-feed-1-public-post.rss' );
+		$feed_1_public_post = __DIR__ . '/data/friend-feed-1-public-post.rss';
 		$feed_parsing_test = $this->feed_parsing_test( $feed_1_public_post, new User( $this->alex ) );
 
 		$new_items = $feed_parsing_test->current();
@@ -287,13 +284,13 @@ class FeedTest extends \WP_UnitTestCase {
 		$this->assertCount( 0, $feed_parsing_test->current() );
 		$this->assertCount( 0, wp_get_post_revisions( $post_id ) );
 
-		$feed_parsing_test->send( new \SimplePie_File( __DIR__ . '/data/friend-feed-1-public-post-modified-content.rss' ) );
+		$feed_parsing_test->send( __DIR__ . '/data/friend-feed-1-public-post-modified-content.rss' );
 		$this->assertCount( 0, $feed_parsing_test->current() );
 		$this->assertCount( 1, wp_get_post_revisions( $post_id ) );
 	}
 
 	public function test_feed_item_revisions_modified_title() {
-		$feed_1_public_post = new \SimplePie_File( __DIR__ . '/data/friend-feed-1-public-post.rss' );
+		$feed_1_public_post = __DIR__ . '/data/friend-feed-1-public-post.rss';
 		$feed_parsing_test = $this->feed_parsing_test( $feed_1_public_post, new User( $this->alex ) );
 
 		$new_items = $feed_parsing_test->current();
@@ -305,13 +302,13 @@ class FeedTest extends \WP_UnitTestCase {
 		$this->assertCount( 0, $feed_parsing_test->current() );
 		$this->assertCount( 0, wp_get_post_revisions( $post_id ) );
 
-		$feed_parsing_test->send( new \SimplePie_File( __DIR__ . '/data/friend-feed-1-public-post-modified-title.rss' ) );
+		$feed_parsing_test->send( __DIR__ . '/data/friend-feed-1-public-post-modified-title.rss' );
 		$this->assertCount( 0, $feed_parsing_test->current() );
 		$this->assertCount( 1, wp_get_post_revisions( $post_id ) );
 	}
 
 	public function test_feed_item_revisions_modified_title_content() {
-		$feed_1_public_post = new \SimplePie_File( __DIR__ . '/data/friend-feed-1-public-post.rss' );
+		$feed_1_public_post = __DIR__ . '/data/friend-feed-1-public-post.rss';
 		$feed_parsing_test = $this->feed_parsing_test( $feed_1_public_post, new User( $this->alex ) );
 
 		$new_items = $feed_parsing_test->current();
@@ -323,11 +320,11 @@ class FeedTest extends \WP_UnitTestCase {
 		$this->assertCount( 0, $feed_parsing_test->current() );
 		$this->assertCount( 0, wp_get_post_revisions( $post_id ) );
 
-		$feed_parsing_test->send( new \SimplePie_File( __DIR__ . '/data/friend-feed-1-public-post-modified-title.rss' ) );
+		$feed_parsing_test->send( __DIR__ . '/data/friend-feed-1-public-post-modified-title.rss' );
 		$this->assertCount( 0, $feed_parsing_test->current() );
 		$this->assertCount( 1, wp_get_post_revisions( $post_id ) );
 
-		$feed_parsing_test->send( new \SimplePie_File( __DIR__ . '/data/friend-feed-1-public-post-modified-content.rss' ) );
+		$feed_parsing_test->send( __DIR__ . '/data/friend-feed-1-public-post-modified-content.rss' );
 		$this->assertCount( 0, $feed_parsing_test->current() );
 		$this->assertCount( 2, wp_get_post_revisions( $post_id ) );
 	}
@@ -514,7 +511,7 @@ class FeedTest extends \WP_UnitTestCase {
 	}
 
 	function test_external_comments() {
-		$zylstra = new \SimplePie_File( __DIR__ . '/data/zylstra.rss' );
+		$zylstra = __DIR__ . '/data/zylstra.rss';
 		$feed_parsing_test = $this->feed_parsing_test( $zylstra );
 
 		$new_items = $feed_parsing_test->current();
@@ -527,5 +524,86 @@ class FeedTest extends \WP_UnitTestCase {
 		$this->assertEquals( 6, $post->comment_count );
 
 		$this->assertEquals( 'https://www.zylstra.org/blog/2022/10/habet-machina-translatio-lingua-latina/feed/', get_post_meta( $post_id, Feed::COMMENTS_FEED_META, true ) );
+	}
+
+	function test_global_retention_count() {
+		$this->assertTrue( Friends::get_retention_number() > 10 );
+		$user = new User( $this->friend_id );
+
+		$feed = __DIR__ . '/data/friend-feed-10-posts.rss';
+		$feed_parsing_test = $this->feed_parsing_test( $feed, $user );
+
+		$new_items = $feed_parsing_test->current();
+		$this->assertCount( 10, $new_items );
+		$count = wp_count_posts( Friends::CPT );
+
+		$this->assertEquals( 10, $count->publish );
+		$this->assertTrue( Friends::get_retention_number() > 10 );
+
+		// Now we fetch it again, there are no posts.
+		$feed_parsing_test->send( $feed );
+
+		$new_items = $feed_parsing_test->current();
+			$this->assertCount( 0, $new_items );
+		$count = wp_count_posts( Friends::CPT );
+		$this->assertEquals( 10, $count->publish );
+
+		// Now we'll set the global retention and fetch again.
+		update_option( 'friends_retention_number', 10 );
+		$this->assertEquals( 10, Friends::get_retention_number() );
+
+		// We're just at the limit, so nothing should change.
+		$feed_parsing_test->send( $feed );
+		$new_items = $feed_parsing_test->current();
+		$this->assertCount( 0, $new_items );
+		$count = wp_count_posts( Friends::CPT );
+		$this->assertEquals( 10, $count->publish );
+
+		// Now we'll reduce the global retention and fetch again.
+		update_option( 'friends_retention_number', 9 );
+		$this->assertEquals( 9, Friends::get_retention_number() );
+
+		// It's not enabled, so nothing should change.
+		$feed_parsing_test->send( $feed );
+		$new_items = $feed_parsing_test->current();
+		$this->assertCount( 0, $new_items );
+		$count = wp_count_posts( Friends::CPT );
+		$this->assertEquals( 10, $count->publish );
+
+		update_option( 'friends_enable_retention_number', true );
+
+		// Now finally, it should go down to 9.
+		$feed_parsing_test->send( $feed );
+		$new_items = $feed_parsing_test->current();
+		$this->assertCount( 0, $new_items );
+		wp_cache_delete( _count_posts_cache_key( Friends::CPT, '' ), 'counts' );
+		$count = wp_count_posts( Friends::CPT );
+		$this->assertEquals( 9, $count->publish );
+
+		// No new items but one more than we had.
+		$feed_parsing_test->send( $feed );
+		$new_items = $feed_parsing_test->current();
+		$this->assertCount( 0, $new_items );
+		wp_cache_delete( _count_posts_cache_key( Friends::CPT, '' ), 'counts' );
+		$count = wp_count_posts( Friends::CPT );
+		$this->assertEquals( 9, $count->publish );
+
+		update_option( 'friends_enable_retention_number', false );
+
+		// Since retention limiting was disabled, it should go back up to 10.
+		$feed_parsing_test->send( $feed );
+		$new_items = $feed_parsing_test->current();
+		$this->assertCount( 1, $new_items );
+		wp_cache_delete( _count_posts_cache_key( Friends::CPT, '' ), 'counts' );
+		$count = wp_count_posts( Friends::CPT );
+		$this->assertEquals( 10, $count->publish );
+
+		// No new items but one more than we had.
+		$feed_parsing_test->send( $feed );
+		$new_items = $feed_parsing_test->current();
+		$this->assertCount( 0, $new_items );
+		wp_cache_delete( _count_posts_cache_key( Friends::CPT, '' ), 'counts' );
+		$count = wp_count_posts( Friends::CPT );
+		$this->assertEquals( 9, $count->publish );
 	}
 }

--- a/tests/test-messages.php
+++ b/tests/test-messages.php
@@ -64,10 +64,10 @@ class MessagesTest extends Friends_TestCase_Cache_HTTP {
 			update_option( 'friends_in_token_' . $this->friends_in_token, $this->friend_id );
 		}
 
-		$this->friends_out_token = wp_generate_password( 128, false );
-		update_user_option( $this->user_id, 'friends_in_token', $this->friends_out_token );
-		if ( update_user_option( $this->friend_id, 'friends_out_token', $this->friends_out_token ) ) {
-			update_option( 'friends_in_token_' . $this->friends_out_token, $this->user_id );
+		$friends_out_token = wp_generate_password( 128, false );
+		update_user_option( $this->user_id, 'friends_in_token', $friends_out_token );
+		if ( update_user_option( $this->friend_id, 'friends_out_token', $friends_out_token ) ) {
+			update_option( 'friends_in_token_' . $friends_out_token, $this->user_id );
 		}
 
 		add_filter(


### PR DESCRIPTION
You can now specify global retention settings:

![Screenshot 2023-01-10 at 12 33 00](https://user-images.githubusercontent.com/203408/211541452-3ac18a77-3697-4f23-9d44-6985442635ea.png)

This is also exposed on the individual friend page:
![Screenshot 2023-01-10 at 12 36 08](https://user-images.githubusercontent.com/203408/211541949-8be8ff97-7e99-4973-9d53-784066a1daec.png)

Or not, if they are not enabled:
![Screenshot 2023-01-10 at 12 37 18](https://user-images.githubusercontent.com/203408/211542154-c444ec85-9759-49ff-8b63-e7ad97271521.png)

This was discussed here:
- #162
- https://phoenixtrap.com/2023/01/09/wordpress-friends-retention/
- https://phoenixtrap.com/2023/01/08/re-wordpress-friends-activitypub-indieweb/
- https://burningbird.net/yet-more-wordpress-mastodon-activitypub-integration/
