### PR TITLE
Send ActivityPub activity for created comments

### DIFF
--- a/feed-parsers/activitypub/class-comment.php
+++ b/feed-parsers/activitypub/class-comment.php
@@ -1,0 +1,260 @@
+<?php
+/**
+ * ActivityPub Comment Model Class
+ *
+ * @package Activitypub
+ */
+
+namespace Activitypub\Model;
+
+/**
+ * ActivityPub Comment Model Class
+ *
+ * @author Alex Kirk
+ */
+class Comment extends Post {
+	/**
+	 * The WordPress Comment Object.
+	 *
+	 * @var \WP_Comment
+	 */
+	private $comment;
+
+	/**
+	 * The Post Author.
+	 *
+	 * @var string
+	 */
+	private $post_author;
+
+	/**
+	 * The Object ID.
+	 *
+	 * @var string
+	 */
+	private $id;
+
+	/**
+	 * The Object Summary
+	 *
+	 * @var string
+	 */
+	private $content;
+
+	/**
+	 * The Object Tags. This is usually the list of used Hashtags.
+	 *
+	 * @var array
+	 */
+	private $tags;
+
+	/**
+	 * The Onject Type
+	 *
+	 * @var string
+	 */
+	private $object_type;
+
+	/**
+	 * The Allowed Tags, used in the content.
+	 *
+	 * @var array
+	 */
+	private $allowed_tags = array(
+		'a'          => array(
+			'href'  => array(),
+			'title' => array(),
+			'class' => array(),
+			'rel'   => array(),
+		),
+		'br'         => array(),
+		'p'          => array(
+			'class' => array(),
+		),
+		'span'       => array(
+			'class' => array(),
+		),
+		'div'        => array(
+			'class' => array(),
+		),
+		'ul'         => array(),
+		'ol'         => array(),
+		'li'         => array(),
+		'strong'     => array(
+			'class' => array(),
+		),
+		'b'          => array(
+			'class' => array(),
+		),
+		'i'          => array(
+			'class' => array(),
+		),
+		'em'         => array(
+			'class' => array(),
+		),
+		'blockquote' => array(),
+		'cite'       => array(),
+	);
+
+	/**
+	 * Constructor
+	 *
+	 * @param  WP_Comment|int $comment  The comment.
+	 */
+	public function __construct( $comment ) {
+		$this->comment = \get_comment( $comment );
+		if ( ! is_wp_error( $this->comment ) ) {
+			parent::__construct( $this->comment->comment_post_ID );
+		}
+	}
+
+	/**
+	 * Magic function to implement getter and setter
+	 *
+	 * @param string $method The method.
+	 * @param string $params The parameters.
+	 *
+	 * @return mixed The variable.
+	 */
+	public function __call( $method, $params ) {
+		$var = \strtolower( \substr( $method, 4 ) );
+
+		if ( \strncasecmp( $method, 'get', 3 ) === 0 ) {
+			if ( empty( $this->$var ) && ! empty( $this->comment->$var ) ) {
+				return $this->comment->$var;
+			}
+			return $this->$var;
+		}
+
+		if ( \strncasecmp( $method, 'set', 3 ) === 0 ) {
+			$this->$var = $params[0];
+		}
+	}
+
+	/**
+	 * Converts this Object into an Array.
+	 *
+	 * @return array
+	 */
+	public function to_array() {
+		$array = array(
+			'id'           => $this->comment->comment_ID,
+			'type'         => $this->get_object_type(),
+			'published'    => \gmdate( 'Y-m-d\TH:i:s\Z', \strtotime( $this->comment->comment_date_gmt ) ),
+			'attributedTo' => \get_author_posts_url( $this->comment->user_id ),
+			'summary'      => $this->get_summary(),
+			'inReplyTo'    => \get_permalink( $this->comment->comment_post_ID ),
+			'content'      => $this->get_content(),
+			'contentMap'   => array(
+				\strstr( \get_locale(), '_', true ) => $this->get_content(),
+			),
+			'to'           => array( 'https://www.w3.org/ns/activitystreams#Public' ),
+			'cc'           => array( 'https://www.w3.org/ns/activitystreams#Public' ),
+			'attachment'   => $this->get_attachments(),
+			'tag'          => $this->get_tags(),
+		);
+
+		return \apply_filters( 'activitypub_post', $array, $this->post );
+	}
+
+
+	/**
+	 * Returns the ID of an Activity Object
+	 *
+	 * @return string
+	 */
+	public function get_id() {
+		if ( $this->id ) {
+			return $this->id;
+		}
+
+		if ( 'trash' === $this->comment->post_status ) {
+			$permalink = \get_post_meta( $this->comment->comment_post_ID, 'activitypub_canonical_url', true );
+		} else {
+			$permalink = \get_permalink( $this->comment->comment_post_ID );
+		}
+
+		$permalink .= '#comment-' . $this->comment->comment_ID;
+
+		$this->id = $permalink;
+
+		return $permalink;
+	}
+
+	/**
+	 * Returns a list of Image Attachments
+	 *
+	 * @return array
+	 */
+	public function get_attachments() {
+		return array();
+	}
+
+	/**
+	 * Returns a list of Tags, used in the Post
+	 *
+	 * @return array
+	 */
+	public function get_tags() {
+		if ( $this->tags ) {
+			return $this->tags;
+		}
+
+		$tags = array();
+
+		$mentions = apply_filters( 'activitypub_extract_mentions', array(), $this->comment->comment_content, $this );
+		if ( $mentions ) {
+			foreach ( $mentions as $mention => $url ) {
+				$tag = array(
+					'type' => 'Mention',
+					'href' => $url,
+					'name' => $mention,
+				);
+				$tags[] = $tag;
+			}
+		}
+
+		$this->tags = $tags;
+
+		return $tags;
+	}
+
+	/**
+	 * Returns the as2 object-type for a given post
+	 *
+	 * @return string the object-type
+	 */
+	public function get_object_type() {
+		if ( $this->object_type ) {
+			return $this->object_type;
+		}
+
+		$this->object_type = 'Note';
+
+		return $this->object_type;
+	}
+
+	/**
+	 * Returns the content for the ActivityPub Item.
+	 *
+	 * @return string the content
+	 */
+	public function get_content() {
+		if ( $this->content ) {
+			return $this->content;
+		}
+
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$content = $this->comment->comment_content;
+
+		$content = \wpautop( \wp_kses( $content, $this->allowed_tags ) );
+		$content = \trim( \preg_replace( '/[\n\r\t]/', '', $content ) );
+
+		$content = \apply_filters( 'activitypub_the_content', $content, $this->comment );
+		$content = \html_entity_decode( $content, \ENT_QUOTES, 'UTF-8' );
+
+		$this->content = $content;
+
+		return $content;
+	}
+}

