### PR TITLE
Fix Quick Subscribe

### DIFF
--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -1707,11 +1707,11 @@ class Admin {
 			if ( isset( $vars['friendship'] ) ) {
 				// translators: %s is a Site URL.
 				$message = sprintf( __( 'No friends plugin installed at %s.', 'friends' ), $friend_link );
+				$message .= ' ' . esc_html__( 'We subscribed you to their updates.', 'friends' );
 			} else {
 				// translators: %s is a Site URL.
 				$message = sprintf( __( "You're now subscribed to %s.", 'friends' ), $friend_link );
 			}
-			$message .= ' ' . esc_html__( 'We subscribed you to their updates.', 'friends' );
 		}
 
 		if ( $message ) {
@@ -1865,9 +1865,14 @@ class Admin {
 			unset( $feeds[ $rest_url ] );
 		}
 
-		if ( 1 === count( $feeds ) && isset( $vars['quick-subscribe'] ) ) {
+		if ( isset( $vars['quick-subscribe'] ) ) {
 			$vars['feeds'] = $feeds;
-			$vars['subscribe'] = array_keys( $feeds );
+			$vars['subscribe'] = array();
+			foreach ( $feeds as $feed_url => $details ) {
+				if ( isset( $details['autoselect'] ) && $details['autoselect'] ) {
+					$vars['subscribe'][] = $feed_url;
+				}
+			}
 
 			$friend_user = false;
 			if ( isset( $rest_url ) ) {


### PR DESCRIPTION
Before this PR, quick subscribe would only work when the site only had one feed. This now just uses the autoselected feeds.

<img width="771" alt="Screenshot 2023-07-22 at 22 24 00" src="https://github.com/akirk/friends/assets/203408/dc4e1e3a-5333-452d-94cb-59c5e195cb21">
