### PR TITLE
Remove dysfunct double setting from Edit User Page

### DIFF
--- a/feed-parsers/class-feed-parser-activitypub.php
+++ b/feed-parsers/class-feed-parser-activitypub.php
@@ -51,8 +51,8 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 		\add_action( 'friends_feed_parser_activitypub_unannounce', array( $this, 'activitypub_unannounce' ), 10, 2 );
 		\add_filter( 'friends_rewrite_incoming_url', array( $this, 'friends_webfinger_resolve' ), 10, 2 );
 
-		\add_filter( 'friends_edit_friend_table_end', array( $this, 'activitypub_settings' ), 10 );
-		\add_filter( 'friends_edit_friend_after_form_submit', array( $this, 'activitypub_save_settings' ), 10 );
+		\add_filter( 'friends_edit_feeds_table_end', array( $this, 'activitypub_settings' ), 10 );
+		\add_filter( 'friends_edit_feeds_after_form_submit', array( $this, 'activitypub_save_settings' ), 10 );
 		\add_filter( 'friends_modify_feed_item', array( $this, 'modify_incoming_item' ), 9, 3 );
 		\add_filter( 'friends_potential_avatars', array( $this, 'friends_potential_avatars' ), 10, 2 );
 		\add_filter( 'friends_suggest_user_login', array( $this, 'suggest_user_login' ), 10, 2 );

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -1159,6 +1159,8 @@ class Admin {
 			return;
 		}
 
+		do_action( 'friends_edit_friend_after_form_submit', $friend );
+
 		if ( isset( $_GET['_wp_http_referer'] ) ) {
 			wp_safe_redirect( add_query_arg( $arg, $arg_value, wp_get_referer() ) );
 		} else {
@@ -1498,9 +1500,8 @@ class Admin {
 					do_action( 'friends_user_feed_deactivated', $user_feed );
 					$user_feed->delete();
 				}
-
-				do_action( 'friends_edit_friend_after_form_submit', $friend );
 			}
+			do_action( 'friends_edit_feeds_after_form_submit', $friend );
 		} else {
 			return;
 		}

--- a/templates/admin/edit-feeds.php
+++ b/templates/admin/edit-feeds.php
@@ -302,9 +302,9 @@ $has_last_log = false;
 				</td>
 			</tr>
 			<?php endif; ?>
-			<?php do_action( 'friends_edit_friend_table_end', $args['friend'] ); ?>
+			<?php do_action( 'friends_edit_feeds_table_end', $args['friend'] ); ?>
 	</table>
-	<?php do_action( 'friends_edit_friend_after_form', $args['friend'] ); ?>
+	<?php do_action( 'friends_edit_feeds_after_form', $args['friend'] ); ?>
 	<p class="submit">
 		<input type="submit" id="submit" class="button button-primary" value="<?php /* phpcs:ignore WordPress.WP.I18n.MissingArgDomain */ esc_html_e( 'Save Changes' ); ?>">
 	</p>


### PR DESCRIPTION
Fixes #283. This setting appeared both on the Edit User and Edit Feeds page (if the user has an active ActivityPub feed), now it remains on the Edit Feeds page.

<img width="783" alt="Screenshot 2024-02-07 at 22 21 44" src="https://github.com/akirk/friends/assets/203408/e1ae897b-76c2-4039-80fc-83cb808324a7">