--- a/feed-parsers/activitypub/class-comment.php
+++ b/feed-parsers/activitypub/class-comment.php
@@ -2,7 +2,7 @@
 /**
  * ActivityPub Comment Model Class
  *
- * @package Activitypub
+ * @package Friends
  */
 
 namespace Activitypub\Model;

--- a/feed-parsers/activitypub/class-comment.php
+++ b/feed-parsers/activitypub/class-comment.php
@@ -138,7 +138,7 @@ class Comment extends Post {
 	 */
 	public function to_array() {
 		$array = array(
-			'id'           => $this->comment->comment_ID,
+			'id'           => $this->get_id(),
 			'type'         => $this->get_object_type(),
 			'published'    => \gmdate( 'Y-m-d\TH:i:s\Z', \strtotime( $this->comment->comment_date_gmt ) ),
 			'attributedTo' => \get_author_posts_url( $this->comment->user_id ),
@@ -153,8 +153,14 @@ class Comment extends Post {
 			'attachment'   => $this->get_attachments(),
 			'tag'          => $this->get_tags(),
 		);
+		if ( $this->comment->comment_parent ) {
+			$source_url = get_comment_meta( $this->comment->comment_parent, 'source_url', true );
+			if ( $source_url ) {
+				$array['inReplyTo'] = $source_url;
+			}
+		}
 
-		return \apply_filters( 'activitypub_post', $array, $this->post );
+		return \apply_filters( 'activitypub_post', $array, $this->comment );
 	}
 
 
@@ -171,10 +177,8 @@ class Comment extends Post {
 		if ( 'trash' === $this->comment->post_status ) {
 			$permalink = \get_post_meta( $this->comment->comment_post_ID, 'activitypub_canonical_url', true );
 		} else {
-			$permalink = \get_permalink( $this->comment->comment_post_ID );
+			$permalink = \get_comment_link( $this->comment->comment_ID );
 		}
-
-		$permalink .= '#comment-' . $this->comment->comment_ID;
 
 		$this->id = $permalink;
 

--- a/feed-parsers/activitypub/class-comment.php
+++ b/feed-parsers/activitypub/class-comment.php
@@ -177,7 +177,7 @@ class Comment extends Post {
 		if ( 'trash' === $this->comment->post_status ) {
 			$permalink = \get_post_meta( $this->comment->comment_post_ID, 'activitypub_canonical_url', true );
 		} else {
-			$permalink = \get_comment_link( $this->comment->comment_ID );
+			$permalink = add_query_arg( 'c', $this->comment->comment_ID, \home_url() );
 		}
 
 		$this->id = $permalink;
@@ -260,5 +260,9 @@ class Comment extends Post {
 		$this->content = $content;
 
 		return $content;
+	}
+
+	public function get_post_author() {
+		return $this->comment->user_id;
 	}
 }

--- a/feed-parsers/activitypub/class-virtual-user-feed.php
+++ b/feed-parsers/activitypub/class-virtual-user-feed.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * Virtual User Feed Class
+ *
+ * @package Friends
+ */
+
+namespace Friends;
+
+/**
+ * Virtual User Feed Class
+ *
+ * @author Alex Kirk
+ */
+class Virtual_User_Feed extends User_Feed {
+	private $friend_user;
+	private $title;
+
+	public function __construct( User $friend_user, $title ) {
+		$this->friend_user = $friend_user;
+		$this->title = $title;
+	}
+	public function __toString() {
+
+	}
+	public function get_id() {
+		return 'virtual-user-feed-' . $this->friend_user->get_id();
+	}
+	public function get_url() {
+		return null;
+	}
+	public function get_private_url( $validity = 3600 ) {
+		return null;
+	}
+	public function get_friend_user() {
+		return $this->friend_user;
+	}
+	public function get_active() {
+		return array();
+	}
+	public function get_post_format() {
+		return 'status';
+	}
+	public function get_parser() {
+		return 'virtual';
+	}
+	public function get_mime_type() {
+		return '';
+	}
+	public function get_title() {
+		return $this->title;
+	}
+	public function get_last_log() {
+		return '';
+	}
+	public function is_active() {
+		return true;
+	}
+	public function get_interval() {
+		return 0;
+	}
+	public function get_modifier() {
+		return 0;
+	}
+	public function get_next_poll() {
+		return 0;
+	}
+	public function was_polled() {
+		return false;
+	}
+	public function activate() {
+		return true;
+	}
+	public function deactivate() {
+		return false;
+	}
+	public function delete() {
+		return false;
+	}
+	public function get_metadata( $key ) {
+		return null;
+	}
+	public function update_metadata( $key, $value ) {
+		return $value;
+	}
+	public function delete_metadata( $key ) {
+		return null;
+	}
+	public function update_last_log( $value ) {
+	}
+
+}

--- a/feed-parsers/class-feed-parser-activitypub.php
+++ b/feed-parsers/class-feed-parser-activitypub.php
@@ -415,6 +415,8 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 			);
 
 			$user = new User( $user_id );
+		} else {
+			$user = new User( $user->ID );
 		}
 		return $user;
 	}

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -1477,7 +1477,7 @@ class Admin {
 
 		if ( isset( $_POST['_wpnonce'] ) && wp_verify_nonce( $_POST['_wpnonce'], 'unfriend-' . $friend->ID ) ) {
 			if ( is_multisite() ) {
-				remote_user_from_blog( $friend->ID, get_current_blog_id() );
+				remove_user_from_blog( $friend->ID, get_current_blog_id() );
 			} else {
 				wp_delete_user( $friend->ID );
 			}

--- a/includes/class-frontend.php
+++ b/includes/class-frontend.php
@@ -588,6 +588,8 @@ class Frontend {
 		if ( empty( $comments ) && ( is_wp_error( $feed_comments ) || ! is_array( $feed_comments ) ) ) {
 			wp_send_json_error( '<small>' . __( 'Unfortunately, comments were not available via RSS.', 'friends' ) . '</small>' );
 			exit;
+		} elseif ( is_wp_error( $feed_comments ) ) {
+			$feed_comments = array();
 		}
 
 		$template_loader = Friends::template_loader();

--- a/includes/class-frontend.php
+++ b/includes/class-frontend.php
@@ -564,11 +564,17 @@ class Frontend {
 		$post_id = intval( $_POST['post_id'] );
 		check_ajax_referer( "comments-$post_id" );
 
+		$comments = get_comments(
+			array(
+				'post_id' => $post_id,
+			)
+		);
+
 		$author_id = get_post_field( 'post_author', $post_id );
 		$friend_user = new User( $author_id );
 
 		$comments_url = get_post_meta( $post_id, Feed::COMMENTS_FEED_META, true );
-		if ( ! $comments_url ) {
+		if ( $comments_url && empty( $comments ) ) {
 			wp_send_json_error( __( 'No comments feed available.', 'friends' ) );
 			exit;
 		}
@@ -578,8 +584,8 @@ class Frontend {
 			$comments_url = $this->friends->access_control->append_auth( $comments_url, $friend_user, 300 );
 		}
 
-		$comments = $this->friends->feed->preview( 'simplepie', $comments_url );
-		if ( is_wp_error( $comments ) || ! is_array( $comments ) ) {
+		$feed_comments = $this->friends->feed->preview( 'simplepie', $comments_url );
+		if ( empty( $comments ) && ( is_wp_error( $feed_comments ) || ! is_array( $feed_comments ) ) ) {
 			wp_send_json_error( '<small>' . __( 'Unfortunately, comments were not available via RSS.', 'friends' ) . '</small>' );
 			exit;
 		}
@@ -590,6 +596,18 @@ class Frontend {
 		<h5><?php esc_html_e( 'Comments' ); /* phpcs:ignore WordPress.WP.I18n.MissingArgDomain */ ?></h5>
 		<?php
 		foreach ( $comments as $comment ) {
+			$template_loader->get_template_part(
+				'frontend/parts/comment',
+				null,
+				array(
+					'author'       => $comment->comment_author,
+					'date'         => $comment->comment_date,
+					'permalink'    => $comment->guid . '#comment-' . $comment->comment_ID,
+					'post_content' => $comment->comment_content,
+				)
+			);
+		}
+		foreach ( $feed_comments as $comment ) {
 			$template_loader->get_template_part(
 				'frontend/parts/comment',
 				null,


### PR DESCRIPTION
When you comment on someone else's post (for example via https://github.com/akirk/enable-mastodon-apps/pull/3), we send it to them via ActivityPub.