### PR TITLE
Allow sharing a private friends post with special URL

### DIFF
--- a/includes/class-frontend.php
+++ b/includes/class-frontend.php
@@ -1101,8 +1101,12 @@ class Frontend {
 				}
 			}
 		}
+		$page_id = get_query_var( 'page' );
+		$share_hash = hash( 'crc32b', apply_filters( 'friends_share_salt', wp_salt( 'nonce' ) ) . $page_id );
 
-		if ( ! $viewable || ! Friends::on_frontend() ) {
+		if ( isset( $_GET['share'] ) && $_GET['share'] === $share_hash ) {
+			$viewable = true;
+		} elseif ( ! $viewable || ! Friends::on_frontend() ) {
 			if ( $query->is_feed() ) {
 				status_header( 404 );
 				$query->set_404();
@@ -1122,7 +1126,6 @@ class Frontend {
 		remove_action( 'pre_get_posts', array( 'Kind_Taxonomy', 'kind_firehose_query' ), 99 );
 
 		switch_to_locale( get_user_locale() );
-		$page_id = get_query_var( 'page' );
 
 		$tax_query = array();
 		$post_formats = get_post_format_slugs();
@@ -1195,7 +1198,7 @@ class Frontend {
 		$query->set( 'post_type', $post_types );
 		$query->set( 'tax_query', $tax_query );
 
-		if ( friends::has_required_privileges() ) {
+		if ( ( isset( $_GET['share'] ) && $_GET['share'] === $share_hash ) || friends::has_required_privileges() ) {
 			$post_status = array( 'publish', 'private' );
 			if ( isset( $_GET['show-hidden'] ) ) {
 				$post_status[] = 'trash';

--- a/templates/frontend/parts/header.php
+++ b/templates/frontend/parts/header.php
@@ -105,6 +105,9 @@ $override_author_name = apply_filters( 'friends_override_author_name', '', $auth
 					<li class="menu-item"><a href="<?php echo esc_attr( $edit_user_link ); ?>"><?php esc_html_e( 'Edit friend', 'friends' ); ?></a></li>
 				<?php endif; ?>
 					<li class="menu-item friends-dropdown">
+						<a href="<?php echo esc_attr( $friend_user->get_local_friends_page_url() . get_the_ID() . '/?share=' . hash( 'crc32b', apply_filters( 'friends_share_salt', wp_salt( 'nonce' ) ) . get_the_ID() ) ); ?>"><?php esc_html_e( 'Share link', 'friends' ); ?></a>
+					</li>
+					<li class="menu-item friends-dropdown">
 						<select name="post-format" class="friends-change-post-format form-select select-sm" data-change-post-format-nonce="<?php echo esc_attr( wp_create_nonce( 'friends-change-post-format_' . get_the_ID() ) ); ?>" data-id="<?php echo esc_attr( get_the_ID() ); ?>" >
 							<option disabled="disabled"><?php esc_html_e( 'Change post format', 'friends' ); ?></option>
 							<?php foreach ( get_post_format_strings() as $format => $title ) : ?>


### PR DESCRIPTION
This adds a "Share link" entry to the drop down which contains a special `?share=` parameter which allows someone who doesn't have access to your personal friends page to view the post.

<img width="378" alt="Screenshot 2023-05-30 at 05 02 20" src="https://github.com/akirk/friends/assets/203408/bc2bf207-3260-46de-b0a5-e34a2c5b1777">

This can be useful for sharing articles privately with friends. So you'd right click this link and copy it and send it to your friend who can then read the post.