### PR TITLE
Added missing space to generated SQL query

### DIFF
--- a/includes/class-feed.php
+++ b/includes/class-feed.php
@@ -1116,7 +1116,7 @@ class Feed {
 			$sql .= ' AND post_author = %d';
 		}
 
-		$sql .= 'AND guid IN (%s, %s) LIMIT 1';
+		$sql .= ' AND guid IN (%s, %s) LIMIT 1';
 		$args[] = $url;
 		$args[] = esc_attr( $url );
 


### PR DESCRIPTION
Corrects a generated SQL query by adding a missing space.

Hopefully fixes #190.
