### PR TITLE
Support for incoming tags

### DIFF
--- a/feed-parsers/class-feed-item.php
+++ b/feed-parsers/class-feed-item.php
@@ -140,6 +140,10 @@ class Feed_Item {
 				$value = $this->validate_post_status( $value );
 				break;
 
+			case 'tags':
+				$value = $this->validate_tags( $value );
+				break;
+
 			case 'date':
 				$value = $this->validate_date( $value, 'invalid-date' );
 				break;
@@ -291,6 +295,42 @@ class Feed_Item {
 
 		}
 		return $status;
+	}
+
+	/**
+	 * Validate a given post status.
+	 *
+	 * @param      string|array $tags  The tags.
+	 *
+	 * @return     string|\WP_Error  The validated status.
+	 */
+	public function validate_tags( $tags ) {
+		if ( ! is_array( $tags ) ) {
+			if ( ! is_string( $tags ) ) {
+				return new \WP_Error( 'invalid-tags', 'The tags need to be a hashtag string or an array.' );
+			}
+			if ( false !== strpos( $tags, '#' ) ) {
+				$tags = explode( '#', $tags );
+			} elseif ( false !== strpos( $tags, ',' ) ) {
+				$tags = explode( ',', $tags );
+			} else {
+				$tags = array( $tags );
+			}
+		}
+
+		$validated_tags = array();
+		foreach ( $tags as $tag ) {
+			if ( ! is_string( $tag ) ) {
+				continue;
+			}
+			$tag = mb_substr( trim( ltrim( trim( $tag ), '#,' ) ), 0, 50 );
+			if ( ! $tag ) {
+				continue;
+			}
+			$validated_tags[ $tag ] = true;
+		}
+
+		return array_keys( $validated_tags );
 	}
 
 	/**

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -2053,6 +2053,10 @@ class Admin {
 									?>
 								</p>
 							<?php endif; ?>
+							<?php if ( $item->tags ) {
+								echo '<br/>#' . implode( ', #', $item->tags );
+							}
+							?>
 						</li>
 						<?php
 				}

--- a/includes/class-feed.php
+++ b/includes/class-feed.php
@@ -444,7 +444,7 @@ class Feed {
 
 	public function extract_tags( $item, User_Feed $feed = null, User $friend_user = null ) {
 		// This is a variation of the ACTIVITYPUB_HASHTAGS_REGEXP.
-		if ( \preg_match_all( '/(?:(?<=\s)|(?<=<p>)|(?<=<br\s*/?>)|^)#(\w+)(?:(?=\s|[[:punct:]]|$))/ui', \wp_strip_all_tags( $item->post_content ), $match ) ) {
+		if ( \preg_match_all( '/(?:(?<=\s)|(?<=<p>)|(?<=<br>)|^)#(\w+)(?:(?=\s|[[:punct:]]|$))/ui', \wp_strip_all_tags( $item->post_content ), $match ) ) {
 			$tags = \implode( ', ', $match[1] );
 			$item->tags = $tags;
 		}

--- a/includes/class-frontend.php
+++ b/includes/class-frontend.php
@@ -47,6 +47,13 @@ class Frontend {
 	public $post_format = false;
 
 	/**
+	 * Whether a tag is being displayed
+	 *
+	 * @var string|false
+	 */
+	public $tag = false;
+
+	/**
 	 * Whether a reaciton is being displayed
 	 *
 	 * @var string|false
@@ -1194,6 +1201,17 @@ class Frontend {
 					if ( $tax_query ) {
 						$this->post_format = $post_format;
 					}
+					break;
+
+				case 'tag':
+					$this->tag = array_shift( $pagename_parts );
+					$tax_query = array(
+						array(
+							'taxonomy' => 'post_tag',
+							'field'    => 'slug',
+							'terms'    => array( $this->tag ),
+						),
+					);
 					break;
 
 				default: // Maybe an author.

--- a/templates/frontend/main-feed-header.php
+++ b/templates/frontend/main-feed-header.php
@@ -56,6 +56,15 @@ if ( $args['friends']->frontend->reaction ) {
 			$title
 		)
 	);
+} elseif ( $args['friends']->frontend->tag ) {
+	echo esc_html(
+		sprintf(
+		// translators: %1$s is a hash tag, %2$s is a type of feed, e.g. "Main Feed".
+			_x( '#%1$s on %2$s', '#tag on feed', 'friends' ),
+			$args['friends']->frontend->tag,
+			$title
+		)
+	);
 } else {
 	echo esc_html( $title );
 }

--- a/templates/frontend/parts/footer.php
+++ b/templates/frontend/parts/footer.php
@@ -9,6 +9,7 @@
 ?><footer class="entry-meta card-footer">
 	<?php if ( in_array( get_post_type(), apply_filters( 'friends_frontend_post_types', array() ), true ) ) : ?>
 		<?php
+		Friends\Friends::template_loader()->get_template_part( 'frontend/parts/tags', null, $args );
 		do_action( 'friends_post_footer_first' );
 		Friends\Friends::template_loader()->get_template_part( 'frontend/parts/reactions', null, $args );
 		Friends\Friends::template_loader()->get_template_part( 'frontend/parts/comments', null, $args );

--- a/templates/frontend/parts/tags.php
+++ b/templates/frontend/parts/tags.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * This template contains the reactions in the footer for an article on /friends/.
+ *
+ * @version 1.0
+ * @package Friends
+ */
+
+$tags = get_the_tags();
+if ( ! $tags ) {
+	return;
+}
+?><div>
+<?php
+foreach ( $tags as $tag ) {
+	?>
+	<a href="<?php echo esc_attr( home_url( '/friends/tag/' . $tag->slug ) ); ?>">#<?php echo esc_html( $tag->name ); ?></a>
+	<?php
+}
+?>
+</div>
+<?php


### PR DESCRIPTION
Extract the hashtags in incoming items and use the `post_tag` taxonomy to classify them. Thus you can then view all posts in your friends' posts that have a certain tag:

![Screenshot 2023-06-02 at 08 49 12](https://github.com/akirk/friends/assets/203408/4bf3dc89-4a41-44c9-8d95-2789b1eb8aa5)

The hairy thing with this is that it will pollute your own tags, often with random tags. Probably best to create a separate taxonomy.
