### PR TITLE
Allow embedding friend posts in your own posts

### DIFF
--- a/includes/class-feed.php
+++ b/includes/class-feed.php
@@ -76,6 +76,7 @@ class Feed {
 
 		add_action( 'wp_insert_post', array( $this, 'invalidate_post_count_cache' ), 10, 2 );
 		add_action( 'oembed_request_post_id', array( $this, 'oembed_request_post_id' ), 10, 2 );
+		add_action( 'post_embed_url', array( $this, 'post_embed_url' ), 10, 2 );
 	}
 
 	/**
@@ -1101,31 +1102,61 @@ class Feed {
 	 * @return int Post ID, or 0 on failure.
 	 */
 	public function url_to_postid( $url, $author_id = false ) {
+		$post_types = Friends::get_frontend_post_types();
+		$args = $post_types;
+
 		global $wpdb;
+		$sql = sprintf(
+			'SELECT ID from ' . $wpdb->posts . ' WHERE post_type IN ( %s )',
+			implode( ',', array_fill( 0, count( $post_types ), '%s' ) )
+		);
+
 		if ( $author_id ) {
-			$post_id = $wpdb->get_var( $wpdb->prepare( 'SELECT ID from ' . $wpdb->posts . ' WHERE guid IN (%s, %s) AND post_author = %d LIMIT 1', $url, esc_attr( $url ), $author_id ) );
-		} else {
-			$post_id = $wpdb->get_var( $wpdb->prepare( 'SELECT ID from ' . $wpdb->posts . ' WHERE guid IN (%s, %s) LIMIT 1', $url, esc_attr( $url ) ) );
+			$args[] = $author_id;
+			$sql .= ' AND post_author = %d';
 		}
+
+		$sql .= 'AND guid IN (%s, %s) LIMIT 1';
+		$args[] = $url;
+		$args[] = esc_attr( $url );
+
+		$post_id = $wpdb->get_var(
+			$wpdb->prepare(
+				$sql, // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+				$args
+			)
+		);
 		return $post_id;
 	}
 
 	public function oembed_request_post_id( $post_id, $url ) {
 		if ( ! $post_id ) {
 			$post_id = $this->url_to_postid( $url );
-			remove_filter( 'oembed_response_data', 'get_oembed_response_data_rich', 10, 4 );
-			add_action( 'oembed_response_data', array( $this, 'oembed_response_data' ), 10, 4 );
 			global $wp_post_types;
 			$wp_post_types[ Friends::CPT ]->publicly_queryable = true;
 		}
 		return $post_id;
 	}
 
+	public function post_embed_url( $embed_url, $post ) {
+		if ( ! in_array( $post->post_type, Friends::get_frontend_post_types() ) ) {
+			return $embed_url;
+		}
+
+		return add_query_arg( 'url', $post->guid, rest_url( Rest::PREFIX . '/embed' ) );
+	}
+
 	public function oembed_response_data( $data, $post, $width, $height ) {
 		$data['width']  = absint( $width );
 		$data['height'] = absint( $height );
 		$data['type']   = 'rich';
-		$data['html']   = $post->post_content;
+
+		ob_start();
+		Friends::template_loader()->get_template_part( 'oembed/status', null, array( 'post' => $post ) );
+		$data['html'] = ob_get_contents();
+		ob_end_clean();
+
+		$data['html'] = '<p>' . wp_kses_post( $post->post_content ) . '</p>';
 		return $data;
 	}
 

--- a/includes/class-rest.php
+++ b/includes/class-rest.php
@@ -77,6 +77,15 @@ class REST {
 				'permission_callback' => '__return_true',
 			)
 		);
