### PR TITLE
Add option to enable/disable Gutenberg on the frontend

### DIFF
--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -556,6 +556,12 @@ class Admin {
 				delete_option( 'comment_registration' );
 			}
 
+			if ( isset( $_POST['blocks_everywhere'] ) && $_POST['blocks_everywhere'] ) {
+				update_user_option( get_current_user_id(), 'friends_blocks_everywhere', 1 );
+			} else {
+				delete_user_option( get_current_user_id(), 'friends_blocks_everywhere' );
+			}
+
 			if ( isset( $_POST['comment_registration_message'] ) && $_POST['comment_registration_message'] ) {
 				update_option( 'friends_comment_registration_message', $_POST['comment_registration_message'] );
 			} else {
@@ -757,6 +763,7 @@ class Admin {
 					'retention_days_enabled'         => get_option( 'friends_enable_retention_days' ),
 					'retention_number_enabled'       => get_option( 'friends_enable_retention_number' ),
 					'frontend_default_view'          => get_option( 'friends_frontend_default_view', 'expanded' ),
+					'blocks_everywhere'              => get_user_option( 'friends_blocks_everywhere' ),
 				)
 			)
 		);

--- a/includes/class-frontend.php
+++ b/includes/class-frontend.php
@@ -771,6 +771,7 @@ class Frontend {
 			'friends'               => $this->friends,
 			'friend_user'           => $this->author,
 			'frontend_default_view' => get_option( 'friends_frontend_default_view', 'expanded' ),
+			'blocks-everywhere'     => get_user_option( 'friends_blocks_everywhere' ),
 		);
 
 		if ( isset( $_GET['in_reply_to'] ) && wp_parse_url( $_GET['in_reply_to'] ) ) {

--- a/includes/class-messages.php
+++ b/includes/class-messages.php
@@ -400,6 +400,8 @@ class Messages {
 			return;
 		}
 
+		$args['blocks-everywhere'] = get_user_option( 'friends_blocks_everywhere' );
+
 		if ( $args['friend_user']->has_cap( self::get_minimum_cap() ) ) {
 			Friends::template_loader()->get_template_part(
 				'frontend/messages/message-form',

--- a/libs/blocks-everywhere/classes/handlers/class-friends-message.php
+++ b/libs/blocks-everywhere/classes/handlers/class-friends-message.php
@@ -39,6 +39,6 @@ class Friends_Message extends Handler {
 	 * Get the HTML that the editor uses on the page
 	 */
 	public function add_to_form() {
-		$this->load_editor( '.friends-message-message', '.blocks-everywhere' );
+		$this->load_editor( '.friends-message-message.blocks-everywhere-enabled', '.blocks-everywhere' );
 	}
 }

--- a/libs/blocks-everywhere/classes/handlers/class-friends-status-post.php
+++ b/libs/blocks-everywhere/classes/handlers/class-friends-status-post.php
@@ -54,6 +54,6 @@ class Friends_Status_Post extends Handler {
 	 * Get the HTML that the editor uses on the page
 	 */
 	public function add_to_form() {
-		$this->load_editor( '.friends-status-content', '.blocks-everywhere' );
+		$this->load_editor( '.friends-status-content.blocks-everywhere-enabled', '.blocks-everywhere' );
 	}
 }

--- a/templates/admin/settings.php
+++ b/templates/admin/settings.php
@@ -402,7 +402,7 @@ do_action( 'friends_settings_before_form' );
 				</td>
 			</tr>
 			<tr>
-				<th scope="row"><?php esc_html_e( 'Frontend', 'friends' ); ?></th>
+				<th scope="row" rowspan="2"><?php esc_html_e( 'Frontend', 'friends' ); ?></th>
 				<td>
 					<fieldset>
 						<label for="frontend-default-view">
@@ -411,6 +411,16 @@ do_action( 'friends_settings_before_form' );
 								<option value="expanded"<?php selected( $args['frontend_default_view'], 'expanded' ); ?>><?php esc_html_e( 'Expanded', 'friends' ); ?></option>
 								<option value="collapsed"<?php selected( $args['frontend_default_view'], 'collapsed' ); ?>><?php esc_html_e( 'Collapsed', 'friends' ); ?></option>
 							</select>
+						</label>
+					</fieldset>
+				</td>
+			</tr>
+			<tr>
+				<td>
+					<fieldset>
+						<label for="blocks_everywhere">
+							<input name="blocks_everywhere" type="checkbox" id="blocks_everywhere" value="1" <?php checked( '1', $args['blocks_everywhere'] ); ?> />
+							<span><?php esc_html_e( 'Enable Gutenberg on the frontend.', 'friends' ); ?></span>
 						</label>
 					</fieldset>
 				</td>

--- a/templates/frontend/header.php
+++ b/templates/frontend/header.php
@@ -89,8 +89,8 @@ if ( isset( $_GET['s'] ) ) {
 				</div>
 				<div id="in_reply_to_preview"><?php echo wp_kses_post( ! empty( $args['in_reply_to'] ) ? $args['in_reply_to']['html'] : '' ); ?></div>
 				<p class="description">Click the mentions to copy them into your reply.</p>
-				<div class="form-group blocks-everywhere iso-editor__loading">
-					<textarea class="form-input friends-status-content" name="content" rows="5" cols="70" placeholder="<?php echo /* translators: %s is a user display name. */ esc_attr( sprintf( __( "What's on your mind, %s?", 'friends' ), wp_get_current_user()->display_name ) ); ?>"><?php echo wp_kses_post( ! empty( $args['in_reply_to'] ) ? '<!-- wp:paragraph -->' . PHP_EOL . '<p>' . $args['in_reply_to']['mention'] . PHP_EOL . '</p>' . PHP_EOL . '<!-- /wp:paragraph -->' . PHP_EOL : '' ); ?></textarea><br />
+				<div class="form-group<?php echo esc_attr( $args['blocks-everywhere'] ? ' blocks-everywhere iso-editor__loading' : '' ); ?>">
+					<textarea class="form-input friends-status-content<?php echo esc_attr( $args['blocks-everywhere'] ? ' blocks-everywhere-enabled' : '' ); ?>" name="content" rows="5" cols="70" placeholder="<?php echo /* translators: %s is a user display name. */ esc_attr( sprintf( __( "What's on your mind, %s?", 'friends' ), wp_get_current_user()->display_name ) ); ?>"><?php echo wp_kses_post( ! empty( $args['in_reply_to'] ) ? ( $args['blocks-everywhere'] ? '<!-- wp:paragraph -->' . PHP_EOL . '<p>' . $args['in_reply_to']['mention'] . PHP_EOL . '</p>' . PHP_EOL . '<!-- /wp:paragraph -->' . PHP_EOL : $args['in_reply_to']['mention'] . ' ' ) : '' ); ?></textarea><br />
 					<?php
 					do_action( 'friends_post_status_form' );
 					?>

--- a/templates/frontend/messages/message-form.php
+++ b/templates/frontend/messages/message-form.php
@@ -35,8 +35,8 @@ if ( ! isset( $args['subject'] ) ) {
 		<div class="col-2 col-sm-12">
 			<label class="form-label" for="friends_message_message"><?php esc_html_e( 'Message', 'friends' ); ?></label>
 		</div>
-		<div class="col-8 col-sm-12 blocks-everywhere iso-editor__loading">
-			<textarea class="form-input friends-message-message" name="friends_message_message" placeholder="" rows="3"></textarea>
+		<div class="col-8 col-sm-12<?php echo esc_attr( $args['blocks-everywhere'] ? ' blocks-everywhere iso-editor__loading' : '' ); ?>">
+			<textarea class="form-input friends-message-message<?php echo esc_attr( $args['blocks-everywhere'] ? ' blocks-everywhere-enabled' : '' ); ?>" name="friends_message_message" placeholder="" rows="3"></textarea>
 		<?php
 		do_action( 'friends_message_form' );
 		?>


### PR DESCRIPTION
Since I've already updated [Blocks Everywhere](https://github.com/Automattic/blocks-everywhere) to a WordPress 6.3 compatible version which turns out to be incompatible with WordPress 6.2, I'm adding the ability to disable it via option. Right now the default is off.

<img width="581" alt="Screenshot 2023-08-04 at 11 27 27" src="https://github.com/akirk/friends/assets/203408/9790dd34-bd63-4cf4-8cbb-0b2df9153d52">
