### PR TITLE
Prepare for Activitypub Update

### DIFF
--- a/feed-parsers/class-feed-parser-activitypub.php
+++ b/feed-parsers/class-feed-parser-activitypub.php
@@ -35,7 +35,6 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 		$this->friends_feed = $friends_feed;
 
 		\add_action( 'init', array( $this, 'register_post_meta' ) );
-		\add_action( 'init', array( $this, 'include_activitypub_model_comment' ), 2 );
 		\add_action( 'admin_menu', array( $this, 'admin_menu' ), 20 );
 		\add_filter( 'feed_item_allow_set_metadata', array( $this, 'feed_item_allow_set_metadata' ), 10, 3 );
 		\add_filter( 'friends_add_friends_input_placeholder', array( $this, 'friends_add_friends_input_placeholder' ) );
@@ -1680,7 +1679,12 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 	}
 
 	public function include_activitypub_model_comment() {
+		if ( ! class_exists( 'Activitypub\Model\Post' ) ) {
+			return false;
+		}
+
 		require_once __DIR__ . '/activitypub/class-comment.php';
+		return true;
 	}
 
 	public function comment_post( $comment_id, $comment_approved, $commentdata ) {
@@ -1699,10 +1703,11 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 			// Don't act on non-local comments.
 			return;
 		}
-		$this->include_activitypub_model_comment();
-		$activitypub_comment = new \Activitypub\Model\Comment( $comment_id );
+		if ( $this->include_activitypub_model_comment() ) {
+			$activitypub_comment = new \Activitypub\Model\Comment( $comment_id );
 
-		\wp_schedule_single_event( \time(), 'activitypub_send_post_activity', array( $activitypub_comment ) );
+			\wp_schedule_single_event( \time(), 'activitypub_send_post_activity', array( $activitypub_comment ) );
+		}
 	}
 
 	public function trashed_comment( $comment_id, $comment ) {
@@ -1722,10 +1727,11 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 			return;
 		}
 
-		$this->include_activitypub_model_comment();
-		$activitypub_comment = new \Activitypub\Model\Comment( $comment );
+		if ( $this->include_activitypub_model_comment() ) {
+			$activitypub_comment = new \Activitypub\Model\Comment( $comment );
 
-		\wp_schedule_single_event( \time(), 'activitypub_send_delete_activity', array( $activitypub_comment ) );
+			\wp_schedule_single_event( \time(), 'activitypub_send_delete_activity', array( $activitypub_comment ) );
+		}
 	}
 
 	/**


### PR DESCRIPTION
Because we're extending `Activitypub\Model\Post` (for allowing to post own responses as comment), the upcoming ActivityPub update would fatal since https://github.com/Automattic/wordpress-activitypub/pull/355.

<img width="839" alt="Screenshot 2023-07-23 at 14 55 32" src="https://github.com/akirk/friends/assets/203408/782e3711-5aeb-46f9-8410-37eb3c52bfd3">

This feature is currently only being used by the Enable Mastodon Apps, and [there only through an option](https://github.com/akirk/enable-mastodon-apps/blob/main/includes/class-mastodon-api.php#L1145)
 (which I personally discourage because it introduces sorting problems in apps that sort the feed by id instead of date). Therefore I don't see a high impact and I'll probably remove the whole functionality.

As a first step, I check for the existance of the class.

cc @pfefferle