### PR TITLE
Use a Custom Web Protocol for following

### DIFF
--- a/feed-parsers/class-feed-parser-activitypub.php
+++ b/feed-parsers/class-feed-parser-activitypub.php
@@ -81,6 +81,7 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 		\add_filter( 'friends_reblog', array( $this, 'reblog' ), 20, 2 );
 		\add_filter( 'friends_unreblog', array( $this, 'unreblog' ), 20, 2 );
 		\add_filter( 'friends_reblog', array( $this, 'maybe_unqueue_friends_reblog_post' ), 9, 2 );
+		\add_filter( 'friends_reblogged_author', array( $this, 'reblogged_author' ), 10, 2 );
 
 		\add_filter( 'pre_get_remote_metadata_by_actor', array( $this, 'disable_webfinger_for_example_domains' ), 9, 2 );
 
@@ -1578,6 +1579,18 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 
 		remove_filter( 'friends_reblog', array( 'Friends\Frontend', 'reblog' ), 10, 2 );
 		return $ret;
+	}
+
+	public function reblogged_author( $url, $post_id ) {
+		if ( User_Feed::get_parser_for_post_id( $post_id ) !== 'activitypub' ) {
+			return $url;
+		}
+
+		$meta = get_post_meta( $post_id, self::SLUG, true );
+		if ( isset( $meta['attributedTo']['id'] ) ) {
+			return $meta['attributedTo']['id'];
+		}
+		return $url;
 	}
 
 	public function reblog( $ret, $post ) {

--- a/includes/class-feed.php
+++ b/includes/class-feed.php
@@ -755,8 +755,11 @@ class Feed {
 		if ( ! isset( $_GET['add-friend'] ) || isset( $_GET['page'] ) ) {
 			return;
 		}
-
-		wp_safe_redirect( add_query_arg( 'url', $_GET['add-friend'], self_admin_url( 'admin.php?page=add-friend' ) ) );
+		$add_friend = $_GET['add-friend'];
+		if ( 'web+follow' === substr( $add_friend, 0, 10 ) ) {
+			$add_friend = substr( $add_friend, 13 );
+		}
+		wp_safe_redirect( add_query_arg( 'url', $add_friend, self_admin_url( 'admin.php?page=add-friend' ) ) );
 		exit;
 	}
 

--- a/includes/class-frontend.php
+++ b/includes/class-frontend.php
@@ -95,6 +95,7 @@ class Frontend {
 		add_filter( 'body_class', array( $this, 'add_body_class' ) );
 
 		add_filter( 'friends_override_author_name', array( $this, 'override_author_name' ), 10, 3 );
+		add_filter( 'friends_boosted_author', array( $this, 'boosted_author' ), 10, 2 );
 	}
 
 	/**

--- a/templates/frontend/header.php
+++ b/templates/frontend/header.php
@@ -17,6 +17,11 @@ if ( isset( $_GET['s'] ) ) {
 	<meta charset="<?php bloginfo( 'charset' ); ?>">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<?php wp_head(); ?>
+	<script>
+		if (typeof navigator.registerProtocolHandler === "function") {
+			navigator.registerProtocolHandler( 'web+follow', '<?php echo esc_js( add_query_arg( 'add-friend', '%s', home_url() ) ); ?>', 'Follow' );
+		}
+	</script>
 </head>
 
 <body <?php body_class( 'off-canvas off-canvas-sidebar-show' ); ?>>

--- a/templates/frontend/parts/header-status.php
+++ b/templates/frontend/parts/header-status.php
@@ -28,6 +28,7 @@ $author_name = $args['friend_user']->display_name;
  * ```
  */
 $override_author_name = apply_filters( 'friends_override_author_name', '', $author_name, get_the_id() );
+$reblogged_author = apply_filters( 'friends_reblogged_author', false, get_the_id() );
 ?><header class="entry-header card-header columns">
 	<div class="avatar col-auto mr-2">
 		<?php if ( in_array( get_post_type(), apply_filters( 'friends_frontend_post_types', array() ), true ) ) : ?>
@@ -49,6 +50,10 @@ $override_author_name = apply_filters( 'friends_override_author_name', '', $auth
 						– <?php echo esc_html( $override_author_name ); ?>
 					<?php endif; ?>
 				</a>
+				<?php if ( $reblogged_author ) : ?>
+					[<a href="web+follow://<?php echo esc_attr( $reblogged_author ); ?>"><?php esc_html_e( 'Follow', 'friends' ); ?></a>]
+				<?php endif; ?>
+
 			<?php else : ?>
 				<a href="<?php echo esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ); ?>">
 					<strong><?php the_author(); ?></strong>


### PR DESCRIPTION
Akin to https://github.com/mastodon/mastodon/issues/14187 (cc @pfefferle), following people of boosted posts now uses a custom web protocol `web+follow`. It works like this:

When visiting the Friends page, you'll get a popup from your browser (if supported):
![friends-web-follow](https://github.com/akirk/friends/assets/203408/68c30dbb-ec9b-48e4-b968-34fbd2fe452b)

So then on your friends page you can find Follow links like this:
![friends-web-follow-link](https://github.com/akirk/friends/assets/203408/39278f8e-e0e6-47bb-b5d8-f1db0195ffdc)

Which when you click it, opens your browser's dialog:
![friends-open-web-follow](https://github.com/akirk/friends/assets/203408/c55d9429-f311-4c04-8616-a3098f429a8d)

Which will then send you with this URL to follow to your Add Friend page:
![friends-web-follow-add-friend](https://github.com/akirk/friends/assets/203408/4fb4f2ee-af0e-40d6-a0a3-1c1b265f414a)
