### PR TITLE
Allow translator translation for the welcome box

### DIFF
--- a/templates/frontend/index.php
+++ b/templates/frontend/index.php
@@ -13,7 +13,7 @@ Friends\Friends::template_loader()->get_template_part(
 );
 
 ?>
-<section class="posts columns translator-exclude<?php echo 'collapsed' === $args['frontend_default_view'] ? ' all-collapsed' : ''; ?>">
+<section class="posts columns <?php echo 'collapsed' === $args['frontend_default_view'] ? ' all-collapsed' : ''; ?>">
 	<?php
 	if ( ! have_posts() ) {
 		?>

--- a/templates/frontend/parts/content.php
+++ b/templates/frontend/parts/content.php
@@ -8,7 +8,7 @@
 
 $template_loader = Friends\Friends::template_loader();
 ?>
-<article id="post-<?php the_ID(); ?>" <?php post_class( 'card column col-12' ); ?>>
+<article id="post-<?php the_ID(); ?>" <?php post_class( 'card column col-12 translator-exclude' ); ?>>
 	<?php
 	$template_loader->get_template_part( 'frontend/parts/header', get_post_format(), $args );
 	$template_loader->get_template_part( 'frontend/parts/title', get_post_format(), $args );

--- a/templates/frontend/parts/header.php
+++ b/templates/frontend/parts/header.php
@@ -29,7 +29,7 @@ $author_name = $args['friend_user']->display_name;
  */
 $override_author_name = apply_filters( 'friends_override_author_name', '', $author_name, get_the_id() );
 ?><header class="entry-header card-header columns">
-	<div class="avatar col-auto mr-2">
+	<div class="avatar col-auto mr-2 translator-exclude">
 		<?php if ( in_array( get_post_type(), apply_filters( 'friends_frontend_post_types', array() ), true ) ) : ?>
 			<a href="<?php echo esc_attr( $friend_user->get_local_friends_page_url() ); ?>" class="author-avatar">
 				<?php echo get_avatar( $args['friend_user']->user_login, 36 ); ?>
@@ -40,7 +40,7 @@ $override_author_name = apply_filters( 'friends_override_author_name', '', $auth
 			</a>
 		<?php endif; ?>
 	</div>
-	<div class="post-meta">
+	<div class="post-meta translator-exclude">
 		<div class="author">
 			<?php if ( in_array( get_post_type(), apply_filters( 'friends_frontend_post_types', array() ), true ) ) : ?>
 				<a href="<?php echo esc_attr( $friend_user->get_local_friends_page_url() ); ?>">


### PR DESCRIPTION
This is for [Local GlotPress](https://github.com/GlotPress/GlotPress/tree/local) that is used on https://translate.wordpress.org/projects/wp-plugins/friends/dev/de/default/playground/ which will soon follow blueprints and thus the user lands on the welcome page.