+		register_rest_route(
+			self::PREFIX,
+			'embed',
+			array(
+				'methods'             => 'GET',
+				'callback'            => array( $this, 'rest_embed_friend_post' ),
+				'permission_callback' => '__return_true',
+			)
+		);
 	}
 
 	/**
@@ -296,6 +305,30 @@ class REST {
 		return array(
 			'deleted' => true,
 		);
+	}
+
+	public function rest_embed_friend_post( $request ) {
+		if ( empty( $_GET['url'] ) ) {
+			return false;
+		}
+		$post_id = $this->friends->feed->url_to_postid( $_GET['url'] );
+		if ( empty( $post_id ) ) {
+			return false;
+		}
+
+		if ( ! in_array( get_post_type( $post_id ), Friends::get_frontend_post_types() ) ) {
+			return false;
+		}
+
+		enqueue_embed_scripts();
+		$post = get_post( $post_id );
+		$args = compact( 'post' );
+		setup_postdata( $post );
+
+		header( 'Content-type: text/html' );
+		Friends::template_loader()->get_template_part( 'embed/header-embed', null, $args );
+		Friends::template_loader()->get_template_part( 'embed/embed-content', null, $args );
+		exit;
 	}
 
 	/**

--- a/templates/embed/embed-content.php
+++ b/templates/embed/embed-content.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Copy of the post embed content template part
+ *
+ * When a post is embedded in an iframe, this file is used to create the content template part
+ * output if the active theme does not include an embed-content.php template.
+ *
+ * @package Friends
+ */
+
+?>
+	<div class="wp-embed">
+
+		<p class="wp-embed-heading">
+			<a href="<?php the_permalink(); ?>" target="_top">
+				<?php the_title(); ?>
+			</a>
+		</p>
+
+		<div class="wp-embed-excerpt"><?php echo wp_kses_post( get_the_content( null, false, $args['post'] ) ); ?></div>
+
+		<?php
+		/**
+		 * Prints additional content after the embed excerpt.
+		 *
+		 * @since 4.4.0
+		 */
+		do_action( 'embed_content' );
+		?>
+
+		<div class="wp-embed-footer">
+			<div class="wp-embed-site-title">
+				<a href="<?php the_permalink( $args['post'] ); ?>" target="_top">
+					<img src="<?php echo esc_url( $avatar ? $avatar : get_avatar_url( get_the_author_meta( 'ID' ) ) ); ?>" width="36" height="36" class="wp-embed-site-icon" />
+					<span><?php echo esc_html( get_the_author_meta( 'display_name' ) ); ?></span>
+				</a>
+			</div>
+
+			<div class="wp-embed-meta">
+				<?php
+				/**
+				 * Prints additional meta content in the embed template.
+				 *
+				 * @since 4.4.0
+				 */
+				do_action( 'embed_content_meta' );
+				?>
+			</div>
+		</div>
+	</div>
+<?php

--- a/templates/embed/header-embed.php
+++ b/templates/embed/header-embed.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Contains the post embed header template
+ *
+ * When a post is embedded in an iframe, this file is used to create the header output
+ * if the active theme does not include a header-embed.php template.
+ *
+ * @package WordPress
+ * @subpackage Theme_Compat
+ * @since 4.5.0
+ */
+
+if ( ! headers_sent() ) {
+	header( 'X-WP-embed: true' );
+}
+
+?>
+<!DOCTYPE html>
+<html <?php language_attributes(); ?> class="no-js">
+<head>
+	<title><?php echo esc_html( wp_get_document_title() ); ?></title>
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+	<?php
+	/**
+	 * Prints scripts or data in the embed template head tag.
+	 *
+	 * @since 4.4.0
+	 */
+	do_action( 'embed_head' );
+	?>
+</head>
+<body <?php body_class(); ?>>


### PR DESCRIPTION
By handling oEmbeds for Friend Posts, we can control how they appear: if you use Gutenberg and you embed a URL of a post that is in your database because you have subscribed to them via the Friends plugin, then we can handle the embed.

![friends-embed](https://user-images.githubusercontent.com/203408/213781974-c3843268-8686-4198-8af9-ffa18859ec81.gif)

cc @regenpfeifer