### PR TITLE
Disable Blocks Everywhere

### DIFF
--- a/friends.php
+++ b/friends.php
@@ -27,7 +27,6 @@ define( 'FRIENDS_PLUGIN_FILE', plugin_dir_path( __FILE__ ) . '/' . basename( __F
 define( 'FRIENDS_VERSION', '2.8.2' );
 
 require_once __DIR__ . '/libs/Mf2/Parser.php';
-require_once __DIR__ . '/libs/blocks-everywhere/blocks-everywhere.php';
 
 require_once __DIR__ . '/includes/class-user.php';
 require_once __DIR__ . '/includes/class-user-feed.php';

--- a/includes/class-frontend.php
+++ b/includes/class-frontend.php
@@ -769,7 +769,7 @@ class Frontend {
 			'friends'               => $this->friends,
 			'friend_user'           => $this->author,
 			'frontend_default_view' => get_option( 'friends_frontend_default_view', 'expanded' ),
-			'blocks-everywhere'     => get_user_option( 'friends_blocks_everywhere' ),
+			'blocks-everywhere'     => false,
 			'post_format'           => $this->post_format,
 		);
 

--- a/includes/class-messages.php
+++ b/includes/class-messages.php
@@ -399,7 +399,7 @@ class Messages {
 			return;
 		}
 
-		$args['blocks-everywhere'] = get_user_option( 'friends_blocks_everywhere' );
+		$args['blocks-everywhere'] = false;
 
 		if ( $args['friend_user']->has_cap( self::get_minimum_cap() ) ) {
 			Friends::template_loader()->get_template_part(

--- a/templates/admin/settings.php
+++ b/templates/admin/settings.php
@@ -423,8 +423,8 @@ do_action( 'friends_settings_before_form' );
 				<td>
 					<fieldset>
 						<label for="blocks_everywhere">
-							<input name="blocks_everywhere" type="checkbox" id="blocks_everywhere" value="1" <?php checked( '1', $args['blocks_everywhere'] ); ?> />
-							<span><?php esc_html_e( 'Enable Gutenberg on the frontend.', 'friends' ); ?></span>
+							<input name="blocks_everywhere" type="checkbox" id="blocks_everywhere" value="1" <?php checked( '1', $args['blocks_everywhere'] ); ?> disabled="disabled" />
+							<span><?php esc_html_e( 'Unfortunately, Gutenberg on the frontend is currently unavailable.', 'friends' ); ?></span>
 						</label>
 					</fieldset>
 				</td>


### PR DESCRIPTION
Fixes #264 for now. Unfortunately, [because Blocks Everywhere is now locked to specific versions of Gutenberg](https://github.com/Automattic/blocks-everywhere/pull/193) this makes it impossible to ship this for general use since everyone would have a different version of Gutenberg (or the one in Core), also this needs to be updated timely after new Gutenberg releases.