### PR TITLE
Fix crash when using get_the_excerpt in the admin edit-post screen

### DIFF
--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -2471,11 +2471,12 @@ class Admin {
 	 * @return     string  The potentially overriden title.
 	 */
 	public function override_post_format_title( $title, $post_id = null ) {
-		if ( empty( $title ) && is_admin() && function_exists( 'get_current_screen' ) ) {
+		if ( $post_id && empty( $title ) && is_admin() && function_exists( 'get_current_screen' ) ) {
 			$screen = get_current_screen();
 			if ( $screen && 'edit-post' === $screen->id ) {
 				if ( 'status' === get_post_format() ) {
-					return get_the_excerpt();
+					$post = get_post( $post_id );
+					return wp_trim_excerpt( wp_strip_all_tags( $post->post_content ) );
 				}
 			}
 		}


### PR DESCRIPTION
Fixes #259.

In the edit-post admin screen, we try to display status posts in a more useful way, displaying their content instead of `(no title)`. Before this patch, we were using `get_the_excerpt()` for this. This causes problems with themes (like for example GeneratePress) or plugins that filter `excerpt_more`.

As an alternative, we now just do a very basic `wp_trim_excerpt( wp_strip_all_tags( $post->post_content ) )` ourselves which won't run the above filter.