### PR TITLE
Expose the ActivityPub plugin more on the Add Friend screen

### DIFF
--- a/feed-parsers/class-feed-parser-activitypub.php
+++ b/feed-parsers/class-feed-parser-activitypub.php
@@ -38,6 +38,8 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 		\add_action( 'init', array( $this, 'include_activitypub_model_comment' ), 2 );
 		\add_action( 'admin_menu', array( $this, 'admin_menu' ), 20 );
 		\add_filter( 'feed_item_allow_set_metadata', array( $this, 'feed_item_allow_set_metadata' ), 10, 3 );
+		\add_filter( 'friends_add_friends_input_placeholder', array( $this, 'friends_add_friends_input_placeholder' ) );
+		\add_action( 'friends_add_friend_form_top', array( $this, 'friends_add_friend_form_top' ) );
 
 		\add_action( 'activitypub_inbox', array( $this, 'handle_received_activity' ), 10, 3 );
 		\add_action( 'friends_user_feed_activated', array( $this, 'queue_follow_user' ), 10 );
@@ -154,6 +156,31 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 		}
 		wp_safe_redirect( add_query_arg( 'updated', 'true', admin_url( 'admin.php?page=friends-activitypub-settings' ) ) );
 		exit;
+	}
+
+	public function friends_add_friends_input_placeholder() {
+		return __( 'Enter URL or @activitypub@handle.domain', 'friends' );
+	}
+
+	public function friends_add_friend_form_top() {
+		?>
+		<p>
+			<?php
+			echo wp_kses(
+				sprintf(
+					// translators: %1$s and %2$s are links to the respective services.
+					__( '<strong>Note:</strong> Because you have the ActivityPub plugin installed, you can also follow people over that protocol, for example <a href=%1$s>Mastodon</a> or <a href=%2$s>Pixelfed</a>.', 'friends' ),
+					'"https://joinmastodon.org/"',
+					'"https://pixelfed.social/"'
+				),
+				array(
+					'a'      => array( 'href' => array() ),
+					'strong' => array(),
+				)
+			);
+			?>
+		</p>
+		<?php
 	}
 
 	public function friends_get_feed_metadata( $meta, $feed ) {

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -2093,7 +2093,8 @@ class Admin {
 		}
 
 		$args = array(
-			'friend_url' => '',
+			'friend_url'              => '',
+			'add-friends-placeholder' => apply_filters( 'friends_add_friends_input_placeholder', __( 'Enter URL', 'friends' ) ),
 		);
 
 		if ( ! empty( $_GET['url'] ) || ! empty( $_POST['url'] ) ) {

--- a/templates/admin/activitypub-settings.php
+++ b/templates/admin/activitypub-settings.php
@@ -28,5 +28,20 @@
 	<p class="submit">
 		<input type="submit" id="submit" class="button button-primary" value="<?php /* phpcs:ignore WordPress.WP.I18n.MissingArgDomain */ esc_html_e( 'Save Changes' ); ?>">
 	</p>
+
+	<p class="description">
+	<?php
+	echo wp_kses(
+		sprintf(
+			// translators: %s is the URL of the Friends admin menu.
+			__( 'Find further settings around ActivityPub in the <a href=%s>ActivityPub plugin settings</a>.', 'friends' ),
+			'"' . admin_url( 'options-general.php?page=activitypub&tab=settings' ) . '"'
+		),
+		array(
+			'a' => array( 'href' => array() ),
+		)
+	);
+	?>
+	</p>
 </form>
 <?php

--- a/templates/admin/add-friend.php
+++ b/templates/admin/add-friend.php
@@ -19,12 +19,14 @@ $quick_subscribe = _x( 'Quick Subscribe', 'button', 'friends' );
 		?>
 	</p>
 
+	<?php do_action( 'friends_add_friend_form_top', $args ); ?>
+
 	<table class="form-table">
 		<tbody>
 			<tr>
 				<th scope="row"><label for="friend_url"><?php esc_html_e( 'Site', 'friends' ); ?></label></th>
 				<td>
-					<input type="text" autofocus id="friend_url" name="friend_url" value="<?php echo esc_attr( $args['friend_url'] ); ?>" required placeholder="<?php esc_attr_e( 'Enter URL', 'friends' ); ?>" class="regular-text" />
+					<input type="text" autofocus id="friend_url" name="friend_url" value="<?php echo esc_attr( $args['friend_url'] ); ?>" required placeholder="<?php echo esc_attr( $args['add-friends-placeholder'] ); ?>" class="regular-text" />
 					<p class="description" id="friend_url-description">
 						<?php esc_html_e( "In the next step we'll give you a selection of available feeds.", 'friends' ); ?>
 					</p>


### PR DESCRIPTION
Explain that you can also use a Mastodon account:
<img width="819" alt="Screenshot 2023-07-22 at 22 27 54" src="https://github.com/akirk/friends/assets/203408/9235cdee-5f7c-42fc-9540-28d2e30eb5e8">

And link further settings in the ActivityPub plugin:
<img width="698" alt="Screenshot 2023-07-22 at 22 28 00" src="https://github.com/akirk/friends/assets/203408/4d99586e-6a42-49c9-b256-d9f506dbbd83">
