### PR TITLE
Don't create a user when only following someone

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ There is a cache of your friends post in form of a Custom Post Type friend_post 
 
 ## Changelog
 
-### 2.5.3
-- Don't create a user when only following someone ([#215])
+### 2.6.0
+- Don't create a user when only following someone ([#215]). This means that if you only want to use the Friends plugin to follow people, it will no longer create a user for each follow.
 
 ### 2.5.3
 - Add a new Reply To field to the Status post form ([#210]), also see the related update to the Firefox extension at https://addons.mozilla.org/addon/wpfriends/

--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ There is a cache of your friends post in form of a Custom Post Type friend_post 
 ## Changelog
 
 ### 2.5.3
+- Don't create a user when only following someone ([#215])
+
+### 2.5.3
 - Add a new Reply To field to the Status post form ([#210]), also see the related update to the Firefox extension at https://addons.mozilla.org/addon/wpfriends/
 - Fix a Fatal regarding ActivityPub metadata
 
@@ -208,6 +211,7 @@ There is a cache of your friends post in form of a Custom Post Type friend_post 
 - Add Emoji reactions
 - Add blog to blog messaging
 
+[#215]: https://github.com/akirk/friends/pull/215
 [#210]: https://github.com/akirk/friends/pull/210
 [#206]: https://github.com/akirk/friends/pull/206
 [#205]: https://github.com/akirk/friends/pull/205

--- a/feed-parsers/class-feed-parser-activitypub.php
+++ b/feed-parsers/class-feed-parser-activitypub.php
@@ -1447,7 +1447,7 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 	}
 
 	public function friends_reblog_button_label( $button_label ) {
-		if ( get_post_meta( get_the_ID(), 'parser', true ) === 'activitypub' ) {
+		if ( User_Feed::get_parser_for_post_id( get_the_ID() ) === 'activitypub' ) {
 			if ( get_user_option( 'friends_activitypub_dont_reblog' ) ) {
 				$button_label = _x( 'Boost', 'button', 'friends' );
 			} else {
@@ -1495,7 +1495,7 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 			return $ret;
 		}
 
-		if ( get_post_meta( $post->ID, 'parser', true ) !== 'activitypub' ) {
+		if ( User_Feed::get_parser_for_post_id( $post->ID ) !== 'activitypub' ) {
 			return $ret;
 		}
 
@@ -1508,7 +1508,7 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 		if ( ! $post ) {
 			return $ret;
 		}
-		if ( get_post_meta( $post->ID, 'parser', true ) === 'activitypub' ) {
+		if ( User_Feed::get_parser_for_post_id( $post->ID ) === 'activitypub' ) {
 			$this->queue_announce( $post->guid );
 			\update_post_meta( $post->ID, 'reblogged', 'activitypub' );
 			\update_post_meta( $post->ID, 'reblogged_by', get_current_user_id() );

--- a/feed-parsers/class-feed-parser-activitypub.php
+++ b/feed-parsers/class-feed-parser-activitypub.php
@@ -1124,7 +1124,7 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 	}
 
 	public function activitypub_save_settings( User $friend ) {
-		if ( isset( $_POST['_wpnonce'] ) && wp_verify_nonce( $_POST['_wpnonce'], 'edit-friend-feeds-' . $friend->ID ) ) {
+		if ( isset( $_POST['_wpnonce'] ) && wp_verify_nonce( $_POST['_wpnonce'], 'edit-friend-feeds-' . $friend->user_login ) ) {
 
 			if ( isset( $_POST['friends_show_replies'] ) && $_POST['friends_show_replies'] ) {
 				$friend->update_user_option( 'activitypub_friends_show_replies', '1' );

--- a/friends-admin.css
+++ b/friends-admin.css
@@ -214,3 +214,39 @@ span#friends_enable_retention_number_line {
 #wpadminbar li#wp-admin-bar-friends {
 	display: block;
 }
+@keyframes loading{
+	0% {
+		transform: rotate(0deg);
+	}
+	100% {
+		transform: rotate(360deg);
+	}
+}
+.friends-loading {
+	color: rgba(0,0,0,0) !important;
+	min-height: .8rem;
+	pointer-events: none;
+	position: relative;
+	margin-left: 1em;
+}
+
+.friends-loading::after{
+	animation: loading 500ms infinite linear;
+	background: rgba(0,0,0,0);
+	border: .1rem solid #2e5bec;
+	border-radius: 50%;
+	border-right-color: rgba(0,0,0,0);
+	border-top-color: rgba(0,0,0,0);
+	content: "";
+	display: block;
+	height: .8rem;
+	left: 50%;
+	margin-left: -0.4rem;
+	margin-top: -0.4rem;
+	opacity: 1;
+	padding: 0;
+	position: absolute;
+	top: 50%;
+	width: .8rem;
+	z-index: 1;
+}

--- a/friends-admin.js
+++ b/friends-admin.js
@@ -323,4 +323,28 @@ jQuery( function ( $ ) {
 		);
 		return false;
 	} );
+
+	if ( $( '#fetch-feeds' ).length ) {
+		$( '#fetch-feeds' ).append( ' <i class="friends-loading"></i>' );
+		$.post(
+			friends.ajax_url,
+			{
+				friend: $( '#fetch-feeds' ).data( 'friend' ),
+				_ajax_nonce: $( '#fetch-feeds' ).data( 'nonce' ),
+				action: 'friends_fetch_feeds',
+			},
+			function ( response ) {
+				if ( response.success ) {
+					$( '#fetch-feeds i' )
+						.removeClass( 'friends-loading' )
+						.addClass( 'dashicons dashicons-saved' );
+				} else {
+					$( '#fetch-feeds i' )
+						.removeClass( 'friends-loading' )
+						.addClass( 'dashicons dashicons-warning' )
+						.prop( 'title', response.data );
+				}
+			}
+		);
+	}
 } );

--- a/friends-admin.js
+++ b/friends-admin.js
@@ -324,27 +324,29 @@ jQuery( function ( $ ) {
 		return false;
 	} );
 
-	if ( $( '#fetch-feeds' ).length ) {
-		$( '#fetch-feeds' ).append( ' <i class="friends-loading"></i>' );
-		$.post(
-			friends.ajax_url,
-			{
-				friend: $( '#fetch-feeds' ).data( 'friend' ),
-				_ajax_nonce: $( '#fetch-feeds' ).data( 'nonce' ),
-				action: 'friends_fetch_feeds',
-			},
-			function ( response ) {
-				if ( response.success ) {
-					$( '#fetch-feeds i' )
-						.removeClass( 'friends-loading' )
-						.addClass( 'dashicons dashicons-saved' );
-				} else {
-					$( '#fetch-feeds i' )
-						.removeClass( 'friends-loading' )
-						.addClass( 'dashicons dashicons-warning' )
-						.prop( 'title', response.data );
+	setTimeout( function () {
+		if ( $( '#fetch-feeds' ).length ) {
+			$( '#fetch-feeds' ).append( ' <i class="friends-loading"></i>' );
+			$.post(
+				friends.ajax_url,
+				{
+					friend: $( '#fetch-feeds' ).data( 'friend' ),
+					_ajax_nonce: $( '#fetch-feeds' ).data( 'nonce' ),
+					action: 'friends_fetch_feeds',
+				},
+				function ( response ) {
+					if ( response.success ) {
+						$( '#fetch-feeds i' )
+							.removeClass( 'friends-loading' )
+							.addClass( 'dashicons dashicons-saved' );
+					} else {
+						$( '#fetch-feeds i' )
+							.removeClass( 'friends-loading' )
+							.addClass( 'dashicons dashicons-warning' )
+							.prop( 'title', response.data );
+					}
 				}
-			}
-		);
-	}
+			);
+		}
+	}, 500 );
 } );

--- a/friends-admin.js
+++ b/friends-admin.js
@@ -100,7 +100,7 @@ jQuery( function ( $ ) {
 
 	const previewRules = function () {
 		const $this = $( 'button#refresh-preview-rules' );
-		let url = friends.ajax_url + '?user=' + $this.data( 'id' );
+		let url = friends.ajax_url + '?user=' + $this.data( 'friend' );
 		if ( $this.data( 'post' ) ) {
 			url += '&post=' + $this.data( 'post' );
 		}
@@ -111,7 +111,7 @@ jQuery( function ( $ ) {
 				.serialize() +
 				'&_ajax_nonce=' +
 				$this.data( 'nonce' ) +
-				'&action=friends_previewRules',
+				'&action=friends_preview_rules',
 			function ( response ) {
 				$( '#preview-rules' ).html( response );
 			}

--- a/friends.php
+++ b/friends.php
@@ -3,7 +3,7 @@
  * Plugin name: Friends
  * Plugin author: Alex Kirk
  * Plugin URI: https://github.com/akirk/friends
- * Version: 2.5.3
+ * Version: 2.5.4
  *
  * Description: A social network between WordPresses. Privacy focused, by itself a self-hosted RSS++ reader with notifications.
  *
@@ -24,7 +24,7 @@ defined( 'ABSPATH' ) || exit;
 define( 'FRIENDS_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'FRIENDS_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
 define( 'FRIENDS_PLUGIN_FILE', plugin_dir_path( __FILE__ ) . '/' . basename( __FILE__ ) );
-define( 'FRIENDS_VERSION', '2.5.3' );
+define( 'FRIENDS_VERSION', '2.5.4' );
 
 require_once __DIR__ . '/libs/Mf2/Parser.php';
 require_once __DIR__ . '/libs/blocks-everywhere/blocks-everywhere.php';

--- a/friends.php
+++ b/friends.php
@@ -58,7 +58,7 @@ require_once __DIR__ . '/includes/class-friends.php';
 
 add_action( 'plugins_loaded', array( __NAMESPACE__ . '\Friends', 'init' ) );
 add_action( 'admin_init', array( __NAMESPACE__ . '\Plugin_Installer', 'register_hooks' ) );
-add_action( 'upgrader_process_complete', array( __NAMESPACE__ . '\Friends', 'upgrade_plugin' ) );
+add_action( 'upgrader_process_complete', array( __NAMESPACE__ . '\Friends', 'upgrade_plugin' ), 10, 2 );
 register_activation_hook( __FILE__, array( __NAMESPACE__ . '\Friends', 'activate_plugin' ) );
 register_deactivation_hook( __FILE__, array( __NAMESPACE__ . '\Friends', 'deactivate_plugin' ) );
 register_uninstall_hook( __FILE__, array( __NAMESPACE__ . '\Friends', 'uninstall_plugin' ) );

--- a/friends.php
+++ b/friends.php
@@ -3,7 +3,7 @@
  * Plugin name: Friends
  * Plugin author: Alex Kirk
  * Plugin URI: https://github.com/akirk/friends
- * Version: 2.5.4
+ * Version: 2.6.0
  *
  * Description: A social network between WordPresses. Privacy focused, by itself a self-hosted RSS++ reader with notifications.
  *
@@ -24,7 +24,7 @@ defined( 'ABSPATH' ) || exit;
 define( 'FRIENDS_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'FRIENDS_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
 define( 'FRIENDS_PLUGIN_FILE', plugin_dir_path( __FILE__ ) . '/' . basename( __FILE__ ) );
-define( 'FRIENDS_VERSION', '2.5.4' );
+define( 'FRIENDS_VERSION', '2.6.0' );
 
 require_once __DIR__ . '/libs/Mf2/Parser.php';
 require_once __DIR__ . '/libs/blocks-everywhere/blocks-everywhere.php';

--- a/friends.php
+++ b/friends.php
@@ -32,6 +32,7 @@ require_once __DIR__ . '/libs/blocks-everywhere/blocks-everywhere.php';
 require_once __DIR__ . '/includes/class-user.php';
 require_once __DIR__ . '/includes/class-user-feed.php';
 require_once __DIR__ . '/includes/class-user-query.php';
+require_once __DIR__ . '/includes/class-subscription.php';
 
 // Classes to be implemented or used by parser plugins.
 require_once __DIR__ . '/feed-parsers/class-feed-parser.php';

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -1258,20 +1258,20 @@ class Admin {
 		$arg       = 'updated';
 		$arg_value = 1;
 
-		if ( isset( $_POST['_wpnonce'] ) && wp_verify_nonce( $_POST['_wpnonce'], 'edit-friend-notifications-' . $friend->ID ) ) {
+		if ( isset( $_POST['_wpnonce'] ) && wp_verify_nonce( $_POST['_wpnonce'], 'edit-friend-notifications-' . $friend->user_login ) ) {
 			if ( ! get_user_option( 'friends_no_new_post_notification' ) ) {
 				if ( isset( $_POST['friends_new_post_notification'] ) && $_POST['friends_new_post_notification'] ) {
-					delete_user_option( get_current_user_id(), 'friends_no_new_post_notification_' . $friend->ID );
+					delete_user_option( get_current_user_id(), 'friends_no_new_post_notification_' . $friend->user_login );
 				} else {
-					update_user_option( get_current_user_id(), 'friends_no_new_post_notification_' . $friend->ID, 1 );
+					update_user_option( get_current_user_id(), 'friends_no_new_post_notification_' . $friend->user_login, 1 );
 				}
 			}
 
 			if ( ! get_user_option( 'friends_no_keyword_notification' ) ) {
 				if ( isset( $_POST['friends_keyword_notification'] ) && $_POST['friends_keyword_notification'] ) {
-					delete_user_option( get_current_user_id(), 'friends_no_keyword_notification_' . $friend->ID );
+					delete_user_option( get_current_user_id(), 'friends_no_keyword_notification_' . $friend->user_login );
 				} else {
-					update_user_option( get_current_user_id(), 'friends_no_keyword_notification_' . $friend->ID, 1 );
+					update_user_option( get_current_user_id(), 'friends_no_keyword_notification_' . $friend->user_login, 1 );
 				}
 			}
 
@@ -1330,13 +1330,13 @@ class Admin {
 				$hide_from_friends_page = array();
 			}
 			if ( ! isset( $_POST['show_on_friends_page'] ) || ! $_POST['show_on_friends_page'] ) {
-				if ( ! in_array( $friend->ID, $hide_from_friends_page ) ) {
-					$hide_from_friends_page[] = $friend->ID;
+				if ( ! in_array( $friend->user_login, $hide_from_friends_page ) ) {
+					$hide_from_friends_page[] = $friend->user_login;
 					update_user_option( get_current_user_id(), 'friends_hide_from_friends_page', $hide_from_friends_page );
 				}
 			} else {
-				if ( in_array( $friend->ID, $hide_from_friends_page ) ) {
-					$hide_from_friends_page = array_values( array_diff( $hide_from_friends_page, array( $friend->ID ) ) );
+				if ( in_array( $friend->user_login, $hide_from_friends_page ) ) {
+					$hide_from_friends_page = array_values( array_diff( $hide_from_friends_page, array( $friend->user_login ) ) );
 					update_user_option( get_current_user_id(), 'friends_hide_from_friends_page', $hide_from_friends_page );
 				}
 			}

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -444,7 +444,7 @@ class Admin {
 			return $link;
 		}
 
-		return self_admin_url( 'admin.php?page=edit-friend&user=' . $user->ID );
+		return self_admin_url( 'admin.php?page=edit-friend&user=' . $user->user_login );
 	}
 
 	public static function get_edit_friend_link( $user_id ) {
@@ -1284,7 +1284,7 @@ class Admin {
 		$arg       = 'updated';
 		$arg_value = 1;
 
-		if ( isset( $_POST['_wpnonce'] ) && wp_verify_nonce( $_POST['_wpnonce'], 'edit-friend-feeds-' . $friend->ID ) ) {
+		if ( isset( $_POST['_wpnonce'] ) && wp_verify_nonce( $_POST['_wpnonce'], 'edit-friend-feeds-' . $friend->user_login ) ) {
 			$hide_from_friends_page = get_user_option( 'friends_hide_from_friends_page' );
 			if ( ! $hide_from_friends_page ) {
 				$hide_from_friends_page = array();
@@ -2248,7 +2248,7 @@ class Admin {
 
 		if ( is_multisite() ) {
 			// phpcs:ignore WordPress.WP.I18n.MissingArgDomain
-			$actions = array_merge( array( 'edit' => '<a href="' . esc_url( self_admin_url( 'admin.php?page=edit-friend&user=' . $user->ID ) ) . '">' . __( 'Edit' ) . '</a>' ), $actions );
+			$actions = array_merge( array( 'edit' => '<a href="' . esc_url( self_admin_url( 'admin.php?page=edit-friend&user=' . $user->user_login ) ) . '">' . __( 'Edit' ) . '</a>' ), $actions );
 		}
 
 		// Ensuire we have a friends user here.
@@ -2285,7 +2285,7 @@ class Admin {
 		}
 
 		if ( $user->has_cap( 'pending_friend_request' ) || $user->has_cap( 'subscription' ) ) {
-			$link = wp_nonce_url( add_query_arg( '_wp_http_referer', urlencode( wp_unslash( $_SERVER['REQUEST_URI'] ) ), self_admin_url( 'admin.php?page=edit-friend&user=' . $user->ID ) ), 'add-friend-' . $user->ID, 'add-friend' );
+			$link = wp_nonce_url( add_query_arg( '_wp_http_referer', urlencode( wp_unslash( $_SERVER['REQUEST_URI'] ) ), self_admin_url( 'admin.php?page=edit-friend&user=' . $user->user_login ) ), 'add-friend-' . $user->user_login, 'add-friend' );
 			if ( $user->has_cap( 'pending_friend_request' ) ) {
 				$actions['user_friend_request'] = '<a href="' . esc_url( $link ) . '">' . __( 'Resend Friend Request', 'friends' ) . '</a>';
 			} elseif ( $user->has_cap( 'subscription' ) ) {

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -431,12 +431,14 @@ class Admin {
 	/**
 	 * Don't show the edit link for friend posts
 	 *
-	 * @param  string $link    The edit link.
-	 * @param  int    $user_id The user id.
+	 * @param  string   $link    The edit link.
+	 * @param  int|User $user The user.
 	 * @return string|bool The edit link or false.
 	 */
-	public static function admin_edit_user_link( $link, $user_id ) {
-		$user = new \WP_User( $user_id );
+	public static function admin_edit_user_link( $link, $user ) {
+		if ( ! $user instanceof \WP_User ) {
+			$user = new \WP_User( $user );
+		}
 		if ( is_multisite() && is_super_admin( $user->ID ) ) {
 			return $link;
 		}
@@ -2745,6 +2747,11 @@ class Admin {
 		// Allow unsubscribing to all these feeds.
 		foreach ( $friend_user->get_active_feeds() as $feed ) {
 			do_action( 'friends_user_feed_deactivated', $feed );
+			$feed->delete();
+		}
+
+		// Delete the rest.
+		foreach ( $friend_user->get_feeds() as $feed ) {
 			$feed->delete();
 		}
 

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -438,8 +438,13 @@ class Admin {
 	 */
 	public static function admin_edit_user_link( $link, $user ) {
 		if ( ! $user instanceof \WP_User ) {
-			$user = new \WP_User( $user );
+			if ( is_string( $user ) ) {
+				$user = User::get_by_username( $user );
+			} else {
+				$user = new \WP_User( $user );
+			}
 		}
+
 		if ( is_multisite() && is_super_admin( $user->ID ) ) {
 			return $link;
 		}
@@ -1704,7 +1709,7 @@ class Admin {
 				echo wp_kses( $message, array( 'a' => array( 'href' => array() ) ) );
 				// translators: %s is the friends page URL.
 				echo ' ', wp_kses( sprintf( __( 'Go to your <a href=%s>friends page</a> to view their posts.', 'friends' ), '"' . esc_url( $friend_user->get_local_friends_page_url() ) . '"' ), array( 'a' => array( 'href' => array() ) ) );
-				echo ' <span data-nonce="', esc_attr( wp_create_nonce( 'fetch-feeds-' . $friend_user->user_login ) ), '" data-friend=', esc_attr( $friend_user->user_login ), '>', __( 'Fetching feeds...', 'friends' ), '</span>';
+				echo ' <span id="fetch-feeds" data-nonce="', esc_attr( wp_create_nonce( 'fetch-feeds-' . $friend_user->user_login ) ), '" data-friend=', esc_attr( $friend_user->user_login ), '>', __( 'Fetching feeds...', 'friends' ), '</span>';
 				?>
 			</p></div>
 			<?php
@@ -1769,7 +1774,7 @@ class Admin {
 		$rest_url = false;
 
 		if ( ( isset( $vars['step2'] ) && isset( $vars['feeds'] ) && is_array( $vars['feeds'] ) ) || isset( $vars['step3'] ) ) {
-			$friend_user_login = sanitize_user( $vars['user_login'] );
+			$friend_user_login = str_replace( ' ', '-', sanitize_user( $vars['user_login'] ) );
 			$friend_display_name = sanitize_text_field( $vars['display_name'] );
 			if ( ! $friend_user_login ) {
 				// phpcs:ignore WordPress.WP.I18n.MissingArgDomain

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -1063,14 +1063,15 @@ class Admin {
 
 		if ( isset( $_GET['convert-to-user'] ) && wp_verify_nonce( $_GET['convert-to-user'], 'convert-to-user-' . $friend->user_login ) ) {
 			if ( $friend instanceof Subscription ) {
-				if ( $friend->has_cap( 'friends_plugin' ) && ! $friend->has_cap( 'friend' ) ) {
-					Subscription::convert_to_user( $friend );
-				}
+				Subscription::convert_to_user( $friend );
 			}
 		} elseif ( isset( $_GET['convert-from-user'] ) && wp_verify_nonce( $_GET['convert-from-user'], 'convert-from-user-' . $friend->user_login ) ) {
 			if ( $friend instanceof User && ! $friend instanceof Subscription ) {
-				if ( $friend->has_cap( 'friends_plugin' ) && ! $friend->has_cap( 'friend' ) ) {
+				if ( $friend->has_cap( 'friends_plugin' ) && ! $friend->has_cap( 'friend' ) && ! $friend->has_cap( 'pending_friend_request' ) && ! $friend->has_cap( 'friend_request' ) ) {
 					Subscription::convert_from_user( $friend );
+				} else {
+					$arg = 'error';
+					$arg_value = __( 'A friend cannot be converted to a virtual user.', 'friends' );
 				}
 			}
 		} elseif ( isset( $_GET['accept-friend-request'] ) && wp_verify_nonce( $_GET['accept-friend-request'], 'accept-friend-request-' . $friend->user_login ) ) {
@@ -1143,7 +1144,7 @@ class Admin {
 		}
 
 		if ( isset( $_GET['_wp_http_referer'] ) ) {
-			wp_safe_redirect( wp_get_referer() );
+			wp_safe_redirect( add_query_arg( $arg, $arg_value, wp_get_referer() ) );
 		} else {
 			wp_safe_redirect( add_query_arg( $arg, $arg_value, remove_query_arg( array( '_wp_http_referer', '_wpnonce' ), wp_unslash( $_SERVER['REQUEST_URI'] ) ) ) );
 		}

--- a/includes/class-feed.php
+++ b/includes/class-feed.php
@@ -929,7 +929,7 @@ class Feed {
 			// Backfill titles.
 			if ( empty( $feed['title'] ) ) {
 				$host = wp_parse_url( $link_url, PHP_URL_HOST );
-				if ( trim( $path, '/' ) ) {
+				if ( is_string( $path ) && trim( $path, '/' ) ) {
 					$feed['title'] = trim( preg_replace( '#^www\.#i', '', preg_replace( '#[^a-z0-9.:-]#i', ' ', ucwords( $host . ': ' . $path ) ) ), ': ' );
 				} else {
 					$feed['title'] = strtolower( $host );

--- a/includes/class-feed.php
+++ b/includes/class-feed.php
@@ -539,6 +539,10 @@ class Feed {
 			}
 			$item->permalink = str_replace( array( '&#38;', '&#038;' ), '&', ent2ncr( wp_kses_normalize_entities( $item->permalink ) ) );
 
+			if ( empty( $item->post_content ) ) {
+				$item->post_content = '';
+			}
+
 			$item->post_content = wp_kses_post( trim( $item->post_content ) );
 
 			$item = apply_filters( 'friends_early_modify_feed_item', $item, $user_feed, $friend_user );

--- a/includes/class-feed.php
+++ b/includes/class-feed.php
@@ -606,7 +606,7 @@ class Feed {
 						if ( intval( $old_post->comment_count ) !== intval( $item->comment_count ) ) {
 							$modified_post_data['comment_count'] = $item->comment_count;
 						}
-						wp_update_post( $modified_post_data );
+						$friend_user->save_post( $modified_post_data );
 						$modified_posts[] = $post_id;
 					}
 				}

--- a/includes/class-feed.php
+++ b/includes/class-feed.php
@@ -616,7 +616,7 @@ class Feed {
 				$post_data['post_content'] = str_replace( '\\', '\\\\', $post_data['post_content'] );
 				$post_data['meta_input'] = $item->meta;
 
-				$post_id = $friend_user->save_post( $post_data, true );
+				$post_id = $friend_user->insert_post( $post_data, true );
 				if ( is_wp_error( $post_id ) ) {
 					continue;
 				}

--- a/includes/class-feed.php
+++ b/includes/class-feed.php
@@ -264,38 +264,13 @@ class Feed {
 	 * @param      bool $force  Whether to force retrieval.
 	 */
 	public function retrieve_friend_posts( $force = false ) {
-		$friends = new User_Query( array( 'role__in' => array( 'friend', 'acquaintance', 'pending_friend_request', 'subscription' ) ) );
-		$friends = $friends->get_results();
-
-		if ( empty( $friends ) ) {
-			return;
-		}
-
-		$feeds = array();
-		foreach ( $friends as $friend_user ) {
-			if ( $force ) {
-				$due_feeds = $friend_user->get_active_feeds();
-			} else {
-				// Respect the next poll date.
-				$due_feeds = $friend_user->get_due_feeds();
-			}
-			$feeds = array_merge( $feeds, $due_feeds );
-		}
-
-		// Let's poll the oldest feeds first.
-		usort(
-			$feeds,
-			function( $a, $b ) {
-				return strcmp( $a->get_next_poll(), $b->get_next_poll() );
-			}
-		);
-
-		foreach ( $feeds as $feed ) {
+		foreach ( User_Feed::get_all_due() as $feed ) {
 			$this->retrieve_feed( $feed );
 			$feed->was_polled();
 			$feed->get_friend_user()->delete_outdated_posts();
 		}
 	}
+
 	/**
 	 * Apply the feed rules that need to be applied early.
 	 *

--- a/includes/class-feed.php
+++ b/includes/class-feed.php
@@ -270,7 +270,10 @@ class Feed {
 		foreach ( User_Feed::get_all_due() as $feed ) {
 			$this->retrieve_feed( $feed );
 			$feed->was_polled();
-			$feed->get_friend_user()->delete_outdated_posts();
+			$friend_user = $feed->get_friend_user();
+			if ( $friend_user ) {
+				$friend_user->delete_outdated_posts();
+			}
 		}
 	}
 

--- a/includes/class-feed.php
+++ b/includes/class-feed.php
@@ -253,7 +253,7 @@ class Feed {
 				if ( ! $post ) {
 					$post = get_post( intval( $post_id ) );
 				}
-				do_action( 'notify_new_friend_post', $post );
+				do_action( 'notify_new_friend_post', $post, $user_feed );
 			}
 		}
 	}

--- a/includes/class-feed.php
+++ b/includes/class-feed.php
@@ -69,7 +69,6 @@ class Feed {
 
 		add_action( 'cron_friends_refresh_feeds', array( $this, 'cron_friends_refresh_feeds' ) );
 		add_action( 'friends_retrieve_user_feeds', array( $this, 'friends_retrieve_user_feeds' ) );
-		add_action( 'set_user_role', array( $this, 'retrieve_new_friends_posts' ), 999, 2 );
 
 		add_action( 'wp_loaded', array( $this, 'friends_add_friend_redirect' ), 100 );
 		add_action( 'wp_feed_options', array( $this, 'wp_feed_options' ), 90 );
@@ -1081,20 +1080,6 @@ class Feed {
 		}
 
 		return $query;
-	}
-
-	/**
-	 * Retrieve new friend's posts after changing roles
-	 *
-	 * @param  int    $user_id   The user id.
-	 * @param  string $new_role  The new role.
-	 */
-	public function retrieve_new_friends_posts( $user_id, $new_role ) {
-		if ( ( 'friend' === $new_role || 'acquaintance' === $new_role ) && apply_filters( 'friends_immediately_fetch_feed', true ) ) {
-			update_user_option( $user_id, 'friends_new_friend', true );
-			$friend = new User( $user_id );
-			$friend->retrieve_posts_from_active_feeds();
-		}
 	}
 
 	/**

--- a/includes/class-feed.php
+++ b/includes/class-feed.php
@@ -576,6 +576,10 @@ class Feed {
 				$updated_date = $item->updated_date;
 			}
 
+			if ( empty( $item->title ) ) {
+				$item->title = '';
+			}
+
 			$post_data = array(
 				'post_title'        => $item->title,
 				'post_content'      => force_balance_tags( $item->post_content ),

--- a/includes/class-feed.php
+++ b/includes/class-feed.php
@@ -498,7 +498,11 @@ class Feed {
 	 * @return array                             The post ids of the new posts.
 	 */
 	public function process_incoming_feed_items( array $items, User_Feed $user_feed ) {
-		$friend_user     = $user_feed->get_friend_user();
+		$friend_user = $user_feed->get_friend_user();
+		if ( ! $friend_user ) {
+			error_log( var_export( $user_feed, true ) );
+			return;
+		}
 		$remote_post_ids = $friend_user->get_remote_post_ids();
 		$post_formats    = get_post_format_strings();
 		$feed_post_format = $user_feed->get_post_format();

--- a/includes/class-feed.php
+++ b/includes/class-feed.php
@@ -606,7 +606,7 @@ class Feed {
 						if ( intval( $old_post->comment_count ) !== intval( $item->comment_count ) ) {
 							$modified_post_data['comment_count'] = $item->comment_count;
 						}
-						$friend_user->save_post( $modified_post_data );
+						wp_update_post( $modified_post_data );
 						$modified_posts[] = $post_id;
 					}
 				}

--- a/includes/class-feed.php
+++ b/includes/class-feed.php
@@ -496,6 +496,13 @@ class Feed {
 		return 10;
 	}
 
+	public function dissallowed_html( $allowedposttags, $context ) {
+		if ( 'post' === $context ) {
+			unset( $allowedposttags['article'] );
+		}
+		return $allowedposttags;
+	}
+
 	/**
 	 * Process incoming feed items
 	 *
@@ -527,7 +534,9 @@ class Feed {
 				$item->post_content = '';
 			}
 
+			add_filter( 'wp_kses_allowed_html', array( $this, 'dissallowed_html' ), 10, 2 );
 			$item->post_content = wp_kses_post( trim( $item->post_content ) );
+			remove_filter( 'wp_kses_allowed_html', array( $this, 'dissallowed_html' ), 10 );
 
 			$item = apply_filters( 'friends_early_modify_feed_item', $item, $user_feed, $friend_user );
 			if ( ! $item || $item->_feed_rule_delete ) {

--- a/includes/class-feed.php
+++ b/includes/class-feed.php
@@ -653,7 +653,7 @@ class Feed {
 				update_post_meta( $post_id, 'remote_post_id', $item->{'post-id'} );
 			}
 
-			wp_set_object_terms( $post_id, $user_feed->get_id(), User_Feed::TAXONOMY );
+			wp_set_object_terms( $post_id, $user_feed->get_id(), User_Feed::POST_TAXONOMY );
 
 			update_post_meta( $post_id, 'parser', $user_feed->get_parser() );
 			update_post_meta( $post_id, 'feed_url', $user_feed->get_url() );

--- a/includes/class-feed.php
+++ b/includes/class-feed.php
@@ -128,9 +128,12 @@ class Feed {
 		}
 
 		foreach ( $friend_user->get_active_feeds() as $feed ) {
-			$this->retrieve_feed( $feed );
-			$feed->was_polled();
-			$feed->get_friend_user()->delete_outdated_posts();
+			$friend_user = $feed->get_friend_user();
+			if ( $friend_user ) {
+				$this->retrieve_feed( $feed );
+				$feed->was_polled();
+				$friend_user->delete_outdated_posts();
+			}
 		}
 	}
 

--- a/includes/class-friends.php
+++ b/includes/class-friends.php
@@ -143,6 +143,7 @@ class Friends {
 	 */
 	private function register_hooks() {
 		add_action( 'init', array( $this, 'register_custom_post_type' ) );
+		add_action( 'init', array( 'Friends\Subscription', 'register_taxonomy' ) );
 		add_action( 'init', array( 'Friends\User_Feed', 'register_taxonomy' ) );
 		add_filter( 'get_avatar_data', array( $this, 'get_avatar_data' ), 10, 2 );
 
@@ -621,7 +622,7 @@ class Friends {
 	 */
 	public function get_avatar_data( $args, $id_or_email ) {
 		if ( is_object( $id_or_email ) ) {
-			if ( $id_or_email instanceof \WP_User ) {
+			if ( $id_or_email instanceof User ) {
 				$id_or_email = $id_or_email->ID;
 			} elseif ( $id_or_email instanceof \WP_Post ) {
 				$id_or_email = $id_or_email->post_author;
@@ -631,7 +632,20 @@ class Friends {
 		}
 
 		if ( is_numeric( $id_or_email ) && $id_or_email > 0 ) {
-			$url = get_user_option( 'friends_user_icon_url', $id_or_email );
+			$user = get_user_by( 'ID', $id_or_email );
+			if ( $user ) {
+				$user = new User( $user );
+			}
+		} elseif ( is_string( $id_or_email ) ) {
+			$user = User::get_by_username( $id_or_email );
+		}
+
+		if ( $user ) {
+			if ( is_wp_error( $user ) ) {
+				return $args;
+			}
+
+			$url = $user->get_user_option( 'friends_user_icon_url' );
 			if ( $url ) {
 				$args['url']          = $url;
 				$args['found_avatar'] = true;

--- a/includes/class-friends.php
+++ b/includes/class-friends.php
@@ -425,8 +425,11 @@ class Friends {
 
 	/**
 	 * If a plugin version upgrade requires changes, they can be done here
+	 *
+	 * @param      \WP_Upgrader $upgrader_object  The WP_Upgrader instance.
+	 * @param      array        $options          Array of bulk item update data.
 	 */
-	public static function upgrade_plugin() {
+	public static function upgrade_plugin( $upgrader_object, $options ) {
 		$upgraded = false;
 		if ( 'update' === $options['action'] && 'plugin' === $options['type'] && isset( $options['plugins'] ) ) {
 			foreach ( $options['plugins'] as $plugin ) {
@@ -530,7 +533,14 @@ class Friends {
 		self::setup_roles();
 		self::create_friends_page();
 
-		self::upgrade_plugin();
+		self::upgrade_plugin(
+			null,
+			array(
+				'action'  => 'update',
+				'plugins' => array( FRIENDS_PLUGIN_BASENAME ),
+				'type'    => 'plugin',
+			)
+		);
 
 		if ( false === get_option( 'friends_main_user_id' ) ) {
 			update_option( 'friends_main_user_id', get_current_user_id() );

--- a/includes/class-friends.php
+++ b/includes/class-friends.php
@@ -427,6 +427,18 @@ class Friends {
 	 * If a plugin version upgrade requires changes, they can be done here
 	 */
 	public static function upgrade_plugin() {
+		$upgraded = false;
+		if ( 'update' === $options['action'] && 'plugin' === $options['type'] && isset( $options['plugins'] ) ) {
+			foreach ( $options['plugins'] as $plugin ) {
+				if ( FRIENDS_PLUGIN_BASENAME === $plugin ) {
+					$upgraded = true;
+					break;
+				}
+			}
+		}
+		if ( ! $upgraded ) {
+			return;
+		}
 		$previous_version = get_option( 'friends_plugin_version' );
 
 		if ( version_compare( $previous_version, '0.20.1', '<' ) ) {
@@ -447,7 +459,7 @@ class Friends {
 			self::setup_roles();
 		}
 
-		if ( version_compare( $previous_version, '2.5.3', '<' ) ) {
+		if ( version_compare( $previous_version, '2.6.0', '<' ) ) {
 			$users = User_Query::all_associated_users();
 			foreach ( $users->get_results() as $user ) {
 				if ( get_option( 'friends_feed_rules_' . $user->ID ) ) {
@@ -459,7 +471,7 @@ class Friends {
 			}
 		}
 
-		update_option( 'friends_plugin_version', Friends::VERSION );
+			update_option( 'friends_plugin_version', Friends::VERSION );
 	}
 
 	/**
@@ -826,8 +838,6 @@ class Friends {
 		return $days;
 	}
 
-
-
 	/**
 	 * Gets the post stats.
 	 *
@@ -1059,7 +1069,6 @@ class Friends {
 		$defaults['must_log_in'] = $comment_registration_message;
 		return $defaults;
 	}
-
 
 	/**
 	 * Get all of the rel links for the HTML head.

--- a/includes/class-friends.php
+++ b/includes/class-friends.php
@@ -630,7 +630,6 @@ class Friends {
 				$id_or_email = $id_or_email->user_id;
 			}
 		}
-
 		if ( is_numeric( $id_or_email ) && $id_or_email > 0 ) {
 			$user = get_user_by( 'ID', $id_or_email );
 			if ( $user ) {
@@ -645,7 +644,7 @@ class Friends {
 				return $args;
 			}
 
-			$url = $user->get_user_option( 'friends_user_icon_url' );
+			$url = $user->get_avatar_url();
 			if ( $url ) {
 				$args['url']          = $url;
 				$args['found_avatar'] = true;

--- a/includes/class-friends.php
+++ b/includes/class-friends.php
@@ -430,8 +430,8 @@ class Friends {
 		$previous_version = get_option( 'friends_plugin_version' );
 
 		if ( version_compare( $previous_version, '0.20.1', '<' ) ) {
-			$friends_subscriptions = User_Query::all_associated_users();
-			foreach ( $friends_subscriptions->get_results() as $user ) {
+			$users = User_Query::all_associated_users();
+			foreach ( $users->get_results() as $user ) {
 				$gravatar = get_user_option( 'friends_gravatar', $user->ID );
 				$user_icon_url = get_user_option( 'friends_user_icon_url', $user->ID );
 				if ( $gravatar ) {
@@ -445,6 +445,18 @@ class Friends {
 
 		if ( version_compare( $previous_version, '2.1.3', '<' ) ) {
 			self::setup_roles();
+		}
+
+		if ( version_compare( $previous_version, '2.5.3', '<' ) ) {
+			$users = User_Query::all_associated_users();
+			foreach ( $users->get_results() as $user ) {
+				if ( get_option( 'friends_feed_rules_' . $user->ID ) ) {
+					$user->update_user_option( 'friends_feed_rules', get_option( 'friends_feed_rules_' . $user->ID ) );
+				}
+				if ( get_option( 'friends_feed_catch_all_' . $user->ID ) ) {
+					$user->update_user_option( 'friends_feed_catch_all', get_option( 'friends_feed_catch_all_' . $user->ID ) );
+				}
+			}
 		}
 
 		update_option( 'friends_plugin_version', Friends::VERSION );

--- a/includes/class-friends.php
+++ b/includes/class-friends.php
@@ -630,6 +630,8 @@ class Friends {
 				$id_or_email = $id_or_email->user_id;
 			}
 		}
+
+		$user = false;
 		if ( is_numeric( $id_or_email ) && $id_or_email > 0 ) {
 			$user = get_user_by( 'ID', $id_or_email );
 			if ( $user ) {
@@ -1159,6 +1161,10 @@ class Friends {
 	 * @return false|string URL or false on failure.
 	 */
 	public static function check_url( $url ) {
+		$pre = apply_filters( 'friends_pre_check_url', null );
+		if ( ! is_null( $pre ) ) {
+			return $pre;
+		}
 		$host = parse_url( $url, PHP_URL_HOST );
 
 		$check_url = apply_filters( 'friends_host_is_valid', null, $host );

--- a/includes/class-frontend.php
+++ b/includes/class-frontend.php
@@ -713,15 +713,15 @@ class Frontend {
 	}
 
 	public function ajax_star_friend_user() {
-		if ( ! isset( $_POST['friend_id'] ) || ! intval( $_POST['friend_id'] ) ) {
+		if ( ! isset( $_POST['friend_id'] ) || ! $_POST['friend_id'] ) {
 			wp_send_json_error();
 			exit;
 		}
 
-		$friend_id = intval( $_POST['friend_id'] );
+		$friend_id = wp_unslash( $_POST['friend_id'] );
 		check_ajax_referer( "star-$friend_id" );
 
-		$friend_user = new User( $friend_id );
+		$friend_user = User::get_by_username( $friend_id );
 
 		$starred = boolval( $_POST['starred'] );
 		$friend_user->set_starred( $starred );

--- a/includes/class-frontend.php
+++ b/includes/class-frontend.php
@@ -1234,9 +1234,9 @@ class Frontend {
 			$query->set( 'page_id', $page_id );
 			if ( ! $this->author ) {
 				$post = get_post( $page_id );
-				$author = get_user_by( 'ID', $post->post_author );
+				$author = User::get_post_author( $post );
 				if ( false !== $author ) {
-					$this->author = new User( $author );
+					$this->author = $author;
 				}
 			}
 			$query->is_single = true;

--- a/includes/class-frontend.php
+++ b/includes/class-frontend.php
@@ -160,8 +160,8 @@ class Frontend {
 	public function modify_page_title( $title ) {
 		if ( is_single() ) {
 			$title['page'] = __( 'Friends', 'friends' );
-			$title['site'] = get_the_author();
-		} elseif ( $this->author ) {
+			$title['site'] = $this->author->display_name;
+		} elseif ( $this->author instanceof User ) {
 			$title['title'] = __( 'Friends', 'friends' );
 			$title['site'] = $this->author->display_name;
 		} else {
@@ -1192,7 +1192,7 @@ class Frontend {
 
 				default: // Maybe an author.
 					$author = User::get_by_username( $current_part );
-					if ( false === $author ) {
+					if ( false === $author || is_wp_error( $author ) ) {
 						if ( $query->is_feed() ) {
 							status_header( 404 );
 							$query->set_404();
@@ -1250,10 +1250,14 @@ class Frontend {
 		}
 
 		if ( $this->author ) {
-			$authordata = $this->author;
-			$this->author->modify_query_by_author( $query );
-			if ( ! $page_id ) {
-				$query->is_author = true;
+			if ( $this->author instanceof User ) {
+				$authordata = $this->author;
+				$this->author->modify_query_by_author( $query );
+				if ( ! $page_id ) {
+					$query->is_author = true;
+				}
+			} else {
+				$this->author = null;
 			}
 		}
 

--- a/includes/class-frontend.php
+++ b/includes/class-frontend.php
@@ -770,13 +770,6 @@ class Frontend {
 		}
 
 		global $args;
-		// TODO determine when the conversion should happen.
-		if ( $this->author instanceof User && ! $this->author instanceof Subscription ) {
-			if ( $this->author->has_cap( 'friends_plugin' ) && ! $this->author->has_cap( 'friend' ) ) {
-				$subscription = Subscription::convert_from_user( $this->author );
-				$this->author = $subscription;
-			}
-		}
 		$args = array(
 			'friends'     => $this->friends,
 			'friend_user' => $this->author,

--- a/includes/class-frontend.php
+++ b/includes/class-frontend.php
@@ -499,18 +499,14 @@ class Frontend {
 	public static function have_posts() {
 		$friends = Friends::get_instance();
 		while ( have_posts() ) {
+			global $post;
 			the_post();
 			$args = array(
 				'friends' => $friends,
 				'avatar'  => get_post_meta( get_the_ID(), 'gravatar', true ),
 			);
 
-			$subscription = wp_get_object_terms( get_the_ID(), Subscription::TAXONOMY );
-			if ( empty( $subscription ) ) {
-				$args['friend_user'] = new User( get_the_author() );
-			} else {
-				$args['friend_user'] = new Subscription( $subscription[0] );
-			}
+			$args['friend_user'] = User::get_post_author( $post );
 
 			$read_time = self::calculate_read_time( get_the_content() );
 			if ( $read_time >= 60 ) {

--- a/includes/class-messages.php
+++ b/includes/class-messages.php
@@ -226,7 +226,7 @@ class Messages {
 				)
 			);
 		} else {
-			$post_id = $friend_user->save_post(
+			$post_id = $friend_user->insert_post(
 				array(
 					'post_type'    => self::CPT,
 					'post_title'   => $subject,

--- a/includes/class-messages.php
+++ b/includes/class-messages.php
@@ -226,10 +226,9 @@ class Messages {
 				)
 			);
 		} else {
-			$post_id = wp_insert_post(
+			$post_id = $friend_user->save_post(
 				array(
 					'post_type'    => self::CPT,
-					'post_author'  => $friend_user->ID,
 					'post_title'   => $subject,
 					'post_content' => $content,
 					'post_status'  => $mark_unread ? 'friends_unread' : 'friends_read',
@@ -273,7 +272,7 @@ class Messages {
 
 		while ( $unread_messages->have_posts() ) {
 			$unread_messages->the_post();
-			$friend_user = new User( $post->post_author );
+			$friend_user = User::get_post_author( $post );
 			$wp_menu->add_menu(
 				array(
 					'id'     => 'friend-message-' . $friend_user->ID,
@@ -365,7 +364,7 @@ class Messages {
 	 * @param      array $args         The arguments.
 	 */
 	public function friends_display_messages( $args ) {
-		if ( ! isset( $args['friend_user'] ) ) {
+		if ( ! isset( $args['friend_user'] ) || ! $args['friend_user'] ) {
 			return;
 		}
 
@@ -397,7 +396,7 @@ class Messages {
 	 * @param      array $args         The arguments.
 	 */
 	public function friends_message_form( $args ) {
-		if ( ! isset( $args['friend_user'] ) ) {
+		if ( ! isset( $args['friend_user'] ) || ! $args['friend_user'] ) {
 			return;
 		}
 

--- a/includes/class-notifications.php
+++ b/includes/class-notifications.php
@@ -79,9 +79,10 @@ class Notifications {
 	/**
 	 * Notify the users of this site about a new friend post
 	 *
-	 * @param  \WP_Post $post The new post by a friend or subscription.
+	 * @param  \WP_Post  $post The new post by a friend or subscription.
+	 * @param  User_Feed $user_feed The feed where the post came from.
 	 */
-	public function notify_new_friend_post( \WP_Post $post ) {
+	public function notify_new_friend_post( \WP_Post $post, User_Feed $user_feed ) {
 		if (
 			// Post might be trashed through rules.
 			'trash' === $post->post_status
@@ -94,14 +95,15 @@ class Notifications {
 		if ( ! $user->user_email ) {
 			return;
 		}
-		$notify_user = ! get_user_option( 'friends_no_new_post_notification', $user->ID );
-		$notify_user = $notify_user && ! get_user_option( 'friends_no_new_post_notification_' . $post->post_author, $user->ID );
+		$author = $user_feed->get_friend_user();
 
-		if ( ! apply_filters( 'notify_user_about_friend_post', $notify_user, $user, $post ) ) {
+		$notify_user = ! get_user_option( 'friends_no_new_post_notification', $user->ID );
+		$notify_user = $notify_user && ! get_user_option( 'friends_no_new_post_notification_' . $author->user_login, $user->ID );
+
+		if ( ! apply_filters( 'notify_user_about_friend_post', $notify_user, $user, $post, $author ) ) {
 			return;
 		}
 
-		$author      = new User( $post->post_author );
 		$email_title = $post->post_title;
 
 		$params = array(

--- a/includes/class-notifications.php
+++ b/includes/class-notifications.php
@@ -40,7 +40,7 @@ class Notifications {
 	 */
 	private function register_hooks() {
 		add_action( 'friends_rewrite_mail_html', array( $this, 'rewrite_mail_html' ) );
-		add_action( 'notify_new_friend_post', array( $this, 'notify_new_friend_post' ) );
+		add_action( 'notify_new_friend_post', array( $this, 'notify_new_friend_post' ), 10, 2 );
 		add_filter( 'notify_keyword_match_post', array( $this, 'notify_keyword_match_post' ), 10, 3 );
 		add_action( 'notify_new_friend_request', array( $this, 'notify_new_friend_request' ) );
 		add_action( 'notify_accepted_friend_request', array( $this, 'notify_accepted_friend_request' ) );

--- a/includes/class-subscription.php
+++ b/includes/class-subscription.php
@@ -482,4 +482,41 @@ class Subscription extends User {
 
 		return new self( $term );
 	}
+
+	/**
+	 * Wrap get_user_option
+	 *
+	 * @param string $option_name User option name.
+	 * @return int|bool User meta ID if the option didn't exist, true on successful update,
+	 *                  false on failure.
+	 */
+	function get_user_option( $option_name ) {
+		return get_metadata( 'term', $this->get_term_id(), $option_name, true );
+	}
+
+	/**
+	 * Wrap update_user_option
+	 *
+	 * @param string $option_name User option name.
+	 * @param mixed  $new_value    User option value.
+	 * @param bool   $global      Optional. Whether option name is global or blog specific.
+	 *                            Default false (blog specific).
+	 * @return int|bool User meta ID if the option didn't exist, true on successful update,
+	 *                  false on failure.
+	 */
+	function update_user_option( $option_name, $new_value, $global = false ) {
+		return update_metadata( 'term', $this->get_term_id(), $option_name, $new_value );
+	}
+
+	/**
+	 * Wrap delete_user_option
+	 *
+	 * @param string $option_name User option name.
+	 * @param bool   $global      Optional. Whether option name is global or blog specific.
+	 *                            Default false (blog specific).
+	 * @return bool True on success, false on failure.
+	 */
+	function delete_user_option( $option_name, $global = false ) {
+		return delete_metadata( 'term', $this->get_term_id(), $option_name );
+	}
 }

--- a/includes/class-subscription.php
+++ b/includes/class-subscription.php
@@ -169,7 +169,7 @@ class Subscription extends User {
 					LENGTH( comment_count )
 					) AS total_size,
 					COUNT(*) as post_count
-				FROM ' . $wpdb->posts . ' p, ' . $wpdb->term_taxonomy . ' t, ' . $wpdb->term_relationships . ' r WHERE r.object_id = p.ID AND r.term_taxonomy_id = t    .term_taxonomy_id AND t.term_id = %d AND p.post_type IN ( ' . implode( ', ', array_fill( 0, count( $post_types ), '%s' ) ) . ' )',
+				FROM ' . $wpdb->posts . ' p, ' . $wpdb->term_taxonomy . ' t, ' . $wpdb->term_relationships . ' r WHERE r.object_id = p.ID AND r.term_taxonomy_id = t.term_taxonomy_id AND t.term_id = %d AND p.post_type IN ( ' . implode( ', ', array_fill( 0, count( $post_types ), '%s' ) ) . ' )',
 				array_merge( array( $this->get_term_id() ), $post_types )
 			),
 			ARRAY_A
@@ -238,7 +238,6 @@ class Subscription extends User {
 						$wpdb->term_relationships,
 						$wpdb->term_taxonomy,
 						$wpdb->term_relationships,
-						'%d',
 						implode( ',', array_fill( 0, count( $post_types ), '%s' ) ),
 						'%d'
 					),
@@ -270,7 +269,6 @@ class Subscription extends User {
 						$wpdb->term_relationships,
 						$wpdb->term_taxonomy,
 						$wpdb->term_relationships,
-						'%d',
 						implode( ',', array_fill( 0, count( $post_types ), '%s' ) ),
 						implode( ',', array_fill( 0, count( $post_formats_term_ids ), '%d' ) ),
 						'%d'

--- a/includes/class-subscription.php
+++ b/includes/class-subscription.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * Friend Subscription
+ *
+ * This is a virtual user to allow subscriptions without a WordPress user
+ *
+ * @package Friends
+ */
+
+namespace Friends;
+
+/**
+ * This is the class for the User part of the Friends Plugin.
+ *
+ * @since 3.0
+ *
+ * @package Friends
+ * @author Alex Kirk
+ */
+class Subscription extends User {
+	const TAXONOMY = 'friends-virtual-user';
+	private $term;
+
+	public function __construct( \WP_Term $term ) {
+		$this->term = $term;
+	}
+
+	/**
+	 * Registers the taxonomy
+	 */
+	public static function register_taxonomy() {
+		$args = array(
+			'labels'            => array(
+				'name'          => _x( 'Virtual User', 'taxonomy general name', 'friends' ),
+				'singular_name' => _x( 'Virtual User', 'taxonomy singular name', 'friends' ),
+				'menu_name'     => __( 'Virtual User', 'friends' ),
+			),
+			'hierarchical'      => false,
+			'show_ui'           => true,
+			'show_admin_column' => true,
+			'query_var'         => true,
+			'rewrite'           => false,
+			'public'            => false,
+		);
+		register_taxonomy( self::TAXONOMY, 'None', $args );
+	}
+
+
+	public static function get_by_username( $username ) {
+		$term_query = new \WP_Term_Query(
+			array(
+				'taxonomy' => self::TAXONOMY,
+				'slug'     => $username,
+			)
+		);
+
+		foreach ( $term_query->get_terms() as $term ) {
+			return new self( $term );
+		}
+
+		return new \WP_Error( 'user-not-found' );
+	}
+
+	public static function convert_from_user( User $user ) {
+		if ( $user instanceof Subscription ) {
+			return $user;
+		}
+
+		$subscription = self::create( $user->user_login, $user->roles[0], $user->user_url, $user->display_name, $user->get_user_option( 'friends_user_icon_url' ), $user->description );
+
+		if ( is_wp_error( $subscription ) ) {
+			return $subscription;
+		}
+
+		$query = new \WP_Query( array( 'author' => $user->ID ) );
+		while ( $query->have_posts() ) {
+			$post = $query->the_post();
+			$post->post_author = get_current_user_id();
+			wp_update_post( $post );
+			wp_set_object_terms( $post->ID, $subscription->ID, self::TAXONOMY );
+		}
+
+		wp_delete_user( $user->ID );
+		return $subscription;
+	}
+
+	public static function convert_to_user( Subscription $subscription ) {
+		$user = User::create( $subscription->user_login, $subscription->role, $subscription->user_url, $subscription->display_name, $subscription->get_user_option( 'friends_user_icon_url' ), $subscription->description );
+
+		if ( is_wp_error( $user ) ) {
+			return $user;
+		}
+		$query = new \WP_Query(
+			array(
+				'post_type' => 'post',
+				'tax_query' => array(
+					array(
+						'taxonomy' => self::TAXONOMY,
+						'field'    => 'slug',
+						'terms'    => $user->user_login,
+					),
+				),
+			)
+		);
+
+		while ( $query->have_posts() ) {
+			$post = $query->the_post();
+			$post->post_author = $user->user_login;
+			wp_update_post( $post );
+			wp_remove_object_terms( $post->ID, $subscription->ID, self::TAXONOMY );
+		}
+
+		wp_delete_term( $subscription->ID, self::TAXONOMY );
+
+		return $user;
+	}
+
+	public static function create( $user_login, $role, $user_url, $display_name = null, $icon_url = null, $description = null ) {
+
+		$term = wp_insert_term( $user_login, self::TAXONOMY );
+
+		if ( is_wp_error( $term ) ) {
+			return $term;
+		}
+
+		$term_id = $term['term_id'];
+		add_metadata( 'term', $term_id, 'role', $role, true );
+		add_metadata( 'term', $term_id, 'user_url', $user_url, true );
+		add_metadata( 'term', $term_id, 'display_name', $display_name, true );
+		add_metadata( 'term', $term_id, 'icon_url', $icon_url, true );
+		add_metadata( 'term', $term_id, 'description', $description, true );
+
+		$term = get_term( $term['term_id'] );
+		if ( is_wp_error( $term ) ) {
+			return $term;
+		}
+
+		return new self( $term );
+	}
+}

--- a/includes/class-subscription.php
+++ b/includes/class-subscription.php
@@ -24,13 +24,17 @@ class Subscription extends User {
 	public function __construct( \WP_Term $term ) {
 		$this->term = $term;
 		$this->ID = 'friends-virtual-user-' . $term->term_id;
-		$this->allcaps = array_fill_keys( get_metadata( 'term', $term->term_id, 'roles' ), true );
+
+		$this->caps = array_fill_keys( get_metadata( 'term', $term->term_id, 'roles' ), true );
+		$this->caps['subscription'] = true;
+		$this->get_role_caps();
+
 		$this->data = (object) array(
 			'ID'              => $this->ID,
 			'user_login'      => $term->name,
 			'display_name'    => get_metadata( 'term', $term->term_id, 'display_name', true ),
 			'user_url'        => get_metadata( 'term', $term->term_id, 'user_url', true ),
-			'icon_url'        => get_metadata( 'term', $term->term_id, 'icon_url', true ),
+			'avatar_url'      => get_metadata( 'term', $term->term_id, 'avatar_url', true ),
 			'description'     => get_metadata( 'term', $term->term_id, 'description', true ),
 			'user_registered' => get_metadata( 'term', $term->term_id, 'created', true ),
 		);
@@ -38,6 +42,10 @@ class Subscription extends User {
 
 	public function get_term_id() {
 		return $this->term->term_id;
+	}
+
+	public function get_object_id() {
+		return $this->get_term_id();
 	}
 
 	/**
@@ -81,7 +89,7 @@ class Subscription extends User {
 		if ( ! isset( $postarr['tax_input'] ) ) {
 			$postarr['tax_input'] = array();
 		}
-		$postarr['tax_input'][ self::TAXONOMY ] = array( $this->term );
+		$postarr['tax_input'][ self::TAXONOMY ] = array( $this->get_term_id() );
 		$post = wp_insert_post( $postarr, $wp_error, $fire_after_hooks );
 
 		return $post;
@@ -124,6 +132,68 @@ class Subscription extends User {
 		}
 	}
 
+
+	/**
+	 * Gets the post stats.
+	 *
+	 * @return     object  The post stats.
+	 */
+	public function get_post_stats() {
+		global $wpdb;
+		$post_types = apply_filters( 'friends_frontend_post_types', array() );
+		$post_stats = $wpdb->get_row(
+			$wpdb->prepare(
+				'SELECT SUM(
+					LENGTH( ID ) +
+					LENGTH( post_author ) +
+					LENGTH( post_date ) +
+					LENGTH( post_date_gmt ) +
+					LENGTH( post_content ) +
+					LENGTH( post_title ) +
+					LENGTH( post_excerpt ) +
+					LENGTH( post_status ) +
+					LENGTH( comment_status ) +
+					LENGTH( ping_status ) +
+					LENGTH( post_password ) +
+					LENGTH( post_name ) +
+					LENGTH( to_ping ) +
+					LENGTH( pinged ) +
+					LENGTH( post_modified ) +
+					LENGTH( post_modified_gmt ) +
+					LENGTH( post_content_filtered ) +
+					LENGTH( post_parent ) +
+					LENGTH( guid ) +
+					LENGTH( menu_order ) +
+					LENGTH( post_type ) +
+					LENGTH( post_mime_type ) +
+					LENGTH( comment_count )
+					) AS total_size,
+					COUNT(*) as post_count
+				FROM ' . $wpdb->posts . ' p, ' . $wpdb->term_relationships . ' r WHERE r.object_id = p.ID AND r.term_taxonomy_id = %d AND p.post_type IN ( ' . implode( ', ', array_fill( 0, count( $post_types ), '%s' ) ) . ' )',
+				array_merge( array( $this->get_term_id() ), $post_types )
+			),
+			ARRAY_A
+		);
+
+		$post_stats['earliest_post_date'] = mysql2date(
+			'U',
+			$wpdb->get_var(
+				$wpdb->prepare(
+					"SELECT MIN(post_date) FROM $wpdb->posts p, $wpdb->term_relationships r WHERE r.object_id = p.ID AND r.term_taxonomy_id = %d AND p.post_status = 'publish' AND p.post_type IN ( " . implode( ', ', array_fill( 0, count( $post_types ), '%s' ) ) . ' )',
+					array_merge( array( $this->get_term_id() ), $post_types )
+				)
+			)
+		);
+		return $post_stats;
+	}
+
+	public function get_all_post_ids() {
+		global $wpdb;
+		$post_types_to_delete = implode( "', '", apply_filters( 'friends_frontend_post_types', array() ) );
+
+		$post_ids = $wpdb->get_col( $wpdb->prepare( "SELECT p.ID FROM $wpdb->posts p, $wpdb->term_relationships r WHERE r.object_id = p.ID AND r.term_taxonomy_id = %d AND p.post_type IN ('$post_types_to_delete')", $this->get_term_id() ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		return $post_ids;
+	}
 
 	/**
 	 * Gets the post counts by post format.
@@ -237,34 +307,58 @@ class Subscription extends User {
 		return _nx( 'Subscription', 'Subscriptions', $count, 'User role', 'friends' );
 	}
 
+	public function get_avatar_url() {
+		return $this->data->avatar_url;
+	}
+
+	public function delete() {
+		// Allow unsubscribing to all these feeds.
+		foreach ( $this->get_active_feeds() as $feed ) {
+			do_action( 'friends_user_feed_deactivated', $feed );
+			$feed->delete();
+		}
+
+		foreach ( $this->get_all_post_ids() as $post_id ) {
+			wp_delete_post( $post_id );
+		}
+
+		wp_delete_term( $this->get_term_id(), self::TAXONOMY );
+		return true;
+	}
+
+
 	public static function convert_from_user( User $user ) {
 		if ( $user instanceof Subscription ) {
 			return $user;
 		}
 
-		$subscription = self::create( $user->user_login, $user->roles[0], $user->user_url, $user->display_name, $user->get_user_option( 'friends_user_icon_url' ), $user->description, $user->user_registered );
+		$subscription = self::create( $user->user_login, $user->roles[0], $user->user_url, $user->display_name, $user->get_avatar_url(), $user->description, $user->user_registered );
 
 		if ( is_wp_error( $subscription ) ) {
 			return $subscription;
 		}
 
 		$query = new \WP_Query();
-		$query->set( 'post_type', Friends::CPT );
+		$query->set( 'post_type', apply_filters( 'friends_frontend_post_types', array() ) );
+		$query->set( 'post_status', array( 'publish', 'private', 'draft', 'trashed' ) );
 		$query->set( 'posts_per_page', -1 );
 		$query = $user->modify_query_by_author( $query );
 
 		foreach ( $query->get_posts() as $post ) {
 			$post->post_author = get_current_user_id();
 			wp_update_post( $post );
-			wp_remove_object_terms( $post->ID, $subscription->ID, self::TAXONOMY );
 			wp_set_object_terms( $post->ID, $subscription->get_term_id(), self::TAXONOMY );
 		}
+
+		global $wpdb;
+		$wpdb->query( $wpdb->prepare( "UPDATE $wpdb->term_relationships JOIN $wpdb->term_taxonomy ON $wpdb->term_relationships.term_taxonomy_id = $wpdb->term_taxonomy.term_taxonomy_id SET object_id = %d WHERE object_id = %d AND $wpdb->term_taxonomy.taxonomy = %s", $subscription->get_term_id(), $user->ID, USER_FEED::TAXONOMY ) );
+
 		// \wp_delete_user( $user->ID );
 		return $user;
 	}
 
 	public static function convert_to_user( Subscription $subscription ) {
-		$user = User::create( $subscription->user_login, $subscription->role, $subscription->user_url, $subscription->display_name, $subscription->get_user_option( 'friends_user_icon_url' ), $subscription->description, $subscription->user_registered );
+		$user = User::create( $subscription->user_login, $subscription->role, $subscription->user_url, $subscription->display_name, $subscription->get_avatar_url(), $subscription->description, $subscription->user_registered );
 
 		if ( is_wp_error( $user ) ) {
 			return $user;
@@ -285,7 +379,7 @@ class Subscription extends User {
 		return $user;
 	}
 
-	public static function create( $user_login, $role, $user_url, $display_name = null, $icon_url = null, $description = null, $created = null ) {
+	public static function create( $user_login, $role, $user_url, $display_name = null, $avatar_url = null, $description = null, $created = null ) {
 		$term = term_exists( $user_login, self::TAXONOMY );
 
 		if ( ! $term || ! isset( $term['term_id'] ) ) {
@@ -302,8 +396,8 @@ class Subscription extends User {
 		add_metadata( 'term', $term_id, 'user_url', $user_url, true );
 		delete_metadata( 'term', $term_id, 'display_name' );
 		add_metadata( 'term', $term_id, 'display_name', $display_name, true );
-		delete_metadata( 'term', $term_id, 'icon_url' );
-		add_metadata( 'term', $term_id, 'icon_url', $icon_url, true );
+		delete_metadata( 'term', $term_id, 'avatar_url' );
+		add_metadata( 'term', $term_id, 'avatar_url', $avatar_url, true );
 		delete_metadata( 'term', $term_id, 'description' );
 		add_metadata( 'term', $term_id, 'description', $description, true );
 		delete_metadata( 'term', $term_id, 'created' );

--- a/includes/class-subscription.php
+++ b/includes/class-subscription.php
@@ -20,6 +20,18 @@ namespace Friends;
 class Subscription extends User {
 	const TAXONOMY = 'friends-virtual-user';
 	private $term;
+	const MIGRATE_USER_OPTIONS = array(
+		'friends_retention_number',
+		'friends_enable_retention_days',
+		'friends_retention_days',
+		'friends_feed_rules',
+		'friends_feed_catch_all',
+		'friends_in_token',
+		'friends_out_token',
+		'friends_starred',
+		'friends_rest_url',
+		'friends_user_icon_url',
+	);
 
 	public function __construct( \WP_Term $term ) {
 		$this->term = $term;
@@ -409,6 +421,10 @@ class Subscription extends User {
 		// Convert feeds.
 		$wpdb->query( $wpdb->prepare( "UPDATE $wpdb->term_relationships JOIN $wpdb->term_taxonomy ON $wpdb->term_relationships.term_taxonomy_id = $wpdb->term_taxonomy.term_taxonomy_id SET object_id = %d WHERE object_id = %d AND $wpdb->term_taxonomy.taxonomy = %s", $subscription->get_term_id(), $user->ID, User_Feed::TAXONOMY ) );
 
+		foreach ( self::MIGRATE_USER_OPTIONS as $option_name ) {
+			$subscription->update_user_option( $option_name, $user->get_user_option( $option_name ) );
+		}
+
 		$user->delete();
 
 		return $user;
@@ -436,6 +452,10 @@ class Subscription extends User {
 		global $wpdb;
 		// Convert feeds.
 		$wpdb->query( $wpdb->prepare( "UPDATE $wpdb->term_relationships JOIN $wpdb->term_taxonomy ON $wpdb->term_relationships.term_taxonomy_id = $wpdb->term_taxonomy.term_taxonomy_id SET object_id = %d WHERE object_id = %d AND $wpdb->term_taxonomy.taxonomy = %s", $user->ID, $subscription->get_term_id(), User_Feed::TAXONOMY ) );
+
+		foreach ( self::MIGRATE_USER_OPTIONS as $option_name ) {
+			$user->update_user_option( $option_name, $subscription->get_user_option( $option_name ) );
+		}
 
 		$subscription->delete();
 

--- a/includes/class-subscription.php
+++ b/includes/class-subscription.php
@@ -180,7 +180,7 @@ class Subscription extends User {
 			'U',
 			$wpdb->get_var(
 				$wpdb->prepare(
-					"SELECT MIN(post_date) FROM $wpdb->posts p, ' . $wpdb->term_taxonomy . ' t, ' . $wpdb->term_relationships . ' r WHERE r.object_id = p.ID AND r.term_taxonomy_id = t.term_taxonomy_id AND t.term_id = %d AND p.post_status = 'publish' AND p.post_type IN ( " . implode( ', ', array_fill( 0, count( $post_types ), '%s' ) ) . ' )',
+					"SELECT MIN(post_date) FROM $wpdb->posts p, $wpdb->term_taxonomy t, $wpdb->term_relationships r WHERE r.object_id = p.ID AND r.term_taxonomy_id = t.term_taxonomy_id AND t.term_id = %d AND p.post_status = 'publish' AND p.post_type IN ( " . implode( ', ', array_fill( 0, count( $post_types ), '%s' ) ) . ' )',
 					array_merge( array( $this->get_term_id() ), $post_types )
 				)
 			)

--- a/includes/class-subscription.php
+++ b/includes/class-subscription.php
@@ -23,6 +23,21 @@ class Subscription extends User {
 
 	public function __construct( \WP_Term $term ) {
 		$this->term = $term;
+		$this->ID = 'friends-virtual-user-' . $term->term_id;
+		$this->allcaps = array_fill_keys( get_metadata( 'term', $term->term_id, 'roles' ), true );
+		$this->data = (object) array(
+			'ID'              => $this->ID,
+			'user_login'      => $term->name,
+			'display_name'    => get_metadata( 'term', $term->term_id, 'display_name', true ),
+			'user_url'        => get_metadata( 'term', $term->term_id, 'user_url', true ),
+			'icon_url'        => get_metadata( 'term', $term->term_id, 'icon_url', true ),
+			'description'     => get_metadata( 'term', $term->term_id, 'description', true ),
+			'user_registered' => get_metadata( 'term', $term->term_id, 'created', true ),
+		);
+	}
+
+	public function get_term_id() {
+		return $this->term->term_id;
 	}
 
 	/**
@@ -49,8 +64,9 @@ class Subscription extends User {
 	public static function get_by_username( $username ) {
 		$term_query = new \WP_Term_Query(
 			array(
-				'taxonomy' => self::TAXONOMY,
-				'slug'     => $username,
+				'taxonomy'   => self::TAXONOMY,
+				'name'       => $username,
+				'hide_empty' => false,
 			)
 		);
 
@@ -61,53 +77,207 @@ class Subscription extends User {
 		return new \WP_Error( 'user-not-found' );
 	}
 
+	public function save_post( array $postarr, $wp_error = false, $fire_after_hooks = true ) {
+		if ( ! isset( $postarr['tax_input'] ) ) {
+			$postarr['tax_input'] = array();
+		}
+		$postarr['tax_input'][ self::TAXONOMY ] = array( $this->term );
+		$post = wp_insert_post( $postarr, $wp_error, $fire_after_hooks );
+
+		return $post;
+	}
+
+	public function modify_query_by_author( \WP_Query $query ) {
+		$query->set( 'author', get_current_user_id() );
+		$tax_query = $query->get( 'tax_query' );
+		if ( ! $tax_query ) {
+			$tax_query = array();
+		} else {
+			$tax_query['relation'] = 'AND';
+		}
+		$tax_query[] =
+			array(
+				'taxonomy' => self::TAXONOMY,
+				'field'    => 'term_id',
+				'terms'    => $this->get_term_id(),
+			);
+		$query->set( 'tax_query', $tax_query );
+		return $query;
+	}
+
+	public static function set_authordata_by_query( $query ) {
+		global $authordata;
+		if ( $query->get( 'tax_query' ) ) {
+			foreach ( $query->get( 'tax_query' ) as $tax_query ) {
+				if ( ! is_array( $tax_query ) || ! isset( $tax_query['taxonomy'] ) || self::TAXONOMY !== $tax_query['taxonomy'] ) {
+					continue;
+				}
+				if ( 'term_id' === $tax_query['field'] ) {
+					$term_id = $tax_query['terms'];
+					if ( is_array( $term_id ) ) {
+						$term_id = reset( $term_id );
+					}
+					$authordata = new Subscription( \get_term( $term_id ) );
+					return;
+				}
+			}
+		}
+	}
+
+
+	/**
+	 * Gets the post counts by post format.
+	 *
+	 * @return     array  The post counts.
+	 */
+	public function get_post_count_by_post_format() {
+		$cache_key = 'friends_post_count_by_post_format_author_' . $this->ID;
+
+		$counts = get_transient( $cache_key );
+		if ( false === $counts ) {
+			$counts = array();
+			$post_types = apply_filters( 'friends_frontend_post_types', array() );
+			$post_formats_term_ids = array();
+			foreach ( get_post_format_slugs() as $post_format ) {
+				$term = get_term_by( 'slug', 'post-format-' . $post_format, 'post_format' );
+				if ( $term ) {
+					$post_formats_term_ids[ $term->term_id ] = $post_format;
+				}
+			}
+
+			global $wpdb;
+
+			$counts = array();
+			$post_format_counts = $wpdb->get_results(
+				$wpdb->prepare(
+					sprintf(
+						"SELECT relationships_post_format.term_taxonomy_id AS post_format_id, COUNT(relationships_post_format.term_taxonomy_id) AS count
+						FROM %s AS posts
+						JOIN %s AS relationships_post_format
+						JOIN %s AS relationships_author
+
+						WHERE posts.post_author = %s
+						AND posts.post_status IN ( 'publish', 'private' )
+						AND posts.post_type IN ( %s )
+						AND relationships_post_format.object_id = posts.ID
+						AND relationships_post_format.term_taxonomy_id IN ( %s )
+						AND relationships_author.object_id = posts.ID
+						AND relationships_author.term_taxonomy_id = %s
+						GROUP BY relationships_post_format.term_taxonomy_id",
+						$wpdb->posts,
+						$wpdb->term_relationships,
+						$wpdb->term_relationships,
+						'%d',
+						implode( ',', array_fill( 0, count( $post_types ), '%s' ) ),
+						implode( ',', array_fill( 0, count( $post_formats_term_ids ), '%d' ) ),
+						'%d'
+					),
+					array_merge(
+						array( get_current_user_id() ),
+						$post_types,
+						array_keys( $post_formats_term_ids ),
+						array( $this->get_term_id() )
+					)
+				)
+			);
+
+			foreach ( $post_format_counts as $row ) {
+				$counts[ $post_formats_term_ids[ $row->post_format_id ] ] = $row->count;
+			}
+
+			$counts['standard'] = $wpdb->get_var(
+				$wpdb->prepare(
+					sprintf(
+						"SELECT COUNT(*)
+						FROM %s AS posts
+						JOIN %s AS relationships_post_format
+						JOIN %s AS relationships_author
+
+						WHERE posts.post_author = %s
+						AND posts.post_status IN ( 'publish', 'private' )
+						AND posts.post_type IN ( %s )
+						AND relationships_post_format.object_id = posts.ID
+						AND relationships_post_format.term_taxonomy_id NOT IN ( %s )
+						AND relationships_author.object_id = posts.ID
+						AND relationships_author.term_taxonomy_id = %s",
+						$wpdb->posts,
+						$wpdb->term_relationships,
+						$wpdb->term_relationships,
+						'%d',
+						implode( ',', array_fill( 0, count( $post_types ), '%s' ) ),
+						implode( ',', array_fill( 0, count( $post_formats_term_ids ), '%d' ) ),
+						'%d'
+					),
+					array_merge(
+						array( get_current_user_id() ),
+						$post_types,
+						$post_formats_term_ids,
+						array( $this->get_term_id() )
+					)
+				)
+			);
+
+			$counts = array_filter( $counts );
+
+			set_transient( $cache_key, $counts, HOUR_IN_SECONDS );
+		}
+
+		return $counts;
+	}
+
+	/**
+	 * Gets the role name (for a specific count).
+	 *
+	 * @param      bool $group_subscriptions  Whether to group all types of subscriptions into the name "Subscriptions".
+	 * @param      int  $count                The count if more than one.
+	 *
+	 * @return     string  The role name.
+	 */
+	public function get_role_name( $group_subscriptions = false, $count = 1 ) {
+		return _nx( 'Subscription', 'Subscriptions', $count, 'User role', 'friends' );
+	}
+
 	public static function convert_from_user( User $user ) {
 		if ( $user instanceof Subscription ) {
 			return $user;
 		}
 
-		$subscription = self::create( $user->user_login, $user->roles[0], $user->user_url, $user->display_name, $user->get_user_option( 'friends_user_icon_url' ), $user->description );
+		$subscription = self::create( $user->user_login, $user->roles[0], $user->user_url, $user->display_name, $user->get_user_option( 'friends_user_icon_url' ), $user->description, $user->user_registered );
 
 		if ( is_wp_error( $subscription ) ) {
 			return $subscription;
 		}
 
-		$query = new \WP_Query( array( 'author' => $user->ID ) );
-		while ( $query->have_posts() ) {
-			$post = $query->the_post();
+		$query = new \WP_Query();
+		$query->set( 'post_type', Friends::CPT );
+		$query->set( 'posts_per_page', -1 );
+		$query = $user->modify_query_by_author( $query );
+
+		foreach ( $query->get_posts() as $post ) {
 			$post->post_author = get_current_user_id();
 			wp_update_post( $post );
-			wp_set_object_terms( $post->ID, $subscription->ID, self::TAXONOMY );
+			wp_remove_object_terms( $post->ID, $subscription->ID, self::TAXONOMY );
+			wp_set_object_terms( $post->ID, $subscription->get_term_id(), self::TAXONOMY );
 		}
-
-		wp_delete_user( $user->ID );
-		return $subscription;
+		// \wp_delete_user( $user->ID );
+		return $user;
 	}
 
 	public static function convert_to_user( Subscription $subscription ) {
-		$user = User::create( $subscription->user_login, $subscription->role, $subscription->user_url, $subscription->display_name, $subscription->get_user_option( 'friends_user_icon_url' ), $subscription->description );
+		$user = User::create( $subscription->user_login, $subscription->role, $subscription->user_url, $subscription->display_name, $subscription->get_user_option( 'friends_user_icon_url' ), $subscription->description, $subscription->user_registered );
 
 		if ( is_wp_error( $user ) ) {
 			return $user;
 		}
-		$query = new \WP_Query(
-			array(
-				'post_type' => 'post',
-				'tax_query' => array(
-					array(
-						'taxonomy' => self::TAXONOMY,
-						'field'    => 'slug',
-						'terms'    => $user->user_login,
-					),
-				),
-			)
-		);
+		$query = new \WP_Query();
+		$query->set( 'post_type', Friends::CPT );
+		$query->set( 'posts_per_page', -1 );
+		$query = $subscription->modify_query_by_author( $query );
 
-		while ( $query->have_posts() ) {
-			$post = $query->the_post();
+		foreach ( $query->get_posts() as $post ) {
 			$post->post_author = $user->user_login;
 			wp_update_post( $post );
-			wp_remove_object_terms( $post->ID, $subscription->ID, self::TAXONOMY );
+			wp_remove_object_terms( $post->ID, $subscription->get_term_id(), self::TAXONOMY );
 		}
 
 		wp_delete_term( $subscription->ID, self::TAXONOMY );
@@ -115,20 +285,29 @@ class Subscription extends User {
 		return $user;
 	}
 
-	public static function create( $user_login, $role, $user_url, $display_name = null, $icon_url = null, $description = null ) {
+	public static function create( $user_login, $role, $user_url, $display_name = null, $icon_url = null, $description = null, $created = null ) {
+		$term = term_exists( $user_login, self::TAXONOMY );
 
-		$term = wp_insert_term( $user_login, self::TAXONOMY );
-
-		if ( is_wp_error( $term ) ) {
-			return $term;
+		if ( ! $term || ! isset( $term['term_id'] ) ) {
+			$term = wp_insert_term( $user_login, self::TAXONOMY );
+			if ( is_wp_error( $term ) ) {
+				return $term;
+			}
 		}
 
 		$term_id = $term['term_id'];
-		add_metadata( 'term', $term_id, 'role', $role, true );
+		delete_metadata( 'term', $term_id, 'roles' );
+		add_metadata( 'term', $term_id, 'roles', $role, true );
+		delete_metadata( 'term', $term_id, 'user_url' );
 		add_metadata( 'term', $term_id, 'user_url', $user_url, true );
+		delete_metadata( 'term', $term_id, 'display_name' );
 		add_metadata( 'term', $term_id, 'display_name', $display_name, true );
+		delete_metadata( 'term', $term_id, 'icon_url' );
 		add_metadata( 'term', $term_id, 'icon_url', $icon_url, true );
+		delete_metadata( 'term', $term_id, 'description' );
 		add_metadata( 'term', $term_id, 'description', $description, true );
+		delete_metadata( 'term', $term_id, 'created' );
+		add_metadata( 'term', $term_id, 'created', $created ? $created : gmdate( 'Y-m-d H:i:s' ), true );
 
 		$term = get_term( $term['term_id'] );
 		if ( is_wp_error( $term ) ) {

--- a/includes/class-subscription.php
+++ b/includes/class-subscription.php
@@ -462,16 +462,25 @@ class Subscription extends User {
 		}
 
 		$term_id = $term['term_id'];
+
 		delete_metadata( 'term', $term_id, 'roles' );
 		add_metadata( 'term', $term_id, 'roles', $role, true );
 		delete_metadata( 'term', $term_id, 'user_url' );
 		add_metadata( 'term', $term_id, 'user_url', $user_url, true );
+
 		delete_metadata( 'term', $term_id, 'display_name' );
-		add_metadata( 'term', $term_id, 'display_name', $display_name, true );
+		if ( $display_name ) {
+			add_metadata( 'term', $term_id, 'display_name', $display_name, true );
+		}
+
 		delete_metadata( 'term', $term_id, 'avatar_url' );
-		add_metadata( 'term', $term_id, 'avatar_url', $avatar_url, true );
+		if ( $avatar_url ) {
+			add_metadata( 'term', $term_id, 'avatar_url', $avatar_url, true );
+		}
 		delete_metadata( 'term', $term_id, 'description' );
-		add_metadata( 'term', $term_id, 'description', $description, true );
+		if ( $description ) {
+			add_metadata( 'term', $term_id, 'description', $description, true );
+		}
 		delete_metadata( 'term', $term_id, 'created' );
 		add_metadata( 'term', $term_id, 'created', $user_registered ? $user_registered : gmdate( 'Y-m-d H:i:s' ), true );
 

--- a/includes/class-subscription.php
+++ b/includes/class-subscription.php
@@ -86,14 +86,13 @@ class Subscription extends User {
 		return new \WP_Error( 'user-not-found' );
 	}
 
-	public function save_post( array $postarr, $wp_error = false, $fire_after_hooks = true ) {
-		if ( ! isset( $postarr['tax_input'] ) ) {
-			$postarr['tax_input'] = array();
+	public function insert_post( array $postarr, $wp_error = false, $fire_after_hooks = true ) {
+		$post_id = wp_insert_post( $postarr, $wp_error, $fire_after_hooks );
+		if ( ! is_wp_error( $post_id ) ) {
+			wp_set_object_terms( $post_id, $this->get_term_id(), self::TAXONOMY );
 		}
-		$postarr['tax_input'][ self::TAXONOMY ] = array( $this->get_term_id() );
-		$post = wp_insert_post( $postarr, $wp_error, $fire_after_hooks );
 
-		return $post;
+		return $post_id;
 	}
 
 	public function modify_query_by_author( \WP_Query $query ) {
@@ -401,7 +400,7 @@ class Subscription extends User {
 
 		global $wpdb;
 		// Convert feeds.
-		$wpdb->query( $wpdb->prepare( "UPDATE $wpdb->term_relationships JOIN $wpdb->term_taxonomy ON $wpdb->term_relationships.term_taxonomy_id = $wpdb->term_taxonomy.term_taxonomy_id SET object_id = %d WHERE object_id = %d AND $wpdb->term_taxonomy.taxonomy = %s", $subscription->get_term_id(), $user->ID, USER_FEED::TAXONOMY ) );
+		$wpdb->query( $wpdb->prepare( "UPDATE $wpdb->term_relationships JOIN $wpdb->term_taxonomy ON $wpdb->term_relationships.term_taxonomy_id = $wpdb->term_taxonomy.term_taxonomy_id SET object_id = %d WHERE object_id = %d AND $wpdb->term_taxonomy.taxonomy = %s", $subscription->get_term_id(), $user->ID, User_Feed::TAXONOMY ) );
 
 		$user->delete();
 
@@ -429,7 +428,7 @@ class Subscription extends User {
 
 		global $wpdb;
 		// Convert feeds.
-		$wpdb->query( $wpdb->prepare( "UPDATE $wpdb->term_relationships JOIN $wpdb->term_taxonomy ON $wpdb->term_relationships.term_taxonomy_id = $wpdb->term_taxonomy.term_taxonomy_id SET object_id = %d WHERE object_id = %d AND $wpdb->term_taxonomy.taxonomy = %s", $user->ID, $subscription->get_term_id(), USER_FEED::TAXONOMY ) );
+		$wpdb->query( $wpdb->prepare( "UPDATE $wpdb->term_relationships JOIN $wpdb->term_taxonomy ON $wpdb->term_relationships.term_taxonomy_id = $wpdb->term_taxonomy.term_taxonomy_id SET object_id = %d WHERE object_id = %d AND $wpdb->term_taxonomy.taxonomy = %s", $user->ID, $subscription->get_term_id(), User_Feed::TAXONOMY ) );
 
 		$subscription->delete();
 

--- a/includes/class-subscription.php
+++ b/includes/class-subscription.php
@@ -180,7 +180,7 @@ class Subscription extends User {
 			'U',
 			$wpdb->get_var(
 				$wpdb->prepare(
-					"SELECT MIN(post_date) FROM $wpdb->posts p, ' . $wpdb->term_taxonomy . ' t, ' . $wpdb->term_relationships . ' r WHERE r.object_id = p.ID AND r.term_taxonomy_id = t    .term_taxonomy_id AND t.term_id = %d AND p.post_status = 'publish' AND p.post_type IN ( " . implode( ', ', array_fill( 0, count( $post_types ), '%s' ) ) . ' )',
+					"SELECT MIN(post_date) FROM $wpdb->posts p, ' . $wpdb->term_taxonomy . ' t, ' . $wpdb->term_relationships . ' r WHERE r.object_id = p.ID AND r.term_taxonomy_id = t.term_taxonomy_id AND t.term_id = %d AND p.post_status = 'publish' AND p.post_type IN ( " . implode( ', ', array_fill( 0, count( $post_types ), '%s' ) ) . ' )',
 					array_merge( array( $this->get_term_id() ), $post_types )
 				)
 			)

--- a/includes/class-subscription.php
+++ b/includes/class-subscription.php
@@ -71,6 +71,13 @@ class Subscription extends User {
 
 
 	public static function get_by_username( $username ) {
+		if ( 0 === strpos( $username, 'friends-virtual-user-' ) ) {
+			$term_id = substr( $username, strlen( 'friends-virtual-user-' ) );
+			$term = get_term( $term_id, self::TAXONOMY );
+			if ( $term ) {
+				return new self( $term );
+			}
+		}
 		$term_query = new \WP_Term_Query(
 			array(
 				'taxonomy'   => self::TAXONOMY,

--- a/includes/class-subscription.php
+++ b/includes/class-subscription.php
@@ -97,7 +97,6 @@ class Subscription extends User {
 	}
 
 	public function modify_query_by_author( \WP_Query $query ) {
-		$query->set( 'author', get_current_user_id() );
 		$tax_query = $query->get( 'tax_query' );
 		if ( ! $tax_query ) {
 			$tax_query = array();
@@ -229,8 +228,7 @@ class Subscription extends User {
 						JOIN %s AS taxonomy_author
 						JOIN %s AS relationships_author
 
-						WHERE posts.post_author = %s
-						AND posts.post_status IN ( 'publish', 'private' )
+						WHERE posts.post_status IN ( 'publish', 'private' )
 						AND posts.post_type IN ( %s )
 						AND relationships_post_format.object_id = posts.ID
 						AND relationships_author.object_id = posts.ID
@@ -245,7 +243,6 @@ class Subscription extends User {
 						'%d'
 					),
 					array_merge(
-						array( get_current_user_id() ),
 						$post_types,
 						array( $this->get_term_id() )
 					)
@@ -261,8 +258,7 @@ class Subscription extends User {
 						JOIN %s AS taxonomy_author
 						JOIN %s AS relationships_author
 
-						WHERE posts.post_author = %s
-						AND posts.post_status IN ( 'publish', 'private' )
+						WHERE posts.post_status IN ( 'publish', 'private' )
 						AND posts.post_type IN ( %s )
 						AND relationships_post_format.object_id = posts.ID
 						AND relationships_post_format.term_taxonomy_id IN ( %s )
@@ -280,7 +276,6 @@ class Subscription extends User {
 						'%d'
 					),
 					array_merge(
-						array( get_current_user_id() ),
 						$post_types,
 						array_keys( $post_formats_term_ids ),
 						array( $this->get_term_id() )
@@ -312,8 +307,8 @@ class Subscription extends User {
 
 		$count = $wpdb->get_var(
 			$wpdb->prepare(
-				"SELECT COUNT(*) FROM $wpdb->posts p, $wpdb->term_relationships r WHERE r.object_id = p.ID AND r.term_taxonomy_id = %d AND post_type IN ( " . implode( ', ', array_fill( 0, count( $post_types ), '%s' ) ) . ' ) AND post_status = "trash" AND post_author = %d ',
-				array_merge( array( $this->get_term_id() ), $post_types, array( get_current_user_id() ) )
+				"SELECT COUNT(*) FROM $wpdb->posts p, $wpdb->term_relationships r WHERE r.object_id = p.ID AND r.term_taxonomy_id = %d AND post_type IN ( " . implode( ', ', array_fill( 0, count( $post_types ), '%s' ) ) . ' ) AND post_status = "trash"',
+				array_merge( array( $this->get_term_id() ), $post_types )
 			)
 		);
 
@@ -401,7 +396,7 @@ class Subscription extends User {
 		$query = $user->modify_query_by_author( $query );
 
 		foreach ( $query->get_posts() as $post ) {
-			$post->post_author = get_current_user_id();
+			$post->post_author = 0;
 			wp_update_post( $post );
 			wp_set_object_terms( $post->ID, $subscription->get_term_id(), self::TAXONOMY );
 		}

--- a/includes/class-subscription.php
+++ b/includes/class-subscription.php
@@ -305,7 +305,7 @@ class Subscription extends User {
 
 		$count = $wpdb->get_var(
 			$wpdb->prepare(
-				"SELECT COUNT(*) FROM $wpdb->posts p, $wpdb->term_relationships r WHERE r.object_id = p.ID AND r.term_taxonomy_id = %d AND post_type IN ( " . implode( ', ', array_fill( 0, count( $post_types ), '%s' ) ) . ' ) AND post_status = "trash"',
+				"SELECT COUNT(*) FROM $wpdb->posts p, $wpdb->term_taxonomy t, $wpdb->term_relationships r WHERE r.object_id = p.ID AND r.term_taxonomy_id = t.term_taxonomy_id AND t.term_id = %d AND post_type IN ( " . implode( ', ', array_fill( 0, count( $post_types ), '%s' ) ) . ' ) AND post_status = "trash"',
 				array_merge( array( $this->get_term_id() ), $post_types )
 			)
 		);
@@ -389,7 +389,7 @@ class Subscription extends User {
 
 		$query = new \WP_Query();
 		$query->set( 'post_type', apply_filters( 'friends_frontend_post_types', array() ) );
-		$query->set( 'post_status', array( 'publish', 'private', 'draft', 'trashed' ) );
+		$query->set( 'post_status', array( 'publish', 'private', 'draft', 'trash' ) );
 		$query->set( 'posts_per_page', -1 );
 		$query = $user->modify_query_by_author( $query );
 

--- a/includes/class-subscription.php
+++ b/includes/class-subscription.php
@@ -170,7 +170,7 @@ class Subscription extends User {
 					LENGTH( comment_count )
 					) AS total_size,
 					COUNT(*) as post_count
-				FROM ' . $wpdb->posts . ' p, ' . $wpdb->term_relationships . ' r WHERE r.object_id = p.ID AND r.term_taxonomy_id = %d AND p.post_type IN ( ' . implode( ', ', array_fill( 0, count( $post_types ), '%s' ) ) . ' )',
+				FROM ' . $wpdb->posts . ' p, ' . $wpdb->term_taxonomy . ' t, ' . $wpdb->term_relationships . ' r WHERE r.object_id = p.ID AND r.term_taxonomy_id = t    .term_taxonomy_id AND t.term_id = %d AND p.post_type IN ( ' . implode( ', ', array_fill( 0, count( $post_types ), '%s' ) ) . ' )',
 				array_merge( array( $this->get_term_id() ), $post_types )
 			),
 			ARRAY_A
@@ -180,7 +180,7 @@ class Subscription extends User {
 			'U',
 			$wpdb->get_var(
 				$wpdb->prepare(
-					"SELECT MIN(post_date) FROM $wpdb->posts p, $wpdb->term_relationships r WHERE r.object_id = p.ID AND r.term_taxonomy_id = %d AND p.post_status = 'publish' AND p.post_type IN ( " . implode( ', ', array_fill( 0, count( $post_types ), '%s' ) ) . ' )',
+					"SELECT MIN(post_date) FROM $wpdb->posts p, ' . $wpdb->term_taxonomy . ' t, ' . $wpdb->term_relationships . ' r WHERE r.object_id = p.ID AND r.term_taxonomy_id = t    .term_taxonomy_id AND t.term_id = %d AND p.post_status = 'publish' AND p.post_type IN ( " . implode( ', ', array_fill( 0, count( $post_types ), '%s' ) ) . ' )',
 					array_merge( array( $this->get_term_id() ), $post_types )
 				)
 			)
@@ -226,6 +226,7 @@ class Subscription extends User {
 						"SELECT COUNT(DISTINCT posts.ID)
 						FROM %s AS posts
 						JOIN %s AS relationships_post_format
+						JOIN %s AS taxonomy_author
 						JOIN %s AS relationships_author
 
 						WHERE posts.post_author = %s
@@ -233,9 +234,11 @@ class Subscription extends User {
 						AND posts.post_type IN ( %s )
 						AND relationships_post_format.object_id = posts.ID
 						AND relationships_author.object_id = posts.ID
-						AND relationships_author.term_taxonomy_id = %s",
+						AND taxonomy_author.term_taxonomy_id = relationships_author.term_taxonomy_id
+						AND taxonomy_author.term_id = %s",
 						$wpdb->posts,
 						$wpdb->term_relationships,
+						$wpdb->term_taxonomy,
 						$wpdb->term_relationships,
 						'%d',
 						implode( ',', array_fill( 0, count( $post_types ), '%s' ) ),
@@ -255,6 +258,7 @@ class Subscription extends User {
 						"SELECT relationships_post_format.term_taxonomy_id AS post_format_id, COUNT(relationships_post_format.term_taxonomy_id) AS count
 						FROM %s AS posts
 						JOIN %s AS relationships_post_format
+						JOIN %s AS taxonomy_author
 						JOIN %s AS relationships_author
 
 						WHERE posts.post_author = %s
@@ -263,10 +267,12 @@ class Subscription extends User {
 						AND relationships_post_format.object_id = posts.ID
 						AND relationships_post_format.term_taxonomy_id IN ( %s )
 						AND relationships_author.object_id = posts.ID
-						AND relationships_author.term_taxonomy_id = %s
+						AND taxonomy_author.term_taxonomy_id = relationships_author.term_taxonomy_id
+						AND taxonomy_author.term_id = %s
 						GROUP BY relationships_post_format.term_taxonomy_id",
 						$wpdb->posts,
 						$wpdb->term_relationships,
+						$wpdb->term_taxonomy,
 						$wpdb->term_relationships,
 						'%d',
 						implode( ',', array_fill( 0, count( $post_types ), '%s' ) ),

--- a/includes/class-subscription.php
+++ b/includes/class-subscription.php
@@ -73,7 +73,7 @@ class Subscription extends User {
 	public static function get_by_username( $username ) {
 		if ( 0 === strpos( $username, 'friends-virtual-user-' ) ) {
 			$term_id = substr( $username, strlen( 'friends-virtual-user-' ) );
-			$term = get_term( $term_id, self::TAXONOMY );
+			$term = get_term( intval( $term_id ), self::TAXONOMY );
 			if ( $term ) {
 				return new self( $term );
 			}

--- a/includes/class-third-parties.php
+++ b/includes/class-third-parties.php
@@ -65,6 +65,6 @@ class Third_Parties {
 	 * @return array
 	 */
 	public function wp_sweep_excluded_taxonomies( $excluded_taxonomies ) {
-		return array_merge( $excluded_taxonomies, array( User_Feed::TAXONOMY ) );
+		return array_merge( $excluded_taxonomies, array( User_Feed::TAXONOMY, Subscription::TAXONOMY ) );
 	}
 }

--- a/includes/class-user-feed.php
+++ b/includes/class-user-feed.php
@@ -139,8 +139,9 @@ class User_Feed {
 		$users = array();
 		$user_ids = get_objects_in_term( $this->term->term_id, self::TAXONOMY );
 		foreach ( $user_ids as $user_id ) {
-			if ( term_exists( intval( $user_id ), Subscription::TAXONOMY ) ) {
-				$users[] = new Subscription( get_term( intval( $user_id ), Subscription::TAXONOMY ) );
+			$term_id = term_exists( intval( $user_id ), Subscription::TAXONOMY );
+			if ( $term_id ) {
+				$users[] = new Subscription( get_term( $term_id['term_id'], Subscription::TAXONOMY ) );
 			} else {
 				$user = get_userdata( $user_id );
 				if ( $user && ! is_wp_error( $user ) ) {

--- a/includes/class-user-feed.php
+++ b/includes/class-user-feed.php
@@ -139,8 +139,8 @@ class User_Feed {
 		$users = array();
 		$user_ids = get_objects_in_term( $this->term->term_id, self::TAXONOMY );
 		foreach ( $user_ids as $user_id ) {
-			if ( term_exists( $user_id, Subscription::TAXONOMY ) ) {
-				$users[] = new Subscription( get_term( $user_id, Subscription::TAXONOMY ) );
+			if ( term_exists( intval( $user_id ), Subscription::TAXONOMY ) ) {
+				$users[] = new Subscription( get_term( intval( $user_id ), Subscription::TAXONOMY ) );
 			} else {
 				$user = get_userdata( $user_id );
 				if ( $user && ! is_wp_error( $user ) ) {

--- a/includes/class-user-feed.php
+++ b/includes/class-user-feed.php
@@ -122,19 +122,33 @@ class User_Feed {
 	 */
 	public function get_friend_user() {
 		if ( empty( $this->friend_user ) ) {
-			$user_ids = get_objects_in_term( $this->term->term_id, self::TAXONOMY );
-			if ( ! empty( $user_ids ) ) {
-				$user_id = reset( $user_ids );
-				$user_id = intval( $user_id );
-				if ( term_exists( $user_id, Subscription::TAXONOMY ) ) {
-					$this->friend_user = new Subscription( get_term( $user_id, Subscription::TAXONOMY ) );
-				} else {
-					$this->friend_user = new User( $user_id );
+			$users = $this->get_all_friend_users();
+			$this->friend_user = reset( $users );
+		}
+
+		return $this->friend_user;
+	}
+
+	/**
+	 * Gets the friend users associated wit the term.
+	 *
+	 * @return array(User) The associated users.
+	 */
+	public function get_all_friend_users() {
+		$users = array();
+		$user_ids = get_objects_in_term( $this->term->term_id, self::TAXONOMY );
+		foreach ( $user_ids as $user_id ) {
+			if ( term_exists( $user_id, Subscription::TAXONOMY ) ) {
+				$users[] = new Subscription( get_term( $user_id, Subscription::TAXONOMY ) );
+			} else {
+				$user = get_userdata( $user_id );
+				if ( $user && ! is_wp_error( $user ) ) {
+					$users[] = new User( $user );
 				}
 			}
 		}
 
-		return $this->friend_user;
+		return $users;
 	}
 
 	/**

--- a/includes/class-user-feed.php
+++ b/includes/class-user-feed.php
@@ -86,7 +86,7 @@ class User_Feed {
 		$feed_url = $this->get_url();
 		$friend_user = $this->get_friend_user();
 
-		if ( $friend_user->is_friend_url( $feed_url ) && ( friends::has_required_privileges() || wp_doing_cron() ) ) {
+		if ( $friend_user && $friend_user instanceof User && $friend_user->is_friend_url( $feed_url ) && ( friends::has_required_privileges() || wp_doing_cron() ) ) {
 			$friends = Friends::get_instance();
 			$feed_url = $friends->access_control->append_auth( $feed_url, $friend_user, $validity );
 		}

--- a/includes/class-user-feed.php
+++ b/includes/class-user-feed.php
@@ -617,31 +617,6 @@ class User_Feed {
 	}
 
 	/**
-	 * Fetch the feeds associated with the User.
-	 *
-	 * @param  \WP_User $friend_user The user we're looking for.
-	 * @return array                    An array of User_Feed objects.
-	 */
-	public static function get_for_user( \WP_User $friend_user ) {
-		if ( ! $friend_user instanceof User ) {
-			return array();
-		}
-
-		$term_query = new \WP_Term_Query(
-			array(
-				'taxonomy'   => self::TAXONOMY,
-				'object_ids' => $friend_user->ID,
-			)
-		);
-		$feeds = array();
-		foreach ( $term_query->get_terms() as $term ) {
-			$feeds[ $term->term_id ] = new self( $term, $friend_user );
-		}
-
-		return $feeds;
-	}
-
-	/**
 	 * Get the feed with the specific id.
 	 *
 	 * @param      int $id     The feed id.

--- a/includes/class-user-feed.php
+++ b/includes/class-user-feed.php
@@ -9,6 +9,8 @@
 
 namespace Friends;
 
+use WP_Error;
+
 /**
  * This is the class for the feed URLs part of the Friends Plugin.
  *
@@ -553,8 +555,12 @@ class User_Feed {
 			)
 		);
 
-		if ( ! isset( $all_urls[ $url ] ) ) {
-			return false;
+		if ( is_wp_error( $all_urls ) ) {
+			return $all_urls;
+		}
+
+		if ( ! is_array( $all_urls ) || ! isset( $all_urls[ $url ] ) ) {
+			return new \WP_Error( 'cound-not-save-feed' );
 		}
 
 		$term_id = $all_urls[ $url ];

--- a/includes/class-user-feed.php
+++ b/includes/class-user-feed.php
@@ -21,6 +21,7 @@ use WP_Error;
  */
 class User_Feed {
 	const TAXONOMY = 'friend-user-feed';
+	const POST_TAXONOMY = 'friend-post-feed';
 	const INTERVAL_BACKTRACK = 600;
 
 	/**
@@ -381,6 +382,22 @@ class User_Feed {
 	 * Registers the taxonomy
 	 */
 	public static function register_taxonomy() {
+		$args = array(
+			'labels'            => array(
+				'name'          => _x( 'Posts from Feed', 'taxonomy general name', 'friends' ),
+				'singular_name' => _x( 'Post from Feed', 'taxonomy singular name', 'friends' ),
+				'menu_name'     => __( 'Post from Feed', 'friends' ),
+			),
+			'hierarchical'      => false,
+			'show_ui'           => true,
+			'show_admin_column' => true,
+			'query_var'         => true,
+			'rewrite'           => false,
+			'public'            => false,
+		);
+		register_taxonomy( self::POST_TAXONOMY, 'post', $args );
+		register_taxonomy_for_object_type( self::POST_TAXONOMY, 'post' );
+
 		$args = array(
 			'labels'            => array(
 				'name'          => _x( 'Feed URL', 'taxonomy general name', 'friends' ),

--- a/includes/class-user-query.php
+++ b/includes/class-user-query.php
@@ -85,8 +85,23 @@ class User_Query extends \WP_User_Query {
 					'orderby'  => 'display_name',
 				)
 			);
+			$all[ get_current_blog_id() ]->augment_results_with_virtual_subscriptions();
 		}
 		return $all[ get_current_blog_id() ];
+	}
+
+	public function augment_results_with_virtual_subscriptions() {
+		$term_query = new \WP_Term_Query(
+			array(
+				'taxonomy'   => Subscription::TAXONOMY,
+				'hide_empty' => false,
+			)
+		);
+
+		foreach ( $term_query->get_terms() as $term ) {
+			$this->results[] = new Subscription( $term );
+		}
+
 	}
 
 	/**

--- a/includes/class-user-query.php
+++ b/includes/class-user-query.php
@@ -96,6 +96,9 @@ class User_Query extends \WP_User_Query {
 		if ( isset( $args['meta_key'] ) && str_ends_with( $args['meta_key'], '_starred' ) ) {
 			$args['meta_key'] = 'starred';
 		}
+		if ( isset( $args['search'] ) ) {
+			$args['search'] = str_replace( '*', '', $args['search'] );
+		}
 
 		$term_query = new \WP_Term_Query(
 			array_merge(
@@ -196,15 +199,28 @@ class User_Query extends \WP_User_Query {
 	 * @return     self    The search result.
 	 */
 	public static function search( $query ) {
-		return new self(
-			array(
-				'role__in'       => array( 'friend', 'acquaintance', 'pending_friend_request', 'subscription' ),
-				'order'          => 'ASC',
-				'orderby'        => 'display_name',
-				'search'         => $query,
-				'search_columns' => array( 'display_name' ),
+		$query = array(
+			'search' => $query,
+		);
+		$sort = array(
+			'order'   => 'ASC',
+			'orderby' => 'display_name',
+		);
+		$search = new self(
+			array_merge(
+				array(
+					'role__in'       => array( 'friend', 'acquaintance', 'pending_friend_request', 'subscription' ),
+					'search_columns' => array( 'display_name' ),
+				),
+				$query,
+				$sort
 			)
 		);
+
+		$search->add_virtual_subscriptions( $query );
+		$search->sort( $sort['orderby'], $sort['order'] );
+		return $search;
+
 	}
 
 	/**

--- a/includes/class-user-query.php
+++ b/includes/class-user-query.php
@@ -177,15 +177,22 @@ class User_Query extends \WP_User_Query {
 		static $recent_friends_subscriptions = array();
 		$cache_key = get_current_blog_id() . '_' . $limit;
 		if ( ! self::$cache || ! isset( $recent_friends_subscriptions[ $cache_key ] ) ) {
+			$query = array(
+				'role__in' => array( 'friend', 'acquaintance', 'pending_friend_request', 'subscription' ),
+				'number'   => $limit,
+			);
+			$sort = array(
+				'orderby' => 'user_registered',
+				'order'   => 'DESC',
+			);
 			$recent_friends_subscriptions[ $cache_key ] = new self(
-				array(
-					'role__in' => array( 'friend', 'acquaintance', 'pending_friend_request', 'subscription' ),
-					'number'   => $limit,
-					'orderby'  => 'registered',
-					'order'    => 'DESC',
+				array_merge(
+					$query,
+					$sort
 				)
 			);
 			$recent_friends_subscriptions[ $cache_key ]->add_virtual_subscriptions();
+			$recent_friends_subscriptions[ $cache_key ]->sort( $sort['orderby'], $sort['order'] );
 			$recent_friends_subscriptions[ $cache_key ]->limit( $limit );
 		}
 		return $recent_friends_subscriptions[ $cache_key ];

--- a/includes/class-user.php
+++ b/includes/class-user.php
@@ -71,7 +71,7 @@ class User extends \WP_User {
 	 */
 	public static function create( $user_login, $role, $url, $display_name = null, $icon_url = null, $description = null ) {
 		if ( 'subscription' === $role ) {
-			return Subscription::create( $user_login, $role, $url, $display_name, $icon_url, $description );
+			// return Subscription::create( $user_login, $role, $url, $display_name, $icon_url, $description ); //.
 		}
 		$role_rank = array_flip(
 			array(

--- a/includes/class-user.php
+++ b/includes/class-user.php
@@ -148,7 +148,11 @@ class User extends \WP_User {
 	 * @param      \WP_User $user   The user.
 	 */
 	public static function friends_get_user_feeds( $feeds, $user ) {
-		return array_merge( $feeds, $user->get_feeds() );
+		$user_feeds = $user->get_feeds();
+		if ( is_array( $user_feeds ) ) {
+			$feeds = array_merge( $feeds, $user_feeds );
+		}
+		return $feeds;
 	}
 
 	/**

--- a/includes/class-user.php
+++ b/includes/class-user.php
@@ -734,7 +734,7 @@ class User extends \WP_User {
 					),
 					array_merge(
 						array( $this->ID ),
-						$post_types,
+						$post_types
 					)
 				)
 			);

--- a/includes/class-user.php
+++ b/includes/class-user.php
@@ -730,7 +730,7 @@ class User extends \WP_User {
 						$wpdb->posts,
 						$wpdb->term_relationships,
 						'%d',
-						implode( ',', array_fill( 0, count( $post_types ), '%s' ) ),
+						implode( ',', array_fill( 0, count( $post_types ), '%s' ) )
 					),
 					array_merge(
 						array( $this->ID ),

--- a/includes/class-user.php
+++ b/includes/class-user.php
@@ -42,7 +42,7 @@ class User extends \WP_User {
 		if ( $user && ! is_wp_error( $user ) ) {
 			return new self( $user );
 		}
-		return Subscription::get_by_username( $username );
+		return $user;
 	}
 
 	public static function get_post_author( \WP_Post $post ) {

--- a/includes/class-user.php
+++ b/includes/class-user.php
@@ -314,7 +314,7 @@ class User extends \WP_User {
 		return $friends->messages->send_message( $this, $message, $subject );
 	}
 
-	public function save_post( array $postarr, $wp_error = false, $fire_after_hooks = true ) {
+	public function insert_post( array $postarr, $wp_error = false, $fire_after_hooks = true ) {
 		$current_user = wp_get_current_user();
 
 		// Posts and revisions should be associated with this user.

--- a/includes/class-user.php
+++ b/includes/class-user.php
@@ -294,9 +294,11 @@ class User extends \WP_User {
 	public function __get( $key ) {
 		if ( 'user_url' === $key && empty( $this->data->user_url ) && is_multisite() ) {
 			$site = get_active_blog_for_user( $this->ID );
-			// Ensure we're using the same URL protocol.
-			$this->data->user_url = set_url_scheme( $site->siteurl );
-			return $this->data->user_url;
+			if ( $site ) {
+				// Ensure we're using the same URL protocol.
+				$this->data->user_url = set_url_scheme( $site->siteurl );
+				return $this->data->user_url;
+			}
 		}
 
 		return parent::__get( $key );

--- a/includes/class-user.php
+++ b/includes/class-user.php
@@ -517,7 +517,7 @@ class User extends \WP_User {
 			foreach ( $args as $key => $value ) {
 				$query->set( $key, $value );
 			}
-			$query = $query->modify_query_by_author( $query );
+			$query = $this->modify_query_by_author( $query );
 
 			foreach ( $query->get_posts() as $post ) {
 				if ( apply_filters( 'friends_debug', false ) && ! wp_doing_cron() ) {
@@ -537,7 +537,7 @@ class User extends \WP_User {
 			foreach ( $args as $key => $value ) {
 				$query->set( $key, $value );
 			}
-			$query = $query->modify_query_by_author( $query );
+			$query = $this->modify_query_by_author( $query );
 
 			foreach ( $query->get_posts() as $post ) {
 				if ( apply_filters( 'friends_debug', false ) && ! wp_doing_cron() ) {
@@ -556,7 +556,7 @@ class User extends \WP_User {
 			foreach ( $args as $key => $value ) {
 				$query->set( $key, $value );
 			}
-			$query = $query->modify_query_by_author( $query );
+			$query = $this->modify_query_by_author( $query );
 
 			foreach ( $query->get_posts() as $post ) {
 				if ( apply_filters( 'friends_debug', false ) && ! wp_doing_cron() ) {
@@ -578,7 +578,7 @@ class User extends \WP_User {
 		foreach ( $args as $key => $value ) {
 			$query->set( $key, $value );
 		}
-		$query = $query->modify_query_by_author( $query );
+		$query = $this->modify_query_by_author( $query );
 
 		foreach ( $query->get_posts() as $post ) {
 			if ( apply_filters( 'friends_debug', false ) && ! wp_doing_cron() ) {

--- a/includes/class-user.php
+++ b/includes/class-user.php
@@ -51,7 +51,7 @@ class User extends \WP_User {
 			return new self( $post->post_author );
 		}
 
-		return array_pop( $subscriptions );
+		return new Subscription( reset( $subscriptions ) );
 	}
 
 	/**

--- a/includes/class-user.php
+++ b/includes/class-user.php
@@ -214,6 +214,9 @@ class User extends \WP_User {
 		}
 
 		$host = wp_parse_url( $url, PHP_URL_HOST );
+		if ( ! $host ) {
+			return false;
+		}
 		$path = wp_parse_url( $url, PHP_URL_PATH );
 
 		$site_id = get_blog_id_from_url( $host, trailingslashit( $path ) );
@@ -354,15 +357,7 @@ class User extends \WP_User {
 				'title'       => $this->display_name . ' RSS Feed',
 			);
 
-			$feed_options = array();
-			foreach ( $default_options as $key => $value ) {
-				if ( isset( $options[ $key ] ) ) {
-					$feed_options[ $key ] = $options[ $key ];
-				} else {
-					$feed_options[ $key ] = $value;
-				}
-			}
-			$feeds[ $feed_url ] = $feed_options;
+			$feeds[ $feed_url ] = array_merge( $default_options, $options );
 		}
 
 		$all_urls = array();
@@ -385,7 +380,8 @@ class User extends \WP_User {
 			}
 			$term_id = $all_urls[ $url ];
 			foreach ( $feed_options as $key => $value ) {
-				if ( in_array( $key, array( 'active', 'parser', 'post-format', 'mime-type', 'title' ) ) ) {
+				if ( in_array( $key, array( 'active', 'parser', 'post-format', 'mime-type', 'title', 'interval', 'modifier' ) ) ) {
+
 					if ( metadata_exists( 'term', $term_id, $key ) ) {
 						update_metadata( 'term', $term_id, $key, $value );
 					} else {

--- a/includes/class-user.php
+++ b/includes/class-user.php
@@ -727,7 +727,7 @@ class User extends \WP_User {
 			$counts['standard'] = $wpdb->get_var(
 				$wpdb->prepare(
 					sprintf(
-						"SELECT COUNT(*)
+						"SELECT COUNT(DISTINCT posts.ID)
 						FROM %s AS posts
 						JOIN %s AS relationships_post_format
 

--- a/templates/admin/edit-feeds.php
+++ b/templates/admin/edit-feeds.php
@@ -8,7 +8,7 @@
 
 $active_feeds = $args['friend']->get_active_feeds();
 $feeds = $args['friend']->get_feeds();
-var_dump( $args['friend']->get_term_id() );
+
 $has_last_log = false;
 ?><form method="post">
 	<?php wp_nonce_field( 'edit-friend-feeds-' . $args['friend']->user_login ); ?>

--- a/templates/admin/edit-feeds.php
+++ b/templates/admin/edit-feeds.php
@@ -42,7 +42,7 @@ $has_last_log = false;
 							}
 							?>
 							<tr class="<?php echo esc_attr( ( ++$alternate % 2 ? 'alternate ' : ' ' ) . ( $feed->get_active() ? 'active' : 'inactive hidden' ) ); ?>">
-								<th class="checkbox"><?php echo esc_attr( $term_id ); ?><input type="checkbox" name="feeds[<?php echo esc_attr( $term_id ); ?>][active]" value="1" aria-label="<?php esc_attr_e( 'Feed is active', 'friends' ); ?>"<?php checked( $feed->get_active() ); ?> /></th>
+								<th class="checkbox"><input type="checkbox" name="feeds[<?php echo esc_attr( $term_id ); ?>][active]" value="1" aria-label="<?php esc_attr_e( 'Feed is active', 'friends' ); ?>"<?php checked( $feed->get_active() ); ?> /></th>
 								<td><input type="text" name="feeds[<?php echo esc_attr( $term_id ); ?>][url]" value="<?php echo esc_attr( $feed->get_url() ); ?>" size="30" aria-label="<?php esc_attr_e( 'Feed URL', 'friends' ); ?>" class="url" /></td>
 								<td class="nowrap"><select name="feeds[<?php echo esc_attr( $term_id ); ?>][parser]" aria-label="<?php esc_attr_e( 'Parser', 'friends' ); ?>">
 									<?php foreach ( $args['registered_parsers'] as $slug => $parser_name ) : ?>

--- a/templates/admin/edit-feeds.php
+++ b/templates/admin/edit-feeds.php
@@ -10,7 +10,7 @@ $active_feeds = $args['friend']->get_active_feeds();
 $feeds = $args['friend']->get_feeds();
 $has_last_log = false;
 ?><form method="post">
-	<?php wp_nonce_field( 'edit-friend-feeds-' . $args['friend']->ID ); ?>
+	<?php wp_nonce_field( 'edit-friend-feeds-' . $args['friend']->user_login ); ?>
 	<table class="form-table">
 		<tbody>
 			<tr>

--- a/templates/admin/edit-feeds.php
+++ b/templates/admin/edit-feeds.php
@@ -125,7 +125,7 @@ $has_last_log = false;
 				<td>
 					<fieldset>
 						<label for="show_on_friends_page">
-							<input name="show_on_friends_page" type="checkbox" id="show_on_friends_page" value="1" <?php checked( '1', ! in_array( $args['friend']->ID, $args['hide_from_friends_page'] ) ); ?>>
+							<input name="show_on_friends_page" type="checkbox" id="show_on_friends_page" value="1" <?php checked( '1', ! in_array( $args['friend']->user_login, $args['hide_from_friends_page'] ) ); ?>>
 							<?php esc_html_e( 'Show posts on your friends page', 'friends' ); ?>
 						</label>
 					</fieldset>

--- a/templates/admin/edit-feeds.php
+++ b/templates/admin/edit-feeds.php
@@ -8,6 +8,7 @@
 
 $active_feeds = $args['friend']->get_active_feeds();
 $feeds = $args['friend']->get_feeds();
+var_dump( $args['friend']->get_term_id() );
 $has_last_log = false;
 ?><form method="post">
 	<?php wp_nonce_field( 'edit-friend-feeds-' . $args['friend']->user_login ); ?>
@@ -41,7 +42,7 @@ $has_last_log = false;
 							}
 							?>
 							<tr class="<?php echo esc_attr( ( ++$alternate % 2 ? 'alternate ' : ' ' ) . ( $feed->get_active() ? 'active' : 'inactive hidden' ) ); ?>">
-								<th class="checkbox"><input type="checkbox" name="feeds[<?php echo esc_attr( $term_id ); ?>][active]" value="1" aria-label="<?php esc_attr_e( 'Feed is active', 'friends' ); ?>"<?php checked( $feed->get_active() ); ?> /></th>
+								<th class="checkbox"><?php echo esc_attr( $term_id ); ?><input type="checkbox" name="feeds[<?php echo esc_attr( $term_id ); ?>][active]" value="1" aria-label="<?php esc_attr_e( 'Feed is active', 'friends' ); ?>"<?php checked( $feed->get_active() ); ?> /></th>
 								<td><input type="text" name="feeds[<?php echo esc_attr( $term_id ); ?>][url]" value="<?php echo esc_attr( $feed->get_url() ); ?>" size="30" aria-label="<?php esc_attr_e( 'Feed URL', 'friends' ); ?>" class="url" /></td>
 								<td class="nowrap"><select name="feeds[<?php echo esc_attr( $term_id ); ?>][parser]" aria-label="<?php esc_attr_e( 'Parser', 'friends' ); ?>">
 									<?php foreach ( $args['registered_parsers'] as $slug => $parser_name ) : ?>
@@ -104,7 +105,7 @@ $has_last_log = false;
 								<?php endforeach; ?>
 							</select></td>
 							<td><input type="text" name="feeds[new][title]" value="" size="20" aria-label="<?php esc_attr_e( 'Feed Name', 'friends' ); ?>" /></td>
-							<?php do_action( 'friends_feed_table_row', $feed, 'new' ); ?>
+							<?php do_action( 'friends_feed_table_row', isset( $feed ) ? $feed : array(), 'new' ); ?>
 							<td></td>
 						</tr>
 						</tbody>
@@ -148,7 +149,7 @@ $has_last_log = false;
 					<p class="description">
 					<?php
 					// translators: %s is a URL.
-					printf( __( '<a href=%s>Explicitly refresh</a> this feed now.', 'friends' ), esc_url( self_admin_url( 'admin.php?page=friends-refresh&user=' . $args['friend']->ID ) ) );
+					printf( __( '<a href=%s>Explicitly refresh</a> this feed now.', 'friends' ), esc_url( self_admin_url( 'admin.php?page=friends-refresh&user=' . $args['friend']->user_login ) ) );
 					?>
 					</p>
 				</td>

--- a/templates/admin/edit-friend.php
+++ b/templates/admin/edit-friend.php
@@ -7,13 +7,13 @@
  */
 
 ?><form method="post">
-	<?php wp_nonce_field( 'edit-friend-' . $args['friend']->ID ); ?>
+	<?php wp_nonce_field( 'edit-friend-' . $args['friend']->user_login ); ?>
 	<table class="form-table">
 		<tbody>
 			<tr>
 				<th><label for="friends_avatar"><?php /* phpcs:ignore WordPress.WP.I18n.MissingArgDomain */ esc_html_e( 'Avatar' ); ?></label></th>
 				<td>
-				<?php echo get_avatar( $args['friend']->ID ); ?>
+				<?php echo get_avatar( $args['friend']->user_login ); ?>
 			</td>
 			</tr>
 			<?php do_action( 'friends_edit_friend_after_avatar', $args['friend'] ); ?>
@@ -39,21 +39,21 @@
 					<?php echo esc_html( $args['friend']->get_role_name() ); ?>
 					<?php if ( $args['friend']->has_cap( 'friend_request' ) ) : ?>
 						<p class="description">
-							<a href="<?php echo esc_url( wp_nonce_url( add_query_arg( '_wp_http_referer', urlencode( wp_unslash( $_SERVER['REQUEST_URI'] ) ), self_admin_url( 'admin.php?page=edit-friend&user=' . $args['friend']->ID ) ), 'accept-friend-request-' . $args['friend']->ID, 'accept-friend-request' ) ); ?>"><?php esc_html_e( 'Accept Friend Request', 'friends' ); ?></a>
+							<a href="<?php echo esc_url( wp_nonce_url( add_query_arg( '_wp_http_referer', urlencode( wp_unslash( $_SERVER['REQUEST_URI'] ) ), self_admin_url( 'admin.php?page=edit-friend&user=' . $args['friend']->user_login ) ), 'accept-friend-request-' . $args['friend']->user_login, 'accept-friend-request' ) ); ?>"><?php esc_html_e( 'Accept Friend Request', 'friends' ); ?></a>
 						</p>
 					<?php elseif ( $args['friend']->has_cap( 'pending_friend_request' ) ) : ?>
 						<p class="description">
-							<a href="<?php echo esc_url( wp_nonce_url( add_query_arg( '_wp_http_referer', urlencode( wp_unslash( $_SERVER['REQUEST_URI'] ) ), self_admin_url( 'admin.php?page=edit-friend&user=' . $args['friend']->ID ) ), 'add-friend-' . $args['friend']->ID, 'add-friend' ) ); ?>"><?php esc_html_e( 'Resend Friend Request', 'friends' ); ?></a>
+							<a href="<?php echo esc_url( wp_nonce_url( add_query_arg( '_wp_http_referer', urlencode( wp_unslash( $_SERVER['REQUEST_URI'] ) ), self_admin_url( 'admin.php?page=edit-friend&user=' . $args['friend']->user_login ) ), 'add-friend-' . $args['friend']->user_login, 'add-friend' ) ); ?>"><?php esc_html_e( 'Resend Friend Request', 'friends' ); ?></a>
 						</p>
 					<?php elseif ( $args['friend']->has_cap( 'subscription' ) ) : ?>
 						<p class="description">
-							<a href="<?php echo esc_url( wp_nonce_url( add_query_arg( '_wp_http_referer', urlencode( wp_unslash( $_SERVER['REQUEST_URI'] ) ), self_admin_url( 'admin.php?page=edit-friend&user=' . $args['friend']->ID ) ), 'add-friend-' . $args['friend']->ID, 'add-friend' ) ); ?>"><?php esc_html_e( 'Send Friend Request', 'friends' ); ?></a>
+							<a href="<?php echo esc_url( wp_nonce_url( add_query_arg( '_wp_http_referer', urlencode( wp_unslash( $_SERVER['REQUEST_URI'] ) ), self_admin_url( 'admin.php?page=edit-friend&user=' . $args['friend']->user_login ) ), 'add-friend-' . $args['friend']->user_login, 'add-friend' ) ); ?>"><?php esc_html_e( 'Send Friend Request', 'friends' ); ?></a>
 						</p>
 					<?php elseif ( $args['friend']->has_cap( 'acquaintance' ) ) : ?>
 						<p class="description">
 							<?php
 							// translators: %s is a friend role.
-							echo wp_kses( sprintf( __( 'Change to %s.', 'friends' ), '<a href="' . esc_url( wp_nonce_url( add_query_arg( '_wp_http_referer', urlencode( wp_unslash( $_SERVER['REQUEST_URI'] ) ), self_admin_url( 'admin.php?page=edit-friend&user=' . $args['friend']->ID ) ), 'change-to-friend-' . $args['friend']->ID, 'change-to-friend' ) ) . '">' . __( 'Friend', 'friends' ) . '</a>' ), array( 'a' => array( 'href' => array() ) ) );
+							echo wp_kses( sprintf( __( 'Change to %s.', 'friends' ), '<a href="' . esc_url( wp_nonce_url( add_query_arg( '_wp_http_referer', urlencode( wp_unslash( $_SERVER['REQUEST_URI'] ) ), self_admin_url( 'admin.php?page=edit-friend&user=' . $args['friend']->user_login ) ), 'change-to-friend-' . $args['friend']->user_login, 'change-to-friend' ) ) . '">' . __( 'Friend', 'friends' ) . '</a>' ), array( 'a' => array( 'href' => array() ) ) );
 							?>
 							<?php esc_html_e( 'An Acquaintance has friend status but cannot read private posts.', 'friends' ); ?>
 						</p>
@@ -61,7 +61,7 @@
 						<p class="description">
 						<?php
 							// translators: %s is a friend role.
-						echo wp_kses( sprintf( __( 'Change to %s.', 'friends' ), '<a href="' . esc_url( wp_nonce_url( add_query_arg( '_wp_http_referer', urlencode( wp_unslash( $_SERVER['REQUEST_URI'] ) ), self_admin_url( 'admin.php?page=edit-friend&user=' . $args['friend']->ID ) ), 'change-to-restricted-friend-' . $args['friend']->ID, 'change-to-restricted-friend' ) ) . '">' . __( 'Acquaintance', 'friends' ) . '</a>' ), array( 'a' => array( 'href' => array() ) ) );
+						echo wp_kses( sprintf( __( 'Change to %s.', 'friends' ), '<a href="' . esc_url( wp_nonce_url( add_query_arg( '_wp_http_referer', urlencode( wp_unslash( $_SERVER['REQUEST_URI'] ) ), self_admin_url( 'admin.php?page=edit-friend&user=' . $args['friend']->user_login ) ), 'change-to-restricted-friend-' . $args['friend']->user_login, 'change-to-restricted-friend' ) ) . '">' . __( 'Acquaintance', 'friends' ) . '</a>' ), array( 'a' => array( 'href' => array() ) ) );
 						?>
 							<?php esc_html_e( 'An Acquaintance has friend status but cannot read private posts.', 'friends' ); ?>
 						</p>
@@ -74,7 +74,7 @@
 				<td>
 					<fieldset>
 						<label for="show_on_friends_page">
-							<input name="show_on_friends_page" type="checkbox" id="show_on_friends_page" value="1" <?php checked( '1', ! in_array( $args['friend']->ID, $args['hide_from_friends_page'] ) ); ?>>
+							<input name="show_on_friends_page" type="checkbox" id="show_on_friends_page" value="1" <?php checked( '1', ! in_array( $args['friend']->user_login, $args['hide_from_friends_page'] ) ); ?>>
 							<?php esc_html_e( 'Show posts on your friends page', 'friends' ); ?>
 						</label>
 					</fieldset>
@@ -86,7 +86,7 @@
 						?>
 					</a>
 					<?php if ( apply_filters( 'friends_debug', false ) ) : ?>
-						| <a href="<?php echo esc_url( self_admin_url( 'edit.php?post_type=' . Friends\Friends::CPT . '&author=' . $args['friend']->ID ) ); ?>">
+						| <a href="<?php echo esc_url( self_admin_url( 'edit.php?post_type=' . Friends\Friends::CPT . '&author=' . $args['friend']->user_login ) ); ?>">
 							<?php
 							// translators: %d is the number of posts.
 							echo esc_html( sprintf( _n( 'View %d cached post', 'View %d cached posts', $args['post_count'], 'friends' ), $args['post_count'] ) );
@@ -98,7 +98,7 @@
 					<p class="description">
 					<?php
 					// translators: %s is a URL.
-					printf( __( '<a href=%s>Explicitly refresh</a> this feed now.', 'friends' ), esc_url( self_admin_url( 'admin.php?page=friends-refresh&user=' . $args['friend']->ID ) ) );
+					printf( __( '<a href=%s>Explicitly refresh</a> this feed now.', 'friends' ), esc_url( self_admin_url( 'admin.php?page=friends-refresh&user=' . $args['friend']->user_login ) ) );
 					?>
 					</p>
 				</td>
@@ -110,6 +110,6 @@
 	<?php do_action( 'friends_edit_friend_after_form', $args['friend'] ); ?>
 	<p class="submit">
 		<input type="submit" id="submit" class="button button-primary" value="<?php /* phpcs:ignore WordPress.WP.I18n.MissingArgDomain */ esc_html_e( 'Save Changes' ); ?>">
-		<span class="unfriend"><a class="unfriend" href="<?php echo esc_url( Friends\Admin::get_unfriend_link( $args['friend']->ID ) ); ?>"><?php esc_html_e( 'Unfriend', 'friends' ); ?></a></span>
+		<span class="unfriend"><a class="unfriend" href="<?php echo esc_url( Friends\Admin::get_unfriend_link( $args['friend']->user_login ) ); ?>"><?php esc_html_e( 'Unfriend', 'friends' ); ?></a></span>
 	</p>
 </form>

--- a/templates/admin/edit-friend.php
+++ b/templates/admin/edit-friend.php
@@ -34,6 +34,12 @@
 				<td><?php echo esc_html( date_i18n( /* phpcs:ignore WordPress.WP.I18n.MissingArgDomain */ __( 'F j, Y g:i a' ), strtotime( $args['friend']->user_registered ) ) ); ?></td>
 			</tr>
 			<tr>
+				<th><label for="status"><?php echo esc_html( _x( 'Type', 'of user', 'friends' ) ); ?></label></th>
+				<td>
+					<?php echo esc_html( get_class( $args['friend'] ) ); ?>
+				</td>
+			</tr>
+			<tr>
 				<th><label for="status"><?php esc_html_e( 'Status', 'friends' ); ?></label></th>
 				<td>
 					<?php echo esc_html( $args['friend']->get_role_name() ); ?>
@@ -110,6 +116,6 @@
 	<?php do_action( 'friends_edit_friend_after_form', $args['friend'] ); ?>
 	<p class="submit">
 		<input type="submit" id="submit" class="button button-primary" value="<?php /* phpcs:ignore WordPress.WP.I18n.MissingArgDomain */ esc_html_e( 'Save Changes' ); ?>">
-		<span class="unfriend"><a class="unfriend" href="<?php echo esc_url( Friends\Admin::get_unfriend_link( $args['friend']->user_login ) ); ?>"><?php esc_html_e( 'Unfriend', 'friends' ); ?></a></span>
+		<span class="unfriend"><a class="unfriend" href="<?php echo esc_url( Friends\Admin::get_unfriend_link( $args['friend'] ) ); ?>"><?php esc_html_e( 'Unfriend', 'friends' ); ?></a></span>
 	</p>
 </form>

--- a/templates/admin/edit-friend.php
+++ b/templates/admin/edit-friend.php
@@ -36,7 +36,19 @@
 			<tr>
 				<th><label for="status"><?php echo esc_html( _x( 'Type', 'of user', 'friends' ) ); ?></label></th>
 				<td>
-					<?php echo esc_html( get_class( $args['friend'] ) ); ?>
+					<?php if ( $args['friend'] instanceof Friends\Subscription ) : ?>
+						<?php esc_html_e( 'Virtual User', 'friends' ); ?>
+						<?php echo esc_html( $args['friend']->get_term_id() ); ?>
+						<p class="description">
+							<a href="<?php echo esc_url( wp_nonce_url( add_query_arg( '_wp_http_referer', urlencode( wp_unslash( $_SERVER['REQUEST_URI'] ) ), self_admin_url( 'admin.php?page=edit-friend&user=' . $args['friend']->user_login ) ), 'convert-to-user-' . $args['friend']->user_login, 'convert-to-user' ) ); ?>"><?php esc_html_e( 'Convert to User', 'friends' ); ?></a>
+						</p>
+					<?php else : ?>
+						<?php esc_html_e( 'User', 'friends' ); ?>
+						<?php echo esc_html( $args['friend']->ID ); ?>
+						<p class="description">
+							<a href="<?php echo esc_url( wp_nonce_url( add_query_arg( '_wp_http_referer', urlencode( wp_unslash( $_SERVER['REQUEST_URI'] ) ), self_admin_url( 'admin.php?page=edit-friend&user=' . $args['friend']->user_login ) ), 'convert-from-user-' . $args['friend']->user_login, 'convert-from-user' ) ); ?>"><?php esc_html_e( 'Convert to Virtual User', 'friends' ); ?></a>
+						</p>
+					<?php endif; ?>
 				</td>
 			</tr>
 			<tr>

--- a/templates/admin/edit-friend.php
+++ b/templates/admin/edit-friend.php
@@ -50,7 +50,10 @@
 							<span class="info">ID: <?php echo esc_html( $args['friend']->ID ); ?></span>
 						<?php endif; ?>
 						<p class="description">
+							<?php if ( $args['friend']->has_cap( 'friend' ) || $args['friend']->has_cap( 'pending_friend_request' ) || $args['friend']->has_cap( 'friend_request' ) ) : ?>
+							<?php else : ?>
 							<a href="<?php echo esc_url( wp_nonce_url( add_query_arg( '_wp_http_referer', urlencode( wp_unslash( $_SERVER['REQUEST_URI'] ) ), self_admin_url( 'admin.php?page=edit-friend&user=' . $args['friend']->user_login ) ), 'convert-from-user-' . $args['friend']->user_login, 'convert-from-user' ) ); ?>"><?php esc_html_e( 'Convert to Virtual User', 'friends' ); ?></a>
+						<?php endif; ?>
 						</p>
 					<?php endif; ?>
 				</td>

--- a/templates/admin/edit-friend.php
+++ b/templates/admin/edit-friend.php
@@ -38,13 +38,17 @@
 				<td>
 					<?php if ( $args['friend'] instanceof Friends\Subscription ) : ?>
 						<?php esc_html_e( 'Virtual User', 'friends' ); ?>
-						<?php echo esc_html( $args['friend']->get_term_id() ); ?>
+						<?php if ( apply_filters( 'friends_debug', false ) ) : ?>
+							<span class="info">ID: <?php echo esc_html( $args['friend']->get_term_id() ); ?></span>
+						<?php endif; ?>
 						<p class="description">
 							<a href="<?php echo esc_url( wp_nonce_url( add_query_arg( '_wp_http_referer', urlencode( wp_unslash( $_SERVER['REQUEST_URI'] ) ), self_admin_url( 'admin.php?page=edit-friend&user=' . $args['friend']->user_login ) ), 'convert-to-user-' . $args['friend']->user_login, 'convert-to-user' ) ); ?>"><?php esc_html_e( 'Convert to User', 'friends' ); ?></a>
 						</p>
 					<?php else : ?>
 						<?php esc_html_e( 'User', 'friends' ); ?>
-						<?php echo esc_html( $args['friend']->ID ); ?>
+						<?php if ( apply_filters( 'friends_debug', false ) ) : ?>
+							<span class="info">ID: <?php echo esc_html( $args['friend']->ID ); ?></span>
+						<?php endif; ?>
 						<p class="description">
 							<a href="<?php echo esc_url( wp_nonce_url( add_query_arg( '_wp_http_referer', urlencode( wp_unslash( $_SERVER['REQUEST_URI'] ) ), self_admin_url( 'admin.php?page=edit-friend&user=' . $args['friend']->user_login ) ), 'convert-from-user-' . $args['friend']->user_login, 'convert-from-user' ) ); ?>"><?php esc_html_e( 'Convert to Virtual User', 'friends' ); ?></a>
 						</p>

--- a/templates/admin/edit-notifications.php
+++ b/templates/admin/edit-notifications.php
@@ -19,7 +19,7 @@
 					<?php else : ?>
 					<fieldset>
 						<label for="friends_new_post_notification">
-							<input name="friends_new_post_notification" type="checkbox" id="friends_new_post_notification" value="1" <?php checked( '1', ! get_user_option( 'friends_no_new_post_notification_' . $args['friend']->ID ) ); ?> />
+							<input name="friends_new_post_notification" type="checkbox" id="friends_new_post_notification" value="1" <?php checked( '1', ! get_user_option( 'friends_no_new_post_notification_' . $args['friend']->user_login ) ); ?> />
 							<?php esc_html_e( 'Send me an e-mail for posts of this friend', 'friends' ); ?>
 						</label>
 					</fieldset>
@@ -31,7 +31,7 @@
 				<td>
 					<fieldset>
 						<label for="friends_keyword_notification">
-							<input name="friends_keyword_notification" type="checkbox" id="friends_keyword_notification" value="1" <?php checked( '1', ! get_user_option( 'friends_no_keyword_notification_' . $args['friend']->ID ) ); ?> />
+							<input name="friends_keyword_notification" type="checkbox" id="friends_keyword_notification" value="1" <?php checked( '1', ! get_user_option( 'friends_no_keyword_notification_' . $args['friend']->user_login ) ); ?> />
 							<?php
 							echo wp_kses_post(
 								sprintf(

--- a/templates/admin/edit-notifications.php
+++ b/templates/admin/edit-notifications.php
@@ -7,7 +7,7 @@
  */
 
 ?><form method="post">
-	<?php wp_nonce_field( 'edit-friend-notifications-' . $args['friend']->ID ); ?>
+	<?php wp_nonce_field( 'edit-friend-notifications-' . $args['friend']->user_login ); ?>
 	<table class="form-table">
 		<tbody>
 			<?php if ( $args['friend']->can_refresh_feeds() ) : ?>

--- a/templates/admin/edit-raw-rules.php
+++ b/templates/admin/edit-raw-rules.php
@@ -24,7 +24,7 @@ echo wp_kses(
 <div id="raw-rules-data" style="display: none">
 	<h2><?php esc_html_e( 'Raw Rules Data', 'friends' ); ?></h2>
 	<form method="post">
-		<?php wp_nonce_field( 'friend-rules-raw-' . $args['friend']->ID ); ?>
+		<?php wp_nonce_field( 'friend-rules-raw-' . $args['friend']->user_login ); ?>
 		<table>
 			<tbody>
 				<tr>

--- a/templates/admin/edit-rules.php
+++ b/templates/admin/edit-rules.php
@@ -7,8 +7,8 @@
  */
 
 ?><form method="post" id="edit-rules">
-	<?php wp_nonce_field( 'edit-friend-rules-' . $args['friend']->ID ); ?>
-	<input type="hidden" name="friend" value="<?php echo esc_attr( $args['friend']->ID ); ?>" />
+	<?php wp_nonce_field( 'edit-friend-rules-' . $args['friend']->user_login ); ?>
+	<input type="hidden" name="friend" value="<?php echo esc_attr( $args['friend']->user_login ); ?>" />
 	<p class="description"><?php esc_html_e( 'By specifying rules, you can automatically accept, trash, or transform individual feed items, thus filter incoming posts according to your interest.', 'friends' ); ?></p>
 	<p class="description"><?php esc_html_e( 'Save changes to add another rule, leave the rule text empty to delete the rule.', 'friends' ); ?></p>
 	<table>
@@ -52,8 +52,8 @@
 	</table>
 	<p class="submit">
 		<input type="submit" id="submit" class="button button-primary" value="<?php /* phpcs:ignore WordPress.WP.I18n.MissingArgDomain */ esc_html_e( 'Save Changes' ); ?>">
-		<a href="<?php echo esc_url( self_admin_url( 'admin.php?page=edit-friend&user=' . $args['friend']->ID ) ); ?>" style="margin-left: 1em"><?php /* phpcs:ignore WordPress.WP.I18n.MissingArgDomain */ esc_html_e( 'Back' ); ?></a>
+		<a href="<?php echo esc_url( self_admin_url( 'admin.php?page=edit-friend&user=' . $args['friend']->user_login ) ); ?>" style="margin-left: 1em"><?php /* phpcs:ignore WordPress.WP.I18n.MissingArgDomain */ esc_html_e( 'Back' ); ?></a>
 	</p>
 </form>
 
-<p class="description"><?php esc_html_e( 'See how the rules apply to these items:', 'friends' ); ?> <button id="refresh-preview-rules" data-id="<?php echo esc_attr( $args['friend']->ID ); ?>" data-post="<?php echo $args['post'] ? esc_attr( $args['post']->ID ) : ''; ?>" data-nonce="<?php echo esc_attr( wp_create_nonce( 'preview-rules-' . $args['friend']->ID ) ); ?>"><?php esc_html_e( 'Refresh', 'friends' ); ?></button></p>
+<p class="description"><?php esc_html_e( 'See how the rules apply to these items:', 'friends' ); ?> <button id="refresh-preview-rules" data-friend="<?php echo esc_attr( $args['friend']->user_login ); ?>" data-post="<?php echo $args['post'] ? esc_attr( $args['post']->ID ) : ''; ?>" data-nonce="<?php echo esc_attr( wp_create_nonce( 'preview-rules-' . $args['friend']->user_login ) ); ?>"><?php esc_html_e( 'Refresh', 'friends' ); ?></button></p>

--- a/templates/admin/edit-rules.php
+++ b/templates/admin/edit-rules.php
@@ -32,7 +32,7 @@
 						<option value="replace" <?php selected( 'replace', $rule['action'] ); ?>><?php echo esc_html_e( 'replace the match with this:', 'friends' ); ?></option>
 					</select>
 				</td>
-				<td style="<?php echo esc_attr( 'replace' !== $rule['action'] ? 'display: none' : '' ); ?>" class="replace-with"><input type="text" name="rules[replace][]" value="<?php echo esc_attr( $rule['replace'] ); ?>" class="regular-text" placeholder="<?php esc_attr_e( 'Enter the text to replace it with', 'friends' ); ?>" /></td>
+				<td style="<?php echo esc_attr( 'replace' !== $rule['action'] ? 'display: none' : '' ); ?>" class="replace-with"><input type="text" name="rules[replace][]" value="<?php echo esc_attr( isset( $rule['replace'] ) ? $rule['replace'] : '' ); ?>" class="regular-text" placeholder="<?php esc_attr_e( 'Enter the text to replace it with', 'friends' ); ?>" /></td>
 				<?php if ( empty( $rule['regex'] ) ) : ?>
 					<td><span class="description">(<?php esc_html_e( 'Unsubmitted rule', 'friends' ); ?>)</span></td>
 				<?php endif; ?>

--- a/templates/admin/friends-list.php
+++ b/templates/admin/friends-list.php
@@ -55,14 +55,14 @@
 				);
 
 				?>
-				<a href="<?php echo esc_url( Friends\Admin::admin_edit_user_link( false, $friend_user->user_login ) ); ?>"><?php echo esc_html( $friend_user->display_name ); ?></a>
+				<a href="<?php echo esc_url( Friends\Admin::admin_edit_user_link( false, $friend_user ) ); ?>"><?php echo esc_html( $friend_user->display_name ); ?></a>
 				<button type="button" class="toggle-row"><span class="screen-reader-text"><?php /* phpcs:ignore WordPress.WP.I18n.MissingArgDomain */ esc_html_e( 'Show more details' ); ?></span></button>
 				<div class="row-actions">
 				<?php
 				$actions = array(
 					'edit' => sprintf(
 						'<a href="%s">%s</a>',
-						esc_url( Friends\Admin::admin_edit_user_link( false, $friend_user->user_login ) ),
+						esc_url( Friends\Admin::admin_edit_user_link( false, $friend_user ) ),
 						esc_html__( 'Edit', 'friends' )
 					),
 				);

--- a/templates/admin/friends-list.php
+++ b/templates/admin/friends-list.php
@@ -70,13 +70,13 @@
 				if ( $friend_user->has_cap( 'friend_request' ) ) {
 					$actions['unfriend'] = sprintf(
 						'<a href="%s">%s</a>',
-						esc_url( Friends\Admin::get_unfriend_link( $friend_user->ID ) ),
+						esc_url( Friends\Admin::get_unfriend_link( $friend_user ) ),
 						esc_html__( 'Delete', 'friends' )
 					);
 				} else {
 					$actions['unfriend'] = sprintf(
 						'<a href="%s">%s</a>',
-						esc_url( Friends\Admin::get_unfriend_link( $friend_user->ID ) ),
+						esc_url( Friends\Admin::get_unfriend_link( $friend_user ) ),
 						esc_html__( 'Unfriend', 'friends' )
 					);
 				}

--- a/templates/admin/friends-list.php
+++ b/templates/admin/friends-list.php
@@ -33,6 +33,7 @@
 			<th class="column-url"><?php /* phpcs:ignore WordPress.WP.I18n.MissingArgDomain */ esc_html_e( 'URL' ); ?></th>
 			<th class="column-date"><?php /* phpcs:ignore WordPress.WP.I18n.MissingArgDomain */ esc_html_e( 'Since' ); ?></th>
 			<th class="column-status"><?php esc_html_e( 'Status', 'friends' ); ?></th>
+			<th class="column-type"><?php echo esc_html( _x( 'Type', 'of user', 'friends' ) ); ?></th>
 			<th class="column-friends_posts"><?php esc_html_e( 'Friend Posts', 'friends' ); ?></th>
 		</tr>
 	</thead>
@@ -99,6 +100,19 @@
 			<td class="url column-url" data-colname="<?php /* phpcs:ignore WordPress.WP.I18n.MissingArgDomain */ esc_attr_e( 'URL' ); ?>"><a href="<?php echo esc_url( $friend_user->user_url ); ?>"><?php echo esc_html( wp_parse_url( $friend_user->user_url, PHP_URL_HOST ) ); ?></a></td>
 			<td class="date column-date" data-colname="<?php /* phpcs:ignore WordPress.WP.I18n.MissingArgDomain */ esc_attr_e( 'Since' ); ?>"><?php echo esc_html( date_i18n( __( 'F j, Y g:i a' ), strtotime( $friend_user->user_registered ) ) ); ?></td>
 			<td class="status column-status" data-colname="<?php esc_attr_e( 'Status', 'friends' ); ?>"><?php echo esc_html( $friend_user->get_role_name() ); ?></td>
+			<td class="status column-type" data-colname="<?php echo esc_attr( _x( 'Type', 'of user', 'friends' ) ); ?>">
+				<?php if ( $friend_user instanceof Friends\Subscription ) : ?>
+					<?php esc_html_e( 'Virtual User', 'friends' ); ?>
+					<?php if ( apply_filters( 'friends_debug', false ) ) : ?>
+						<span class="info">ID: <?php echo esc_html( $friend_user->get_term_id() ); ?></span>
+					<?php endif; ?>
+				<?php else : ?>
+					<?php esc_html_e( 'User', 'friends' ); ?>
+					<?php if ( apply_filters( 'friends_debug', false ) ) : ?>
+						<span class="info">ID: <?php echo esc_html( $friend_user->ID ); ?></span>
+					<?php endif; ?>
+				<?php endif; ?>
+			</td>
 			<td class="column-friends_posts" data-colname="<?php esc_attr_e( 'Friend Posts', 'friends' ); ?>"><?php echo wp_kses_post( Friends\Admin::user_list_custom_column( '', 'friends_posts', $friend_user->ID ) ); ?></td>
 		</tr>
 		<?php endforeach; ?>

--- a/templates/admin/friends-list.php
+++ b/templates/admin/friends-list.php
@@ -42,7 +42,7 @@
 			<td class="username column-username column-primary has-row-actions" data-colname="<?php esc_attr_e( 'Site', 'friends' ); ?>">
 				<?php
 				echo wp_kses(
-					get_avatar( $friend_user->ID, 32 ),
+					get_avatar( $friend_user->user_login, 32 ),
 					array(
 						'img' => array(
 							'src'    => array(),
@@ -55,14 +55,14 @@
 				);
 
 				?>
-				<a href="<?php echo esc_url( Friends\Admin::get_edit_friend_link( $friend_user->ID ) ); ?>"><?php echo esc_html( $friend_user->display_name ); ?></a>
+				<a href="<?php echo esc_url( Friends\Admin::admin_edit_user_link( false, $friend_user->user_login ) ); ?>"><?php echo esc_html( $friend_user->display_name ); ?></a>
 				<button type="button" class="toggle-row"><span class="screen-reader-text"><?php /* phpcs:ignore WordPress.WP.I18n.MissingArgDomain */ esc_html_e( 'Show more details' ); ?></span></button>
 				<div class="row-actions">
 				<?php
 				$actions = array(
 					'edit' => sprintf(
 						'<a href="%s">%s</a>',
-						esc_url( Friends\Admin::get_edit_friend_link( $friend_user->ID ) ),
+						esc_url( Friends\Admin::admin_edit_user_link( false, $friend_user->user_login ) ),
 						esc_html__( 'Edit', 'friends' )
 					),
 				);

--- a/templates/admin/notification-manager.php
+++ b/templates/admin/notification-manager.php
@@ -44,18 +44,18 @@ if ( $args['no_new_post_notification'] ) : ?>
 			<?php foreach ( $args['friend_users'] as $friend_user ) : ?>
 				<tr>
 					<td class="column-friend">
-						<a href="<?php echo esc_url( Friends\Admin::get_edit_friend_link( $friend_user->ID ) ); ?>"><?php echo esc_html( $friend_user->display_name ); ?></a>
-						<input type="hidden" name="friend_listed[]" value="<?php echo esc_attr( $friend_user->ID ); ?>" />
+						<a href="<?php echo esc_url( Friends\Admin::get_edit_friend_link( $friend_user->user_login ) ); ?>"><?php echo esc_html( $friend_user->display_name ); ?></a>
+						<input type="hidden" name="friend_listed[]" value="<?php echo esc_attr( $friend_user->user_login ); ?>" />
 					</td>
 					<td class="column-friends-page-feeds">
-						<input name="show_on_friends_page[<?php echo esc_attr( $friend_user->ID ); ?>]" type="checkbox" id="show_on_friends_page" value="1" <?php checked( '1', ! in_array( $friend_user->ID, $args['hide_from_friends_page'] ) ); ?> />
+						<input name="show_on_friends_page[<?php echo esc_attr( $friend_user->user_login ); ?>]" type="checkbox" id="show_on_friends_page" value="1" <?php checked( '1', ! in_array( $friend_user->user_login, $args['hide_from_friends_page'] ) ); ?> />
 					</td>
 					<td class="column-email-notification">
-						<input name="new_post_notification[<?php echo esc_attr( $friend_user->ID ); ?>]" type="checkbox" id="friends_new_post_notification" value="1" <?php checked( '1', ! get_user_option( 'friends_no_new_post_notification_' . $friend_user->ID ) ); ?> <?php echo $args['no_new_post_notification'] ? 'disabled="disabled"' : ''; ?>
+						<input name="new_post_notification[<?php echo esc_attr( $friend_user->user_login ); ?>]" type="checkbox" id="friends_new_post_notification" value="1" <?php checked( '1', ! get_user_option( 'friends_no_new_post_notification_' . $friend_user->user_login ) ); ?> <?php echo $args['no_new_post_notification'] ? 'disabled="disabled"' : ''; ?>
 						/>
 					</td>
 					<td class="column-keyword-notification">
-						<input name="keyword_notification[<?php echo esc_attr( $friend_user->ID ); ?>]" type="checkbox" id="friends_keyword_notification" value="1" <?php checked( '1', ! get_user_option( 'friends_no_keyword_notification_' . $friend_user->ID ) ); ?> <?php echo $args['no_keyword_notification'] ? 'disabled="disabled"' : ''; ?>
+						<input name="keyword_notification[<?php echo esc_attr( $friend_user->user_login ); ?>]" type="checkbox" id="friends_keyword_notification" value="1" <?php checked( '1', ! get_user_option( 'friends_no_keyword_notification_' . $friend_user->user_login ) ); ?> <?php echo $args['no_keyword_notification'] ? 'disabled="disabled"' : ''; ?>
 						/>
 					</td>
 				<?php do_action( 'friends_notification_manager_row', $friend_user ); ?>

--- a/templates/admin/preview-rules.php
+++ b/templates/admin/preview-rules.php
@@ -87,8 +87,8 @@ if ( $args['post'] ) :
 			<th class="column-view"><?php esc_html_e( 'Friends Page', 'friends' ); ?></th>
 		</tr>
 		<?php
-		while ( $args['friend_posts']->have_posts() ) {
-			preview_row( $args['friend_posts']->next_post(), $args );
+		foreach ( $args['friend_posts']->get_posts() as $post ) {
+			preview_row( $post, $args );
 		}
 		?>
 	</tbody>

--- a/templates/admin/unfriend.php
+++ b/templates/admin/unfriend.php
@@ -35,7 +35,7 @@ $numfeeds = count( $args['friend']->get_active_feeds() );
 	<p><?php esc_html_e( 'Since friends correspond to WordPress users, unfriending a user means to delete the user.', 'friends' ); ?></p>
 	<h4>
 	<?php
-			echo get_avatar( $args['friend']->ID, 24 );
+			echo get_avatar( $args['friend']->user_login, 24 );
 			echo ' ';
 			echo esc_html( $args['friend']->user_login );
 	?>

--- a/templates/admin/unfriend.php
+++ b/templates/admin/unfriend.php
@@ -24,14 +24,14 @@ if ( is_multisite() ) {
 		$args['friend']->user_login
 	);
 }
-$numposts = count_user_posts( $args['friend']->ID, apply_filters( 'friends_frontend_post_types', array( 'post' ) ) );
+$numposts = count( $args['friend']->get_all_post_ids() );
 $numfeeds = count( $args['friend']->get_active_feeds() );
 
 ?>
 <div class="wrap">
 <h3><?php echo esc_html( $heading ); ?></h3>
 <form method="post">
-	<?php wp_nonce_field( 'unfriend-' . $args['friend']->ID ); ?>
+	<?php wp_nonce_field( 'unfriend-' . $args['friend']->user_login ); ?>
 	<p><?php esc_html_e( 'Since friends correspond to WordPress users, unfriending a user means to delete the user.', 'friends' ); ?></p>
 	<h4>
 	<?php

--- a/templates/admin/unfriend.php
+++ b/templates/admin/unfriend.php
@@ -54,7 +54,7 @@ $numfeeds = count( $args['friend']->get_active_feeds() );
 			?>
 		</li>
 		<li>
-			<a href="<?php echo esc_url( self_admin_url( 'admin.php?page=edit-friend-feeds&user=' . $args['friend']->ID ) ); ?>">
+			<a href="<?php echo esc_url( self_admin_url( 'admin.php?page=edit-friend-feeds&user=' . $args['friend']->user_login ) ); ?>">
 								<?php
 								echo esc_html(
 									sprintf(

--- a/templates/email/keyword-match-post.text.php
+++ b/templates/email/keyword-match-post.text.php
@@ -47,5 +47,5 @@ printf(
 	// translators: %1$s is a username, %2$s is a URL.
 	__( 'Or just unsubscribe from %1$s\'s posts at %2$s', 'friends' ),
 	$args['author']->display_name,
-	self_admin_url( 'admin.php?page=edit-friend&user=' . $args['author']->ID )
+	self_admin_url( 'admin.php?page=edit-friend&user=' . $args['author']->user_login )
 );

--- a/templates/email/new-friend-post.php
+++ b/templates/email/new-friend-post.php
@@ -60,9 +60,9 @@ $override_author_name = apply_filters( 'friends_override_author_name', '', $args
 		// translators: %1$s is a URL, %2$s is a URL, %3$s is a username, %4$s is a URL.
 		__( 'Manage your <a href=%1$s>global notification settings</a>, <a href=%2$s>change notifications for %3$s</a>, or <a href=%4$s>muffle posts like these</a>.', 'friends' ),
 		'"' . esc_url( self_admin_url( 'admin.php?page=friends-settings' ) ) . '"',
-		'"' . esc_url( self_admin_url( 'admin.php?page=edit-friend&user=' . $args['author']->ID ) ) . '"',
+		'"' . esc_url( self_admin_url( 'admin.php?page=edit-friend&user=' . $args['author']->user_login ) ) . '"',
 		'<em>' . esc_html( $args['author']->display_name ) . '</em>',
-		'"' . esc_url( self_admin_url( 'admin.php?page=edit-friend-rules&user=' . $args['author']->ID . '&post=' . $args['post']->ID ) ) . '"'
+		'"' . esc_url( self_admin_url( 'admin.php?page=edit-friend-rules&user=' . $args['author']->user_login . '&post=' . $args['post']->ID ) ) . '"'
 	);
 	?>
 </div>

--- a/templates/email/new-friend-post.text.php
+++ b/templates/email/new-friend-post.text.php
@@ -42,5 +42,5 @@ printf(
 	// translators: %1$s is a username, %2$s is a URL.
 	__( 'Or just unsubscribe from %1$s\'s posts at %2$s', 'friends' ),
 	$args['author']->display_name,
-	self_admin_url( 'admin.php?page=edit-friend&user=' . $args['author']->ID )
+	self_admin_url( 'admin.php?page=edit-friend&user=' . $args['author']->user_login )
 );

--- a/templates/frontend/author-header.php
+++ b/templates/frontend/author-header.php
@@ -5,7 +5,7 @@
  * @package Friends
  */
 
-$edit_user_link = $args['friends']->admin->admin_edit_user_link( false, $args['friend_user']->ID );
+$edit_user_link = $args['friends']->admin->admin_edit_user_link( false, $args['friend_user']->user_login );
 $feeds = count( $args['friend_user']->get_feeds() );
 $rules = count( $args['friend_user']->get_feed_rules() );
 $active_feeds = count( $args['friend_user']->get_active_feeds() );
@@ -14,9 +14,9 @@ $hidden_post_count = $args['friend_user']->get_post_in_trash_count();
 ?><div id="author-header" class="mb-2">
 <h2 id="page-title">
 	<?php if ( $args['friend_user']->is_starred() ) : ?>
-		<a href="" class="dashicons dashicons-star-filled starred" data-id="<?php echo esc_attr( $args['friend_user']->ID ); ?>" data-nonce="<?php echo esc_attr( wp_create_nonce( 'star-' . $args['friend_user']->ID ) ); ?>"></a>
+		<a href="" class="dashicons dashicons-star-filled starred" data-id="<?php echo esc_attr( $args['friend_user']->user_login ); ?>" data-nonce="<?php echo esc_attr( wp_create_nonce( 'star-' . $args['friend_user']->user_login ) ); ?>"></a>
 	<?php else : ?>
-		<a href="" class="dashicons dashicons-star-empty not-starred" data-id="<?php echo esc_attr( $args['friend_user']->ID ); ?>" data-nonce="<?php echo esc_attr( wp_create_nonce( 'star-' . $args['friend_user']->ID ) ); ?>"></a>
+		<a href="" class="dashicons dashicons-star-empty not-starred" data-id="<?php echo esc_attr( $args['friend_user']->user_login ); ?>" data-nonce="<?php echo esc_attr( wp_create_nonce( 'star-' . $args['friend_user']->user_login ) ); ?>"></a>
 	<?php endif; ?>
 	<a href="<?php echo esc_attr( $args['friend_user']->get_local_friends_page_url() ); ?>">
 <?php
@@ -26,11 +26,11 @@ if ( $args['friends']->frontend->reaction ) {
 		// translators: %1$s is an emoji reaction, %2$s is a type of feed, e.g. "Main Feed".
 			__( 'My %1$s reactions on %2$s', 'friends' ),
 			$args['friends']->frontend->reaction,
-			get_the_author_meta( 'display_name' )
+			$args['friend_user']->display_name
 		)
 	);
 } else {
-	echo esc_html( get_the_author_meta( 'display_name' ) );
+	echo esc_html( $args['friend_user']->display_name );
 }
 ?>
 </a>
@@ -88,7 +88,7 @@ $args['friends']->frontend->link(
 <?php endforeach; ?>
 
 <?php if ( $edit_user_link ) : ?>
-<a class="chip" href="<?php echo esc_attr( self_admin_url( 'admin.php?page=edit-friend-feeds&user=' . $args['friend_user']->ID ) ); ?>">
+<a class="chip" href="<?php echo esc_attr( self_admin_url( 'admin.php?page=edit-friend-feeds&user=' . $args['friend_user']->user_login ) ); ?>">
 	<?php echo esc_html( sprintf( /* translators: %s is the number of feeds */_n( '%s feed', '%s feeds', $active_feeds, 'friends' ), number_format_i18n( $active_feeds ) ) ); ?>
 
 	<?php if ( $feeds - $active_feeds > 1 ) : ?>
@@ -97,7 +97,7 @@ $args['friends']->frontend->link(
 </a>
 
 	<?php if ( $rules > 0 ) : ?>
-<a class="chip" href="<?php echo esc_attr( self_admin_url( 'admin.php?page=edit-friend-rules&user=' . $args['friend_user']->ID ) ); ?>">
+<a class="chip" href="<?php echo esc_attr( self_admin_url( 'admin.php?page=edit-friend-rules&user=' . $args['friend_user']->user_login ) ); ?>">
 		<?php
 		// translators: %d is the number of rules.
 		echo esc_html( sprintf( _n( '%d rule', '%d rules', $rules, 'friends' ), $rules ) );
@@ -109,7 +109,7 @@ $args['friends']->frontend->link(
 <?php endif; ?>
 
 <?php if ( $args['friend_user']->can_refresh_feeds() && apply_filters( 'friends_debug', false ) ) : ?>
-<a class="chip" href="<?php echo esc_url( self_admin_url( 'admin.php?page=friends-refresh&user=' . $args['friend_user']->ID ) ); ?>"><?php esc_html_e( 'Refresh', 'friends' ); ?></a>
+<a class="chip" href="<?php echo esc_url( self_admin_url( 'admin.php?page=friends-refresh&user=' . $args['friend_user']->user_login ) ); ?>"><?php esc_html_e( 'Refresh', 'friends' ); ?></a>
 <?php endif; ?>
 <?php do_action( 'friends_author_header', $args['friend_user'], $args ); ?>
 </div>

--- a/templates/frontend/author-header.php
+++ b/templates/frontend/author-header.php
@@ -5,7 +5,7 @@
  * @package Friends
  */
 
-$edit_user_link = $args['friends']->admin->admin_edit_user_link( false, $args['friend_user']->user_login );
+$edit_user_link = $args['friends']->admin->admin_edit_user_link( false, $args['friend_user'] );
 $feeds = count( $args['friend_user']->get_feeds() );
 $rules = count( $args['friend_user']->get_feed_rules() );
 $active_feeds = count( $args['friend_user']->get_active_feeds() );

--- a/templates/frontend/author-header.php
+++ b/templates/frontend/author-header.php
@@ -58,7 +58,7 @@ $args['friends']->frontend->link(
 
 <span class="chip"><?php echo esc_html( $args['friend_user']->get_role_name() ); ?></span>
 
-<?php if ( true || apply_filters( 'friends_debug', false ) ) : ?>
+<?php if ( apply_filters( 'friends_debug', false ) ) : ?>
 	<span class="chip"><?php echo esc_html( get_class( $args['friend_user'] ) ); ?></span>
 <?php endif; ?>
 

--- a/templates/frontend/author-header.php
+++ b/templates/frontend/author-header.php
@@ -58,6 +58,10 @@ $args['friends']->frontend->link(
 
 <span class="chip"><?php echo esc_html( $args['friend_user']->get_role_name() ); ?></span>
 
+<?php if ( true || apply_filters( 'friends_debug', false ) ) : ?>
+	<span class="chip"><?php echo esc_html( get_class( $args['friend_user'] ) ); ?></span>
+<?php endif; ?>
+
 <span class="chip"><?php echo /* phpcs:ignore WordPress.WP.I18n.MissingArgDomain */ esc_html( sprintf( /* translators: %s is a localized date (F j, Y) */__( 'Since %s', 'friends' ), date_i18n( __( 'F j, Y' ), strtotime( $args['friend_user']->user_registered ) ) ) ); ?></span>
 
 <?php foreach ( $args['friend_user']->get_post_count_by_post_format() as $post_format => $count ) : ?>

--- a/templates/frontend/header.php
+++ b/templates/frontend/header.php
@@ -38,13 +38,13 @@ if ( isset( $_GET['s'] ) ) {
 				<span class="ab-icon dashicons dashicons-menu-alt2"></span>
 			</a>
 			<?php
-			if ( $args['friend_user'] && is_singular() ) {
+			if ( $args['friend_user'] && $args['friend_user'] instanceof Friends\User && is_singular() ) {
 				Friends\Friends::template_loader()->get_template_part(
 					'frontend/single-header',
 					null,
 					$args
 				);
-			} elseif ( $args['friend_user'] ) {
+			} elseif ( $args['friend_user'] && $args['friend_user'] instanceof Friends\User ) {
 				Friends\Friends::template_loader()->get_template_part(
 					'frontend/author-header',
 					null,

--- a/templates/frontend/header.php
+++ b/templates/frontend/header.php
@@ -10,6 +10,7 @@ $search = '';
 if ( isset( $_GET['s'] ) ) {
 	$search = wp_unslash( $_GET['s'] );
 }
+
 ?><!DOCTYPE html>
 <html <?php language_attributes(); ?> class="no-js no-svg">
 <head>
@@ -37,16 +38,13 @@ if ( isset( $_GET['s'] ) ) {
 				<span class="ab-icon dashicons dashicons-menu-alt2"></span>
 			</a>
 			<?php
-			global $authordata;
-			if ( $authordata && is_singular() ) {
-				$args['friend_user'] = new Friends\User( get_the_author_meta( 'ID' ) );
+			if ( $args['friend_user'] && is_singular() ) {
 				Friends\Friends::template_loader()->get_template_part(
 					'frontend/single-header',
 					null,
 					$args
 				);
-			} elseif ( $authordata && is_author() ) {
-				$args['friend_user'] = new Friends\User( get_the_author_meta( 'ID' ) );
+			} elseif ( $args['friend_user'] ) {
 				Friends\Friends::template_loader()->get_template_part(
 					'frontend/author-header',
 					null,

--- a/templates/frontend/index.php
+++ b/templates/frontend/index.php
@@ -6,14 +6,6 @@
  * @package Friends
  */
 
-$friends = Friends\Friends::get_instance();
-$args = array(
-	'friends' => $friends,
-);
-if ( isset( $_GET['in_reply_to'] ) && wp_parse_url( $_GET['in_reply_to'] ) ) {
-	$args['in_reply_to'] = $friends->frontend->get_in_reply_to_metadata( $_GET['in_reply_to'] );
-}
-
 Friends\Friends::template_loader()->get_template_part(
 	'frontend/header',
 	null,
@@ -28,29 +20,27 @@ Friends\Friends::template_loader()->get_template_part(
 		<div class="card">
 			<div class="card-body">
 			<?php
-			if ( $friends->frontend->post_format ) {
+			if ( $args['friends']->frontend->post_format ) {
 				$post_formats = get_post_format_strings();
 
-				if ( get_the_author() ) {
+				if ( $args['friend_user'] ) {
 					echo esc_html(
 						sprintf(
 						// translators: %s is the name of an author.
 							__( '%1$s hasn\'t posted anything with the post format %2$s yet!', 'friends' ),
 							get_the_author(),
-							$post_formats[ $friends->frontend->post_format ]
+							$post_formats[ $args['friends']->frontend->post_format ]
 						)
 					);
-
-					$friend_user = new Friends\User( get_the_author_meta( 'ID' ) );
 					?>
-					<a href="<?php echo esc_url( $friend_user->get_local_friends_page_url() ); ?>"><?php esc_html_e( 'Remove post format filter', 'friends' ); ?></a>
+					<a href="<?php echo esc_url( $args['friend_user']->get_local_friends_page_url() ); ?>"><?php esc_html_e( 'Remove post format filter', 'friends' ); ?></a>
 					<?php
 				} else {
 					echo esc_html(
 						sprintf(
 						// translators: %s is a post format title.
 							__( "Your friends haven't posted anything with the post format %s yet!", 'friends' ),
-							$post_formats[ $friends->frontend->post_format ]
+							$post_formats[ $args['friends']->frontend->post_format ]
 						)
 					);
 					?>

--- a/templates/frontend/parts/header.php
+++ b/templates/frontend/parts/header.php
@@ -99,7 +99,7 @@ $override_author_name = apply_filters( 'friends_override_author_name', '', $auth
 			</a>
 			<ul class="menu" style="min-width: <?php echo esc_attr( intval( _x( '250', 'dropdown-menu-width', 'friends' ) ) ); ?>px">
 				<?php
-				$edit_user_link = $args['friends']->admin->admin_edit_user_link( false, get_the_author_meta( 'ID' ) );
+				$edit_user_link = Friends\Admin::admin_edit_user_link( false, $friend_user );
 				if ( $edit_user_link ) :
 					?>
 					<li class="menu-item"><a href="<?php echo esc_attr( $edit_user_link ); ?>"><?php esc_html_e( 'Edit friend', 'friends' ); ?></a></li>

--- a/templates/frontend/parts/header.php
+++ b/templates/frontend/parts/header.php
@@ -32,7 +32,7 @@ $override_author_name = apply_filters( 'friends_override_author_name', '', $auth
 	<div class="avatar col-auto mr-2">
 		<?php if ( in_array( get_post_type(), apply_filters( 'friends_frontend_post_types', array() ), true ) ) : ?>
 			<a href="<?php echo esc_attr( $friend_user->get_local_friends_page_url() ); ?>" class="author-avatar">
-				<img src="<?php echo esc_url( $args['friend_user']->get_avatar_url() ); ?>" width="36" height="36" class="avatar" />
+				<?php echo get_avatar( $args['friend_user']->user_login, 36 ); ?>
 			</a>
 		<?php else : ?>
 			<a href="<?php echo esc_url( get_the_author_meta( 'url' ) ); ?>" class="author-avatar">

--- a/templates/frontend/parts/header.php
+++ b/templates/frontend/parts/header.php
@@ -8,7 +8,7 @@
 
 $friend_user = $args['friend_user'];
 $avatar = $args['avatar'];
-$author_name = get_the_author_meta( 'display_name' );
+$author_name = $args['friend_user']->display_name;
 
 /**
  * Allows overriding the authorname for a post.
@@ -32,7 +32,7 @@ $override_author_name = apply_filters( 'friends_override_author_name', '', $auth
 	<div class="avatar col-auto mr-2">
 		<?php if ( in_array( get_post_type(), apply_filters( 'friends_frontend_post_types', array() ), true ) ) : ?>
 			<a href="<?php echo esc_attr( $friend_user->get_local_friends_page_url() ); ?>" class="author-avatar">
-				<img src="<?php echo esc_url( get_avatar_url( get_the_author_meta( 'ID' ) ) ); ?>" width="36" height="36" class="avatar" />
+				<img src="<?php echo esc_url( $args['friend_user']->get_avatar_url() ); ?>" width="36" height="36" class="avatar" />
 			</a>
 		<?php else : ?>
 			<a href="<?php echo esc_url( get_the_author_meta( 'url' ) ); ?>" class="author-avatar">
@@ -44,7 +44,7 @@ $override_author_name = apply_filters( 'friends_override_author_name', '', $auth
 		<div class="author">
 			<?php if ( in_array( get_post_type(), apply_filters( 'friends_frontend_post_types', array() ), true ) ) : ?>
 				<a href="<?php echo esc_attr( $friend_user->get_local_friends_page_url() ); ?>">
-					<strong><?php the_author(); ?></strong>
+					<strong><?php echo esc_html( $friend_user->display_name ); ?></strong>
 					<?php if ( $override_author_name && trim( str_replace( $override_author_name, '', $author_name ) ) === $author_name ) : ?>
 						– <?php echo esc_html( $override_author_name ); ?>
 					<?php endif; ?>

--- a/templates/frontend/parts/header.php
+++ b/templates/frontend/parts/header.php
@@ -98,15 +98,18 @@ $override_author_name = apply_filters( 'friends_override_author_name', '', $auth
 				<i class="dashicons dashicons-menu-alt2"></i>
 			</a>
 			<ul class="menu" style="min-width: <?php echo esc_attr( intval( _x( '250', 'dropdown-menu-width', 'friends' ) ) ); ?>px">
-				<?php
-				$edit_user_link = Friends\Admin::admin_edit_user_link( false, $friend_user );
-				if ( $edit_user_link ) :
-					?>
-					<li class="menu-item"><a href="<?php echo esc_attr( $edit_user_link ); ?>"><?php esc_html_e( 'Edit friend', 'friends' ); ?></a></li>
+				<?php if ( apply_filters( 'friends_debug', false ) ) : ?>
+					<?php
+					$edit_user_link = Friends\Admin::admin_edit_user_link( false, $friend_user );
+					if ( $edit_user_link ) :
+						?>
+						<li class="menu-item"><a href="<?php echo esc_attr( $edit_user_link ); ?>"><?php esc_html_e( 'Edit friend', 'friends' ); ?></a></li>
+					<?php endif; ?>
 				<?php endif; ?>
-					<li class="menu-item friends-dropdown">
+					<li class="menu-item">
 						<a href="<?php echo esc_attr( $friend_user->get_local_friends_page_url() . get_the_ID() . '/?share=' . hash( 'crc32b', apply_filters( 'friends_share_salt', wp_salt( 'nonce' ) ) . get_the_ID() ) ); ?>"><?php esc_html_e( 'Share link', 'friends' ); ?></a>
 					</li>
+				<?php if ( apply_filters( 'friends_debug', false ) ) : ?>
 					<li class="menu-item friends-dropdown">
 						<select name="post-format" class="friends-change-post-format form-select select-sm" data-change-post-format-nonce="<?php echo esc_attr( wp_create_nonce( 'friends-change-post-format_' . get_the_ID() ) ); ?>" data-id="<?php echo esc_attr( get_the_ID() ); ?>" >
 							<option disabled="disabled"><?php esc_html_e( 'Change post format', 'friends' ); ?></option>
@@ -115,6 +118,7 @@ $override_author_name = apply_filters( 'friends_override_author_name', '', $auth
 						<?php endforeach; ?>
 						</select>
 					</li>
+				<?php endif; ?>
 				<?php if ( current_user_can( 'edit_post', get_current_user_id(), get_the_ID() ) ) : ?>
 					<li class="menu-item"><?php edit_post_link(); ?></li>
 				<?php endif; ?>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -85,6 +85,19 @@ add_filter( 'friends_immediately_fetch_feed', '__return_false' );
 // Disable sending e-mails.
 add_filter( 'friends_send_mail', '__return_false' );
 
+// Prevent PHP8 Deprecation notices.
+add_filter(
+	'the_author',
+	function( $display_name ) {
+		if ( is_null( $display_name ) ) {
+			return '';
+		}
+		return $display_name;
+	},
+	1,
+	1
+);
+
 // Output setting of options during debugging.
 if ( defined( 'TESTS_VERBOSE' ) && TESTS_VERBOSE ) {
 	add_filter(

--- a/tests/class-friends-testcase-cache-http.php
+++ b/tests/class-friends-testcase-cache-http.php
@@ -65,6 +65,7 @@ class Friends_TestCase_Cache_HTTP extends \WP_UnitTestCase {
 		}
 			return $return;
 	}
+
 	public static function get_cache_filename( $url ) {
 		$p = wp_parse_url( $url );
 		if ( ! $p ) {
@@ -83,6 +84,9 @@ class Friends_TestCase_Cache_HTTP extends \WP_UnitTestCase {
 		}
 		$p = wp_parse_url( $url );
 		$cache = self::get_cache_filename( $url );
+		if ( ! $cache ) {
+			return $preempt;
+		}
 		if ( file_exists( $cache ) ) {
 			return apply_filters(
 				'fake_http_response',

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -10,7 +10,7 @@ namespace Friends;
 /**
  * Test the Notifications
  */
-class APITest extends \WP_UnitTestCase {
+class APITest extends Friends_TestCase_Cache_HTTP {
 	/**
 	 * Current User ID
 	 *
@@ -87,8 +87,7 @@ class APITest extends \WP_UnitTestCase {
 			$feed_url = rtrim( $friend_user->user_url, '/' ) . '/feed/';
 		}
 
-		$user_feed = User_Feed::save(
-			$friend_user,
+		$user_feed = $friend_user->save_feed(
 			$feed_url,
 			array(
 				'active'      => true,

--- a/tests/test-feed.php
+++ b/tests/test-feed.php
@@ -142,11 +142,10 @@ class FeedTest extends \WP_UnitTestCase {
 		}
 		$friends = Friends::get_instance();
 		$friends->feed->register_parser( 'local', new Feed_Parser_Local_File( $friends->feed ) );
-
+		add_filter( 'friends_pre_check_url', '__return_true' );
 		do {
 			if ( ! isset( $feeds[ $file ] ) ) {
-				$feeds[ $file ] = User_Feed::save(
-					$user,
+				$feeds[ $file ] = $user->save_feed(
 					$file,
 					array( 'parser' => 'local' )
 				);
@@ -156,6 +155,7 @@ class FeedTest extends \WP_UnitTestCase {
 			$new_items = $user->retrieve_posts_from_feeds( array( $user_feed ) );
 			$file = ( yield $new_items );
 		} while ( $file );
+		remove_filter( 'friends_pre_check_url', '__return_true' );
 	}
 
 	/**
@@ -330,8 +330,7 @@ class FeedTest extends \WP_UnitTestCase {
 	}
 
 	private function get_user_feed( $user, $url, $interval, $modifier ) {
-		return User_Feed::save(
-			$user,
+		return $user->save_feed(
 			$url,
 			array(
 				'active'   => true,

--- a/tests/test-notifications.php
+++ b/tests/test-notifications.php
@@ -126,7 +126,7 @@ class NotificationTest extends \WP_UnitTestCase {
 
 		$test_user = get_user_by( 'email', \WP_TESTS_EMAIL );
 		$this->assertInstanceOf( 'WP_User', $test_user );
-		update_user_option( $test_user->ID, 'friends_no_new_post_notification_' . $this->friend_id, true );
+		update_user_option( $test_user->ID, 'friends_no_new_post_notification_' . $user->user_login, true );
 
 		$feed = new \SimplePie();
 		$feed->set_file( $file );

--- a/tests/test-notifications.php
+++ b/tests/test-notifications.php
@@ -79,7 +79,8 @@ class NotificationTest extends \WP_UnitTestCase {
 		$user = new User( $this->friend_id );
 		$term = new \WP_Term(
 			(object) array(
-				'url' => $user->user_url . '/feed/',
+				'term_id' => 100,
+				'url'     => $user->user_url . '/feed/',
 			)
 		);
 		$user_feed = new User_Feed( $term, $user );
@@ -117,7 +118,8 @@ class NotificationTest extends \WP_UnitTestCase {
 		$user = new User( $this->friend_id );
 		$term = new \WP_Term(
 			(object) array(
-				'url' => $user->user_url . '/feed/',
+				'term_id' => 100,
+				'url'     => $user->user_url . '/feed/',
 			)
 		);
 		$user_feed = new User_Feed( $term, $user );
@@ -296,7 +298,8 @@ class NotificationTest extends \WP_UnitTestCase {
 		$user = new User( $this->friend_id );
 		$term = new \WP_Term(
 			(object) array(
-				'url' => $user->user_url . '/feed/',
+				'term_id' => 100,
+				'url'     => $user->user_url . '/feed/',
 			)
 		);
 		$user_feed = new User_Feed( $term, $user );

--- a/widgets/class-widget-base-friends-list.php
+++ b/widgets/class-widget-base-friends-list.php
@@ -77,7 +77,6 @@ abstract class Widget_Base_Friends_List extends \WP_Widget {
 	 */
 	public function get_list_items( $users ) {
 		foreach ( $users as $friend_user ) {
-			$friend_user = new User( $friend_user );
 			if ( Friends::has_required_privileges() ) {
 				if ( $this->friends->frontend->post_format ) {
 					$url = $friend_user->get_local_friends_page_post_format_url( $this->friends->frontend->post_format );


### PR DESCRIPTION
This implements something like a virutal user that is taxonomy based. New subscriptions are by default created as virtual users and (for now) you can manually convert existing subscriptions to virtual users on the Edit Friend page:

<img width="434" alt="Screenshot 2023-05-19 at 11 14 48" src="https://github.com/akirk/friends/assets/203408/1f9a4c8a-6ddc-4249-9bdd-2c31c435efb8">

It can also be converted back (and will be as soon as you create a friend request from it).

<img width="503" alt="Screenshot 2023-05-19 at 11 14 57" src="https://github.com/akirk/friends/assets/203408/e11a3f4e-1847-4c4e-afea-f47fde1399e1">


The Friends functionality remains untouched, and I still need to work on the cases where we need to automatically convert the user. Of course you can opt to not use the friend functionality and disable incoming friend request by using some random codeword.

