### PR TITLE
Fix Block Display for unconfigured plugin

### DIFF
--- a/includes/class-friends.php
+++ b/includes/class-friends.php
@@ -620,7 +620,7 @@ class Friends {
 	}
 
 	public static function is_main_user() {
-		return get_current_user_id() === self::get_main_friend_user_id();
+		return is_user_logged_in() && get_current_user_id() === self::get_main_friend_user_id();
 	}
 
 	/**


### PR DESCRIPTION
When no main user was set, the default Friends page would show things as if you were logged in.

![Screenshot 2023-11-23 at 12 44 22](https://github.com/akirk/friends/assets/203408/0fd5d17e-6a3b-4f36-b2ca-339c82f5c47e)
