### PR TITLE
Allow non-protocol feed URLs in Edit Feed screen.

### DIFF
--- a/friends-admin.js
+++ b/friends-admin.js
@@ -200,7 +200,7 @@ jQuery( function ( $ ) {
 	$( document ).on( 'click', '.delete-feed', function () {
 		// eslint-disable-next-line no-alert
 		if ( window.confirm( friends.delete_feed_question ) ) {
-			$( this ).closest( 'tr' ).remove();
+			$( this ).closest( 'li' ).remove();
 		}
 		return false;
 	} );

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -1409,6 +1409,10 @@ class Admin {
 						}
 
 						$feed['active'] = true;
+						$protocol = wp_parse_url( $feed['url'], PHP_URL_SCHEME );
+						if ( ! $protocol ) {
+							$feed['url'] = apply_filters( 'friends_rewrite_incoming_url', 'https://' . $feed['url'], $feed['url'] );
+						}
 						$new_feed = $friend->subscribe( $feed['url'], $feed );
 						if ( is_wp_error( $new_feed ) ) {
 							do_action( 'friends_process_feed_item_submit_error', $new_feed, $feed );

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -1426,6 +1426,11 @@ class Admin {
 					$user_feed = $existing_feeds[ $term_id ];
 					unset( $existing_feeds[ $term_id ] );
 
+					$protocol = wp_parse_url( $feed['url'], PHP_URL_SCHEME );
+					if ( ! $protocol ) {
+						$feed['url'] = apply_filters( 'friends_rewrite_incoming_url', 'https://' . $feed['url'], $feed['url'] );
+					}
+
 					if ( $user_feed->get_url() !== $feed['url'] ) {
 						do_action( 'friends_user_feed_deactivated', $user_feed );
 
@@ -1435,7 +1440,9 @@ class Admin {
 
 						if ( $feed['active'] ) {
 							$new_feed = $friend->subscribe( $feed['url'], $feed );
-							do_action( 'friends_user_feed_activated', $new_feed );
+							if ( ! is_wp_error( $new_feed ) ) {
+								do_action( 'friends_user_feed_activated', $new_feed );
+							}
 						} else {
 							$new_feed = $friend->save_feed( $feed['url'], $feed );
 						}


### PR DESCRIPTION
When you want to add someone using ActivityPub, we need to resolve it before trying to subscribe to it. Thus you can enter `@akirk@micro.blog` or `akirk@micro.blog` which are (resolved through [webfinger](https://webfinger.net/)) an alias for https://micro.blog/activitypub/akirk