### PR TITLE
Allow double clicking the text to collapse/uncollapse posts

### DIFF
--- a/friends.js
+++ b/friends.js
@@ -231,6 +231,15 @@
 		return false;
 	} );
 
+	$document.on(
+		'dblclick',
+		'section.all-collapsed article, article.collapsed, article.uncollapsed',
+		function () {
+			$( this ).closest( 'article' ).find( 'a.collapse-post' ).trigger( 'click' );
+			return false;
+		}
+	);
+
 	$document.on( 'click', 'article a.comments', function ( e ) {
 		if ( e.metaKey || e.altKey || e.shiftKey ) {
 			return;


### PR DESCRIPTION
You no longer have to just use the icon:

![collapse-dbl](https://github.com/akirk/friends/assets/203408/bcc6c48c-9bd2-4df8-ae26-be74cca91011)
