### PR TITLE
ActivityPub: Auto-approve comments by people you follow

### DIFF
--- a/feed-parsers/class-feed-parser-activitypub.php
+++ b/feed-parsers/class-feed-parser-activitypub.php
@@ -977,7 +977,7 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 	 * @return     bool    Whether the comment is approved.
 	 */
 	public function pre_comment_approved( $approved, $commentdata ) {
-		if ( ! $approved || is_string( $approved ) ) {
+		if ( ! $approved || is_string( $approved ) && 'activitypub' === $commentdata['comment_meta']['protocol'] ) {
 			$user_feed = User_Feed::get_by_url( $commentdata['comment_author_url'] );
 			if ( $user_feed instanceof User_Feed ) {
 				$approved = true;

--- a/feed-parsers/class-feed-parser-activitypub.php
+++ b/feed-parsers/class-feed-parser-activitypub.php
@@ -54,6 +54,8 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 		\add_action( 'friends_user_post_reaction', array( $this, 'post_reaction' ) );
 		\add_action( 'friends_user_post_undo_reaction', array( $this, 'undo_post_reaction' ) );
 
+		\add_filter( 'pre_comment_approved', array( $this, 'pre_comment_approved' ), 10, 2 );
+
 		\add_filter( 'pre_get_remote_metadata_by_actor', array( $this, 'disable_webfinger_for_example_domains' ), 9, 2 );
 	}
 
@@ -964,6 +966,24 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 				)
 			);
 		}
+	}
+
+	/**
+	 * Approve comments that
+	 *
+	 * @param      bool  $approved     Whether the comment is approved.
+	 * @param      array $commentdata  The commentdata.
+	 *
+	 * @return     bool    Whether the comment is approved.
+	 */
+	public function pre_comment_approved( $approved, $commentdata ) {
+		if ( ! $approved || is_string( $approved ) ) {
+			$user_feed = User_Feed::get_by_url( $commentdata['comment_author_url'] );
+			if ( $user_feed instanceof User_Feed ) {
+				$approved = true;
+			}
+		}
+		return $approved;
 	}
 
 	/**

--- a/includes/class-friends.php
+++ b/includes/class-friends.php
@@ -730,7 +730,7 @@ class Friends {
 						$post_count = $count;
 					} else {
 						foreach ( (array) $count as $post_status => $c ) {
-							$post_count->$post_status += $c;
+							$post_count->$post_status = ( isset( $post_count->$post_status ) ? $post_count->$post_status : 0 ) + $c;
 						}
 					}
 				}


### PR DESCRIPTION
When an incoming comment arrives via the ActivityPub protocol and we follow that person, auto-approve the comment.