### PR TITLE
Allow specifying a URL as avatar

### DIFF
--- a/feed-parsers/class-feed-parser-activitypub.php
+++ b/feed-parsers/class-feed-parser-activitypub.php
@@ -54,7 +54,7 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 		\add_filter( 'friends_edit_friend_table_end', array( $this, 'activitypub_settings' ), 10 );
 		\add_filter( 'friends_edit_friend_after_form_submit', array( $this, 'activitypub_save_settings' ), 10 );
 		\add_filter( 'friends_modify_feed_item', array( $this, 'modify_incoming_item' ), 9, 3 );
-		\add_filter( 'friends_edit_friend_after_avatar', array( $this, 'admin_show_update_avatar' ) );
+		\add_filter( 'friends_potential_avatars', array( $this, 'friends_potential_avatars' ), 10, 2 );
 		\add_filter( 'friends_suggest_user_login', array( $this, 'suggest_user_login' ), 10, 2 );
 
 		\add_filter( 'the_content', array( $this, 'the_content' ), 99, 2 );
@@ -1257,9 +1257,8 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 		return $item;
 	}
 
-	public function admin_show_update_avatar( User $friend_user ) {
-		$avatars = array();
-		foreach ( $friend_user->get_active_feeds() as $user_feed ) {
+	public function friends_potential_avatars( $avatars, User $friend_user ) {
+		foreach ( $friend_user->get_feeds() as $user_feed ) {
 			if ( 'activitypub' === $user_feed->get_parser() ) {
 				$details = $this->update_feed_details(
 					array(
@@ -1275,27 +1274,7 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 				}
 			}
 		}
-		if ( empty( $avatars ) ) {
-			return;
-		}
-
-		?>
-		<tr>
-				<th><label for="friends_set_avatar"><?php esc_html_e( 'Avatar via ActivityPub', 'friends' ); ?></label></th>
-				<td>
-					<?php
-					foreach ( $avatars as $avatar => $title ) {
-						?>
-						<a href="" data-nonce="<?php echo esc_attr( wp_create_nonce( 'set-avatar-' . $friend_user->ID ) ); ?>" data-id="<?php echo esc_attr( $friend_user->ID ); ?>" class="set-avatar"><img src="<?php echo esc_url( $avatar ); ?>" alt="<?php echo esc_attr( $title ); ?>" title="<?php echo esc_attr( $title ); ?>" width="32" height="32" /></a>
-						<?php
-					}
-					?>
-					<p class="description">
-						<?php esc_html_e( 'Click to set as new avatar.', 'friends' ); ?><br/>
-					</p>
-				</td>
-			</tr>
-		<?php
+		return $avatars;
 	}
 
 	private function get_author_of_post( \WP_Post $post ) {

--- a/friends-admin.js
+++ b/friends-admin.js
@@ -303,25 +303,50 @@ jQuery( function ( $ ) {
 	);
 
 	$( document ).on( 'click', 'a.set-avatar', function () {
-		const url = $( this ).find( 'img' ).prop( 'src' );
-		if ( ! url ) {
+		setAvatarUrl(
+			$( this ).find( 'img' ).prop( 'src' ),
+			$( this ).data( 'id' ),
+			$( this ).data( 'nonce' )
+		);
+		return false;
+	} );
+
+	const setAvatarUrl = function ( url, user, nonce ) {
+		if ( ! url || ! url.match( /^https?:\/\// ) ) {
 			return;
 		}
 		$.post(
 			friends.ajax_url,
 			{
-				user: $( this ).data( 'id' ),
+				user,
 				avatar: url,
-				_ajax_nonce: $( this ).data( 'nonce' ),
+				_ajax_nonce: nonce,
 				action: 'friends_set_avatar',
 			},
 			function ( response ) {
 				if ( response.success ) {
 					window.location.reload();
+				} else {
+					$( '#friend-avatar-setting p.description' ).text(
+						'⚠️ ' + response.data
+					);
 				}
 			}
 		);
+	};
+
+	$( document ).on( 'click', 'button#set-avatar-url', function () {
+		const url = $( '#new-avatar-url' );
+		setAvatarUrl( url.val(), url.data( 'id' ), url.data( 'nonce' ) );
 		return false;
+	} );
+
+	$( document ).on( 'keyup', 'input#new-avatar-url', function ( e ) {
+		const url = $( '#new-avatar-url' );
+		if ( e.keyCode === 13 ) {
+			setAvatarUrl( url.val(), url.data( 'id' ), url.data( 'nonce' ) );
+			return false;
+		}
 	} );
 
 	setTimeout( function () {

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -1233,7 +1233,7 @@ class Admin {
 	}
 
 	public function ajax_set_avatar() {
-		$user_id = isset( $_POST['user'] ) ? (int) $_POST['user'] : 0;
+		$user_id = isset( $_POST['user'] ) ? $_POST['user'] : 0;
 
 		check_ajax_referer( "set-avatar-$user_id" );
 
@@ -1247,7 +1247,22 @@ class Admin {
 			exit;
 		}
 
-		$friend = new User( $user_id );
+		$friend = User::get_user_by_id( $user_id );
+
+		$image = file_get_contents( $_POST['avatar'] );
+
+		// Use WordPress functions to check the image dimensions.
+		$size = \wp_getimagesize( $_POST['avatar'] );
+		if ( ! $size ) {
+			wp_send_json_error( __( 'Image is in an unknown format.', 'friends' ) );
+			exit;
+		}
+		// Needs to be square and not larger than 512x512.
+		if ( $size[0] !== $size[1] || $size[0] > 512 ) {
+			wp_send_json_error( __( 'Image must be square and not larger than 512x512.', 'friends' ) );
+			exit;
+		}
+
 		$url = $friend->update_user_icon_url( $_POST['avatar'] );
 
 		if ( ! $url || is_wp_error( $url ) ) {

--- a/includes/class-subscription.php
+++ b/includes/class-subscription.php
@@ -93,7 +93,6 @@ class Subscription extends User {
 		register_taxonomy( self::TAXONOMY, 'None', $args );
 	}
 
-
 	public static function get_by_username( $username ) {
 		if ( 0 === strpos( $username, 'friends-virtual-user-' ) ) {
 			$term_id = substr( $username, strlen( 'friends-virtual-user-' ) );
@@ -548,6 +547,17 @@ class Subscription extends User {
 		return new self( $term );
 	}
 
+	private function map_option( $option_name ) {
+		$option_map = array(
+			'friends_user_icon_url' => 'avatar_url',
+		);
+		if ( isset( $option_map[ $option_name ] ) ) {
+			$option_name = $option_map[ $option_name ];
+		}
+
+		return $option_name;
+	}
+
 	/**
 	 * Wrap get_user_option
 	 *
@@ -556,7 +566,12 @@ class Subscription extends User {
 	 *                  false on failure.
 	 */
 	function get_user_option( $option_name ) {
-		return get_metadata( 'term', $this->get_term_id(), $option_name, true );
+		$value = get_metadata( 'term', $this->get_term_id(), $option_name, true );
+		if ( false === $value ) {
+			$value = get_metadata( 'term', $this->get_term_id(), $this->map_option( $option_name ), true );
+		}
+
+		return $value;
 	}
 
 	/**
@@ -570,7 +585,7 @@ class Subscription extends User {
 	 *                  false on failure.
 	 */
 	function update_user_option( $option_name, $new_value, $global = false ) {
-		return update_metadata( 'term', $this->get_term_id(), $option_name, $new_value );
+		return update_metadata( 'term', $this->get_term_id(), $this->map_option( $option_name ), $new_value );
 	}
 
 	/**

--- a/includes/class-user.php
+++ b/includes/class-user.php
@@ -285,6 +285,14 @@ class User extends \WP_User {
 	 * @return User|false The friend user or false.
 	 */
 	public static function get_user_by_id( $user_id ) {
+		if ( 0 === strpos( $user_id, 'friends-virtual-user-' ) ) {
+			$term_id = substr( $user_id, strlen( 'friends-virtual-user-' ) );
+			$term = get_term( intval( $term_id ), Subscription::TAXONOMY );
+			if ( $term ) {
+				return new Subscription( $term );
+			}
+		}
+
 		$user = get_user_by( 'ID', $user_id );
 		if ( $user ) {
 			if ( $user->has_cap( 'friend' ) || $user->has_cap( 'pending_friend_request' ) || $user->has_cap( 'friend_request' ) || $user->has_cap( 'subscription' ) ) {
@@ -295,6 +303,7 @@ class User extends \WP_User {
 		}
 		return $user;
 	}
+
 	public function __get( $key ) {
 		if ( 'user_url' === $key && empty( $this->data->user_url ) && is_multisite() ) {
 			$site = get_active_blog_for_user( $this->ID );

--- a/templates/admin/edit-friend.php
+++ b/templates/admin/edit-friend.php
@@ -6,6 +6,8 @@
  * @package Friends
  */
 
+$available_avatars = apply_filters( 'friends_potential_avatars', array(), $args['friend'] );
+
 ?><form method="post">
 	<?php wp_nonce_field( 'edit-friend-' . $args['friend']->user_login ); ?>
 	<table class="form-table">
@@ -16,6 +18,30 @@
 				<?php echo get_avatar( $args['friend']->user_login ); ?>
 			</td>
 			</tr>
+			<tr>
+				<th><label for="friends_set_avatar"><?php esc_html_e( 'Update Avatar', 'friends' ); ?></label></th>
+				<td id="friend-avatar-setting">
+					<?php
+					foreach ( $available_avatars as $avatar => $title ) {
+						?>
+						<a href="" data-nonce="<?php echo esc_attr( wp_create_nonce( 'set-avatar-' . $args['friend']->ID ) ); ?>" data-id="<?php echo esc_attr( $args['friend']->ID ); ?>" class="set-avatar"><img src="<?php echo esc_url( $avatar ); ?>" alt="<?php echo esc_attr( $title ); ?>" title="<?php echo esc_attr( $title ); ?>" width="32" height="32" /></a>
+						<?php
+					}
+					if ( ! empty( $available_avatars ) ) :
+						?>
+					<p class="description">
+						<?php esc_html_e( 'Click to set as new avatar.', 'friends' ); ?><br/>
+					</p>
+					<?php else : ?>
+						<input type="url" id="new-avatar-url" placeholder="<?php esc_attr_e( 'Enter an image URL', 'friends' ); ?>" data-nonce="<?php echo esc_attr( wp_create_nonce( 'set-avatar-' . $args['friend']->ID ) ); ?>" data-id="<?php echo esc_attr( $args['friend']->ID ); ?>" value="<?php echo esc_attr( $args['friend']->get_avatar_url() ); ?>"/>
+						<button id='set-avatar-url'><?php esc_html_e( 'Use this URL', 'friends' ); ?></button>
+						<p class="description">
+							<?php esc_html_e( 'Please specify a square, not too large image URL here.', 'friends' ); ?><br/>
+						</p>
+					<?php endif; ?>
+				</td>
+			</tr>
+
 			<?php do_action( 'friends_edit_friend_after_avatar', $args['friend'] ); ?>
 			<tr>
 				<th><label for="friends_display_name"><?php esc_html_e( 'Display Name', 'friends' ); ?></label></th>


### PR DESCRIPTION
You could already set an avatar through ActivityPub (#142), now you can specify one via URL. You might want to upload it to your own blog and use that URL.

![Screenshot 2023-07-27 at 17 22 25](https://github.com/akirk/friends/assets/203408/26d524d8-66f9-418e-8799-1c3705f50d49)


The avatar needs to be square and 512x512 maximum.

![Screenshot 2023-07-27 at 17 23 41](https://github.com/akirk/friends/assets/203408/dfdc2866-df54-4f12-ba07-9ea43e5be499)
