### PR TITLE
Ensure the reblog button is displayed also for virtual users

### DIFF
--- a/templates/frontend/parts/reblog-button.php
+++ b/templates/frontend/parts/reblog-button.php
@@ -6,7 +6,7 @@
  * @package Friends
  */
 
-if ( get_the_author_meta( 'ID' ) === get_current_user_id() ) {
+if ( \Friends\User::get_post_author( get_post() )->ID === get_current_user_id() ) {
 	return;
 }
 ?>


### PR DESCRIPTION
Fix the missing reblog button discovered in #259. This has been a forgotten update for #215, i.e. we were still using `get_the_author_meta( 'ID' )` which potentially doesn't return the right value for a virtual user.