### PR TITLE
Don't override the ActivityPub plugin info

### DIFF
--- a/bin/generate-plugins-json.php
+++ b/bin/generate-plugins-json.php
@@ -31,22 +31,7 @@ $activitypub_last_update = array_reduce(
 	}
 );
 
-$json = array(
-	'activitypub' => array(
-		'name'              => 'ActivityPub',
-		'short_description' => 'Adds ActivityPub support to your blog. Be followed on Mastodon, follow people on Mastodon with the Friends plugin.',
-		'more_info'         => 'https://wordpress.org/plugins/activitypub/',
-		'author'            => '<a href=\'https://notiz.blog/\'>Matthias Pfefferle</a>',
-		'slug'              => 'activitypub',
-		'version'           => $activitypub_version,
-		'trunk'             => 'https://downloads.wordpress.org/plugin/activitypub.' . $activitypub_version . '.zip',
-		'download_link'     => 'https://downloads.wordpress.org/plugin/activitypub.' . $activitypub_version . '.zip',
-		'last_updated'      => $activitypub_last_update,
-		'sections'          => array(
-			'Description' => 'People can follow your blog on Mastodon and other federated platforms that support ActivityPub, and you can follow them in the Friends plugin.',
-		),
-	),
-);
+$json = array();
 foreach ( glob( __DIR__ . '/../../friends-*', GLOB_ONLYDIR ) as $dir ) {
 	$slug = basename( $dir );
 	if ( ! file_exists( "$dir/$slug.php" ) ) {

--- a/plugins.json
+++ b/plugins.json
@@ -1,18 +1,4 @@
 {
-    "activitypub": {
-        "name": "ActivityPub",
-        "short_description": "Adds ActivityPub support to your blog. Be followed on Mastodon, follow people on Mastodon with the Friends plugin.",
-        "more_info": "https://wordpress.org/plugins/activitypub/",
-        "author": "<a href='https://notiz.blog/'>Matthias Pfefferle</a>",
-        "slug": "activitypub",
-        "version": "0.15.0",
-        "trunk": "https://downloads.wordpress.org/plugin/activitypub.0.15.0.zip",
-        "download_link": "https://downloads.wordpress.org/plugin/activitypub.0.15.0.zip",
-        "last_updated": "2023-01-12",
-        "sections": {
-            "Description": "People can follow your blog on Mastodon and other federated platforms that support ActivityPub, and you can follow them in the Friends plugin."
-        }
-    },
     "friends-autoresolve-links": {
         "name": "Friends Autoresolve Links",
         "short_description": "Transform plaintext links of incoming content (especially t.co shortlinks) into rich(er) links.",

--- a/templates/admin/plugin-info.php
+++ b/templates/admin/plugin-info.php
@@ -19,6 +19,12 @@ $more_info_url = $api->more_info;
 
 		<div class="desc column-description">
 			<p><?php echo esc_html( $api->short_description ); ?></p>
+			<?php if ( isset( $api->comment ) ) : ?>
+			<p>
+				<strong><?php esc_html_e( 'Comment from the author of the Friends Plugin', 'friends' ); ?></strong><br/>
+				<?php echo esc_html( $api->comment ); ?>
+			</p>
+			<?php endif; ?>
 			<p class="authors">
 				<cite>
 					<?php
@@ -39,7 +45,7 @@ $more_info_url = $api->more_info;
 	<div class="plugin-card-bottom">
 		<a class="<?php echo esc_attr( $args['button_classes'] ); ?>" data-slug="<?php echo esc_attr( $api->slug ); ?>" data-name="<?php echo esc_attr( $api->name ); ?>" href="<?php echo esc_url( $args['install_url'] ); ?>" aria-label="<?php echo /* translators: %1$s is a plugin name, %2$s is a plugin version. */ esc_html( sprintf( __( 'Install %1$s %2$s now', 'friends' ), $api->name, $api->version ) ); ?>"><?php echo esc_html( $args['button_text'] ); ?></a>
 
-		<a class="button details" href="<?php echo esc_url( $more_info_url ); ?>" aria-label="<?php /* phpcs:ignore WordPress.WP.I18n.MissingArgDomain */ echo /* translators: %s is a plugin name. */ esc_html( sprintf( __( 'More information about %s' ), $api->name ) ); ?>" data-title="<?php echo esc_attr( $api->name ); ?>"><?php esc_html_e( 'More Details' ); ?></a>
+		<a class="button details thickbox open-plugin-details-modal" href="<?php echo esc_url( $more_info_url ); ?>" aria-label="<?php /* phpcs:ignore WordPress.WP.I18n.MissingArgDomain */ echo /* translators: %s is a plugin name. */ esc_html( sprintf( __( 'More information about %s' ), $api->name ) ); ?>" data-title="<?php echo esc_attr( $api->name ); ?>"><?php esc_html_e( 'More Details' ); ?></a>
 
 		<a class="button deactivate <?php echo esc_attr( $args['deactivate_button_class'] ); ?>"
 			data-slug="<?php echo esc_attr( $api->slug ); ?>"


### PR DESCRIPTION
We don't need to provide the details from plugins.json but we can easily take it from the WordPress.org API. Fixes #194. Sorry about that!