### PR TITLE
Add Option to Disable Friendships

### DIFF
--- a/includes/class-access-control.php
+++ b/includes/class-access-control.php
@@ -103,6 +103,9 @@ class Access_Control {
 	 * @return     int|bool  The user id or false.
 	 */
 	public function verify_token( $token, $until, $auth ) {
+		if ( ! get_option( 'friends_enable_wp_friendships' ) ) {
+			return false;
+		}
 		$user_id = get_option( 'friends_in_token_' . $token );
 		if ( ! $user_id ) {
 			$me = User::get_user( User::get_user_login_for_url( $token ) );
@@ -136,6 +139,9 @@ class Access_Control {
 	 * Log in a friend via URL parameter
 	 */
 	public function remote_login() {
+		if ( ! get_option( 'friends_enable_wp_friendships' ) ) {
+			return false;
+		}
 		if ( ! isset( $_GET['friend_auth'] ) ) {
 			return;
 		}

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -126,7 +126,13 @@ class Admin {
 		add_submenu_page( 'friends', __( 'Add New Friend', 'friends' ), __( 'Add New Friend', 'friends' ), $required_role, 'add-friend', array( $this, 'render_admin_add_friend' ) );
 		// phpcs:ignore WordPress.WP.I18n.MissingArgDomain
 		add_submenu_page( 'friends', __( 'Settings' ), __( 'Settings' ), $required_role, 'friends-settings', array( $this, 'render_admin_settings' ) );
-		if ( isset( $_GET['page'] ) && in_array( $_GET['page'], apply_filters( 'friends_admin_settings_slugs', array( 'friends-settings', 'friends-notification-manager', 'friends-wp-friendships', 'friends-import-export' ) ) ) ) {
+		if (
+			isset( $_GET['page'] ) &&
+			in_array(
+				$_GET['page'],
+				apply_filters( 'friends_admin_settings_slugs', array( 'friends-settings', 'friends-notification-manager', 'friends-wp-friendships', 'friends-import-export' ) )
+			)
+		) {
 			add_submenu_page( 'friends', __( 'Notification Manager', 'friends' ), '- ' . __( 'Notification Manager', 'friends' ), $required_role, 'friends-notification-manager', array( $this, 'render_admin_notification_manager' ) );
 			add_submenu_page( 'friends', __( 'Friendships', 'friends' ), '- ' . __( 'Friendships', 'friends' ), $required_role, 'friends-wp-friendships', array( $this, 'render_admin_wp_friendship_settings' ) );
 			add_submenu_page( 'friends', __( 'Import/Export', 'friends' ), '- ' . __( 'Import/Export', 'friends' ), $required_role, 'friends-import-export', array( $this, 'render_admin_import_export' ) );

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -122,19 +122,22 @@ class Admin {
 		add_menu_page( 'friends', $menu_title, $required_role, 'friends', null, 'dashicons-groups', 3 );
 		// phpcs:ignore WordPress.WP.I18n.MissingArgDomain
 		add_submenu_page( 'friends', __( 'Home' ), __( 'Home' ), $required_role, 'friends', array( $this, 'render_admin_home' ) );
+		add_action( 'load-' . $page_type . '_page_friends-page', array( $this, 'redirect_to_friends_page' ) );
+		add_submenu_page( 'friends', __( 'Add New Friend', 'friends' ), __( 'Add New Friend', 'friends' ), $required_role, 'add-friend', array( $this, 'render_admin_add_friend' ) );
 		// phpcs:ignore WordPress.WP.I18n.MissingArgDomain
 		add_submenu_page( 'friends', __( 'Settings' ), __( 'Settings' ), $required_role, 'friends-settings', array( $this, 'render_admin_settings' ) );
-		add_action( 'load-' . $page_type . '_page_friends-page', array( $this, 'redirect_to_friends_page' ) );
-		add_submenu_page( 'friends', __( 'Notification Manager', 'friends' ), __( 'Notification Manager', 'friends' ), $required_role, 'friends-notification-manager', array( $this, 'render_admin_notification_manager' ) );
+		if ( isset( $_GET['page'] ) && in_array( $_GET['page'], apply_filters( 'friends_admin_settings_slugs', array( 'friends-settings', 'friends-notification-manager', 'friends-wp-friendships', 'friends-import-export' ) ) ) ) {
+			add_submenu_page( 'friends', __( 'Notification Manager', 'friends' ), '- ' . __( 'Notification Manager', 'friends' ), $required_role, 'friends-notification-manager', array( $this, 'render_admin_notification_manager' ) );
+			add_submenu_page( 'friends', __( 'Friendships', 'friends' ), '- ' . __( 'Friendships', 'friends' ), $required_role, 'friends-wp-friendships', array( $this, 'render_admin_wp_friendship_settings' ) );
+			add_submenu_page( 'friends', __( 'Import/Export', 'friends' ), '- ' . __( 'Import/Export', 'friends' ), $required_role, 'friends-import-export', array( $this, 'render_admin_import_export' ) );
+			do_action( 'friends_admin_menu_settings', $page_type );
+		}
 		add_action( 'load-' . $page_type . '_page_friends-notification-manager', array( $this, 'process_admin_notification_manager' ) );
+		add_action( 'load-' . $page_type . '_page_friends-import-export', array( $this, 'process_admin_import_export' ) );
+		add_action( 'load-' . $page_type . '_page_friends-settings', array( $this, 'process_admin_settings' ) );
 		if ( get_option( 'friends_enable_wp_friendships' ) ) {
-			add_submenu_page( 'friends', __( 'Friendships', 'friends' ), __( 'Friendships', 'friends' ), $required_role, 'friends-wp-friendships', array( $this, 'render_admin_wp_friendship_settings' ) );
 			add_action( 'load-' . $page_type . '_page_friends-wp-friendships', array( $this, 'process_admin_wp_friendship_settings' ) );
 		}
-		add_submenu_page( 'friends', __( 'Import/Export', 'friends' ), __( 'Import/Export', 'friends' ), $required_role, 'friends-import-export', array( $this, 'render_admin_import_export' ) );
-		add_action( 'load-' . $page_type . '_page_friends-import-export', array( $this, 'process_admin_import_export' ) );
-		add_submenu_page( 'friends', __( 'Add New Friend', 'friends' ), __( 'Add New Friend', 'friends' ), $required_role, 'add-friend', array( $this, 'render_admin_add_friend' ) );
-		add_action( 'load-' . $page_type . '_page_friends-settings', array( $this, 'process_admin_settings' ) );
 
 		add_submenu_page( 'friends', __( 'Friends &amp; Requests', 'friends' ), __( 'Friends &amp; Requests', 'friends' ), $required_role, 'friends-list', array( $this, 'render_friends_list' ) );
 

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -126,6 +126,10 @@ class Admin {
 		add_action( 'load-' . $page_type . '_page_friends-page', array( $this, 'redirect_to_friends_page' ) );
 		add_submenu_page( 'friends', __( 'Notification Manager', 'friends' ), __( 'Notification Manager', 'friends' ), $required_role, 'friends-notification-manager', array( $this, 'render_admin_notification_manager' ) );
 		add_action( 'load-' . $page_type . '_page_friends-notification-manager', array( $this, 'process_admin_notification_manager' ) );
+		add_submenu_page( 'friends', __( 'Friendships', 'friends' ), __( 'Friendships', 'friends' ), $required_role, 'friends-wp-friendships', array( $this, 'render_admin_wp_friendship_settings' ) );
+		add_action( 'load-' . $page_type . '_page_friends-wp-friendships', array( $this, 'process_admin_wp_friendship_settings' ) );
+		add_submenu_page( 'friends', __( 'Import/Export', 'friends' ), __( 'Import/Export', 'friends' ), $required_role, 'friends-import-export', array( $this, 'render_admin_import_export' ) );
+		add_action( 'load-' . $page_type . '_page_friends-import-export', array( $this, 'process_admin_import_export' ) );
 		add_submenu_page( 'friends', __( 'Add New Friend', 'friends' ), __( 'Add New Friend', 'friends' ), $required_role, 'add-friend', array( $this, 'render_admin_add_friend' ) );
 		add_action( 'load-' . $page_type . '_page_friends-settings', array( $this, 'process_admin_settings' ) );
 
@@ -528,61 +532,11 @@ class Admin {
 			} else {
 				delete_option( 'friends_limit_homepage_post_format' );
 			}
-
-			if ( isset( $_POST['main_user_id'] ) && is_numeric( $_POST['main_user_id'] ) ) {
-				update_option( 'friends_main_user_id', intval( $_POST['main_user_id'] ) );
-			} else {
-				$main_user_id = Friends::get_main_friend_user_id();
-				$main_user_id_exists = false;
-				$users = User_Query::all_admin_users();
-				foreach ( $users->get_results() as $user ) {
-					if ( $user->ID === $main_user_id ) {
-						$main_user_id_exists = true;
-						break;
-					}
-				}
-				if ( ! $main_user_id_exists ) {
-					// Reset the main user id.
-					delete_option( 'friends_main_user_id' );
-					Friends::get_main_friend_user_id();
-				}
-			}
-
-			if ( isset( $_POST['comment_registration'] ) && $_POST['comment_registration'] ) {
-				update_option( 'comment_registration', true );
-			} else {
-				delete_option( 'comment_registration' );
-			}
-
 			if ( isset( $_POST['blocks_everywhere'] ) && $_POST['blocks_everywhere'] ) {
 				update_user_option( get_current_user_id(), 'friends_blocks_everywhere', 1 );
 			} else {
 				delete_user_option( get_current_user_id(), 'friends_blocks_everywhere' );
 			}
-
-			if ( isset( $_POST['comment_registration_message'] ) && $_POST['comment_registration_message'] ) {
-				update_option( 'friends_comment_registration_message', $_POST['comment_registration_message'] );
-			} else {
-				delete_option( 'friends_comment_registration_message' );
-			}
-		}
-
-		if ( isset( $_POST['require_codeword'] ) && $_POST['require_codeword'] ) {
-			update_option( 'friends_require_codeword', true );
-		} else {
-			delete_option( 'friends_require_codeword' );
-		}
-
-		if ( isset( $_POST['codeword'] ) && $_POST['codeword'] ) {
-			update_option( 'friends_codeword', $_POST['codeword'] );
-		} else {
-			delete_option( 'friends_codeword' );
-		}
-
-		if ( isset( $_POST['wrong_codeword_message'] ) && $_POST['wrong_codeword_message'] ) {
-			update_option( 'friends_wrong_codeword_message', $_POST['wrong_codeword_message'] );
-		} else {
-			delete_option( 'friends_wrong_codeword_message' );
 		}
 
 		if ( isset( $_POST['available_emojis'] ) && $_POST['available_emojis'] ) {
@@ -596,29 +550,6 @@ class Admin {
 			update_option( 'friends_selected_emojis', $available_emojis );
 		} else {
 			delete_option( 'friends_selected_emojis' );
-		}
-
-		if ( isset( $_POST['notification_keywords'] ) && $_POST['notification_keywords'] ) {
-			$keywords = array();
-			foreach ( $_POST['notification_keywords'] as $i => $keyword ) {
-				if ( trim( $keyword ) ) {
-					$keywords[] = array(
-						'enabled' => isset( $_POST['notification_keywords_enabled'][ $i ] ) && $_POST['notification_keywords_enabled'][ $i ],
-						'keyword' => $keyword,
-					);
-				}
-			}
-			update_option( 'friends_notification_keywords', $keywords );
-		}
-
-		if ( isset( $_POST['default_role'] ) && in_array( $_POST['default_role'], array( 'friend', 'acquaintance' ), true ) ) {
-			update_option( 'friends_default_friend_role', $_POST['default_role'] );
-		}
-
-		if ( isset( $_POST['new_post_notification'] ) && $_POST['new_post_notification'] ) {
-			delete_user_option( get_current_user_id(), 'friends_no_new_post_notification' );
-		} else {
-			update_user_option( get_current_user_id(), 'friends_no_new_post_notification', 1 );
 		}
 
 		// Global retention.
@@ -710,24 +641,6 @@ class Admin {
 			<?php
 		}
 
-		// In order to switch to the frontend locale, we need to first pretend that nothing was loaded yet.
-		global $l10n;
-		$l10n = array();
-
-		switch_to_locale( $this->get_frontend_locale() );
-		// Now while loading the next translations we need to ensure that determine_locale() doesn't return the admin language but the frontend language.
-		add_filter( 'pre_determine_locale', array( $this, 'get_frontend_locale' ) );
-
-		$wrong_codeword_message = __( 'An invalid codeword was provided.', 'friends' );
-		$comment_registration_message = __( 'Only people in my network can comment.', 'friends' );
-		$my_network = __( 'my network', 'friends' );
-		$comment_registration_default = strip_tags(
-			/* translators: %s: Login URL. */
-			__( 'You must be <a href="%s">logged in</a> to post a comment.' ) // phpcs:ignore WordPress.WP.I18n.MissingArgDomain
-		);
-		// Now let's switch back to the admin language.
-		remove_filter( 'pre_determine_locale', array( $this, 'get_frontend_locale' ) );
-		restore_previous_locale();
 		$post_stats = Friends::get_post_stats();
 
 		Friends::template_loader()->get_template_part(
@@ -736,32 +649,17 @@ class Admin {
 			array_merge(
 				Friends::get_post_stats(),
 				array(
-					'potential_main_users'           => User_Query::all_admin_users(),
-					'main_user_id'                   => Friends::get_main_friend_user_id(),
-					'friend_roles'                   => $this->get_friend_roles(),
-					'default_role'                   => get_option( 'friends_default_friend_role', 'friend' ),
-					'force_enable_post_formats'      => get_option( 'friends_force_enable_post_formats' ),
-					'post_format_strings'            => get_post_format_strings(),
-					'limit_homepage_post_format'     => get_option( 'friends_limit_homepage_post_format', false ),
-					'expose_post_format_feeds'       => get_option( 'friends_expose_post_format_feeds' ),
-					'private_rss_key'                => get_option( 'friends_private_rss_key' ),
-					'comment_registration'           => get_option( 'comment_registration' ), // WordPress option.
-					'comment_registration_message'   => get_option( 'friends_comment_registration_message', $comment_registration_message ),
-					'comment_registration_default'   => $comment_registration_default,
-					'my_network'                     => $my_network,
-					'public_profile_link'            => home_url( '/friends/' ),
-					'codeword'                       => get_option( 'friends_codeword', 'friends' ),
-					'require_codeword'               => get_option( 'friends_require_codeword' ),
-					'wrong_codeword_message'         => get_option( 'friends_wrong_codeword_message', $wrong_codeword_message ),
-					'no_friend_request_notification' => get_user_option( 'friends_no_friend_request_notification' ),
-					'no_new_post_notification'       => get_user_option( 'friends_no_new_post_notification' ),
-					'notification_keywords'          => Feed::get_all_notification_keywords(),
-					'retention_days'                 => Friends::get_retention_days(),
-					'retention_number'               => Friends::get_retention_number(),
-					'retention_days_enabled'         => get_option( 'friends_enable_retention_days' ),
-					'retention_number_enabled'       => get_option( 'friends_enable_retention_number' ),
-					'frontend_default_view'          => get_option( 'friends_frontend_default_view', 'expanded' ),
-					'blocks_everywhere'              => get_user_option( 'friends_blocks_everywhere' ),
+					'force_enable_post_formats'  => get_option( 'friends_force_enable_post_formats' ),
+					'post_format_strings'        => get_post_format_strings(),
+					'limit_homepage_post_format' => get_option( 'friends_limit_homepage_post_format', false ),
+					'expose_post_format_feeds'   => get_option( 'friends_expose_post_format_feeds' ),
+					'enable_wp_friendships'      => get_option( 'friends_enable_wp_friendships' ),
+					'retention_days'             => Friends::get_retention_days(),
+					'retention_number'           => Friends::get_retention_number(),
+					'retention_days_enabled'     => get_option( 'friends_enable_retention_days' ),
+					'retention_number_enabled'   => get_option( 'friends_enable_retention_number' ),
+					'frontend_default_view'      => get_option( 'friends_frontend_default_view', 'expanded' ),
+					'blocks_everywhere'          => get_user_option( 'friends_blocks_everywhere' ),
 				)
 			)
 		);
@@ -2185,6 +2083,26 @@ class Admin {
 		}
 
 		$this->check_admin_settings();
+
+		if ( isset( $_POST['notification_keywords'] ) && $_POST['notification_keywords'] ) {
+			$keywords = array();
+			foreach ( $_POST['notification_keywords'] as $i => $keyword ) {
+				if ( trim( $keyword ) ) {
+					$keywords[] = array(
+						'enabled' => isset( $_POST['notification_keywords_enabled'][ $i ] ) && $_POST['notification_keywords_enabled'][ $i ],
+						'keyword' => $keyword,
+					);
+				}
+			}
+			update_option( 'friends_notification_keywords', $keywords );
+		}
+
+		if ( isset( $_POST['new_post_notification'] ) && $_POST['new_post_notification'] ) {
+			delete_user_option( get_current_user_id(), 'friends_no_new_post_notification' );
+		} else {
+			update_user_option( get_current_user_id(), 'friends_no_new_post_notification', 1 );
+		}
+
 		$friend_ids = $_POST['friend_listed'];
 		$current_user_id = get_current_user_id();
 		$hide_from_friends_page = array();
@@ -2194,7 +2112,7 @@ class Admin {
 				$hide_from_friends_page[] = $friend_id;
 			}
 
-			$no_new_post_notification = ! isset( $_POST['new_post_notification'][ $friend_id ] );
+			$no_new_post_notification = ! isset( $_POST['new_friend_post_notification'][ $friend_id ] ) || '0' === $_POST['new_friend_post_notification'][ $friend_id ];
 			if ( get_user_option( 'friends_no_new_post_notification_' . $friend_id ) !== $no_new_post_notification ) {
 				update_user_option( $current_user_id, 'friends_no_new_post_notification_' . $friend_id, $no_new_post_notification );
 			}
@@ -2252,16 +2170,159 @@ class Admin {
 			'admin/notification-manager',
 			null,
 			array(
-				'friend_users'             => $friend_users->get_results(),
-				'friends_settings_url'     => add_query_arg( '_wp_http_referer', urlencode( wp_unslash( $_SERVER['REQUEST_URI'] ) ), self_admin_url( 'admin.php?page=friends-settings' ) ),
-				'hide_from_friends_page'   => $hide_from_friends_page,
-				'no_new_post_notification' => get_user_option( 'friends_no_new_post_notification' ),
-				'no_keyword_notification'  => get_user_option( 'friends_no_keyword_notification' ),
-				'active_keywords'          => Feed::get_active_notification_keywords(),
+				'friend_users'                   => $friend_users->get_results(),
+				'friends_settings_url'           => add_query_arg( '_wp_http_referer', urlencode( wp_unslash( $_SERVER['REQUEST_URI'] ) ), self_admin_url( 'admin.php?page=friends-settings' ) ),
+				'hide_from_friends_page'         => $hide_from_friends_page,
+				'no_friend_request_notification' => get_user_option( 'friends_no_friend_request_notification' ),
+				'no_new_post_notification'       => get_user_option( 'friends_no_new_post_notification' ),
+				'no_keyword_notification'        => get_user_option( 'friends_no_keyword_notification' ),
+				'notification_keywords'          => Feed::get_all_notification_keywords(),
+				'active_keywords'                => Feed::get_active_notification_keywords(),
 			)
 		);
 
 		Friends::template_loader()->get_template_part( 'admin/settings-footer' );
+	}
+
+	public function render_admin_wp_friendship_settings() {
+		Friends::template_loader()->get_template_part(
+			'admin/settings-header',
+			null,
+			array(
+				'active' => 'friends-wp-friendships',
+				'title'  => __( 'Friends', 'friends' ),
+			)
+		);
+		$this->check_admin_settings();
+
+		// In order to switch to the frontend locale, we need to first pretend that nothing was loaded yet.
+		global $l10n;
+		$l10n = array();
+
+		switch_to_locale( $this->get_frontend_locale() );
+		// Now while loading the next translations we need to ensure that determine_locale() doesn't return the admin language but the frontend language.
+		add_filter( 'pre_determine_locale', array( $this, 'get_frontend_locale' ) );
+
+		$wrong_codeword_message = __( 'An invalid codeword was provided.', 'friends' );
+		$comment_registration_message = __( 'Only people in my network can comment.', 'friends' );
+		$my_network = __( 'my network', 'friends' );
+		$comment_registration_default = strip_tags(
+			/* translators: %s: Login URL. */
+			__( 'You must be <a href="%s">logged in</a> to post a comment.' ) // phpcs:ignore WordPress.WP.I18n.MissingArgDomain
+		);
+		// Now let's switch back to the admin language.
+		remove_filter( 'pre_determine_locale', array( $this, 'get_frontend_locale' ) );
+		restore_previous_locale();
+
+		?>
+		<h1><?php esc_html_e( 'Friendships', 'friends' ); ?></h1>
+		<?php
+
+		Friends::template_loader()->get_template_part(
+			'admin/settings-wp-friendships',
+			null,
+			array(
+				'potential_main_users'         => User_Query::all_admin_users(),
+				'main_user_id'                 => Friends::get_main_friend_user_id(),
+				'friend_roles'                 => $this->get_friend_roles(),
+				'default_role'                 => get_option( 'friends_default_friend_role', 'friend' ),
+				'comment_registration'         => get_option( 'comment_registration' ), // WordPress option.
+				'comment_registration_message' => get_option( 'friends_comment_registration_message', $comment_registration_message ),
+				'comment_registration_default' => $comment_registration_default,
+				'my_network'                   => $my_network,
+				'public_profile_link'          => home_url( '/friends/' ),
+				'codeword'                     => get_option( 'friends_codeword', 'friends' ),
+				'require_codeword'             => get_option( 'friends_require_codeword' ),
+				'wrong_codeword_message'       => get_option( 'friends_wrong_codeword_message', $wrong_codeword_message ),
+			)
+		);
+
+		Friends::template_loader()->get_template_part( 'admin/settings-footer' );
+	}
+	public function process_admin_wp_friendship_settings() {
+		if ( current_user_can( 'manage_options' ) ) {
+
+			if ( isset( $_POST['main_user_id'] ) && is_numeric( $_POST['main_user_id'] ) ) {
+				update_option( 'friends_main_user_id', intval( $_POST['main_user_id'] ) );
+			} else {
+				$main_user_id = Friends::get_main_friend_user_id();
+				$main_user_id_exists = false;
+				$users = User_Query::all_admin_users();
+				foreach ( $users->get_results() as $user ) {
+					if ( $user->ID === $main_user_id ) {
+						$main_user_id_exists = true;
+						break;
+					}
+				}
+				if ( ! $main_user_id_exists ) {
+					// Reset the main user id.
+					delete_option( 'friends_main_user_id' );
+					Friends::get_main_friend_user_id();
+				}
+			}
+
+			if ( isset( $_POST['require_codeword'] ) && $_POST['require_codeword'] ) {
+				update_option( 'friends_require_codeword', true );
+			} else {
+				delete_option( 'friends_require_codeword' );
+			}
+
+			if ( isset( $_POST['codeword'] ) && $_POST['codeword'] ) {
+				update_option( 'friends_codeword', $_POST['codeword'] );
+			} else {
+				delete_option( 'friends_codeword' );
+			}
+
+			if ( isset( $_POST['wrong_codeword_message'] ) && $_POST['wrong_codeword_message'] ) {
+				update_option( 'friends_wrong_codeword_message', $_POST['wrong_codeword_message'] );
+			} else {
+				delete_option( 'friends_wrong_codeword_message' );
+			}
+
+			if ( isset( $_POST['default_role'] ) && in_array( $_POST['default_role'], array( 'friend', 'acquaintance' ), true ) ) {
+				update_option( 'friends_default_friend_role', $_POST['default_role'] );
+			}
+
+			if ( isset( $_POST['comment_registration'] ) && $_POST['comment_registration'] ) {
+				update_option( 'comment_registration', true );
+			} else {
+				delete_option( 'comment_registration' );
+			}
+
+			if ( isset( $_POST['comment_registration_message'] ) && $_POST['comment_registration_message'] ) {
+				update_option( 'friends_comment_registration_message', $_POST['comment_registration_message'] );
+			} else {
+				delete_option( 'friends_comment_registration_message' );
+			}
+		}
+	}
+	public function render_admin_import_export() {
+		Friends::template_loader()->get_template_part(
+			'admin/settings-header',
+			null,
+			array(
+				'active' => 'friends-import-export',
+				'title'  => __( 'Friends', 'friends' ),
+			)
+		);
+		$this->check_admin_settings();
+
+		?>
+		<h1><?php esc_html_e( 'Import/Export', 'friends' ); ?></h1>
+		<?php
+
+		Friends::template_loader()->get_template_part(
+			'admin/import-export',
+			null,
+			array(
+				'private_rss_key' => get_option( 'friends_private_rss_key' ),
+			)
+		);
+
+		Friends::template_loader()->get_template_part( 'admin/settings-footer' );
+	}
+
+	public function process_admin_import_export() {
 	}
 
 	/**

--- a/includes/class-automatic-status.php
+++ b/includes/class-automatic-status.php
@@ -39,7 +39,7 @@ class Automatic_Status {
 	 * Register the WordPress hooks
 	 */
 	private function register_hooks() {
-		add_action( 'admin_menu', array( $this, 'admin_menu' ), 20 );
+		add_action( 'friends_admin_menu_settings', array( $this, 'friends_admin_menu_settings' ), 20 );
 		add_action( 'friends_admin_tabs', array( $this, 'admin_tabs' ), 20 );
 		add_filter( 'handle_bulk_actions-edit-post', array( $this, 'bulk_publish' ), 10, 3 );
 
@@ -53,17 +53,14 @@ class Automatic_Status {
 
 	/**
 	 * Add the admin menu to the sidebar.
+	 *
+	 * @param      string $page_type  The page type.
 	 */
-	public function admin_menu() {
-		$unread_badge = $this->friends->admin->get_unread_badge();
-
-		$menu_title = __( 'Friends', 'friends' ) . $unread_badge;
-		$page_type = sanitize_title( $menu_title );
-
+	public function friends_admin_menu_settings( $page_type ) {
 		add_submenu_page(
 			'friends',
 			__( 'Automatic Status', 'friends' ),
-			__( 'Automatic Status', 'friends' ),
+			'- ' . __( 'Automatic Status', 'friends' ),
 			Friends::required_menu_role(),
 			'friends-auto-status',
 			array( $this, 'validate_drafts' )

--- a/includes/class-friends.php
+++ b/includes/class-friends.php
@@ -444,6 +444,16 @@ class Friends {
 		}
 		$previous_version = get_option( 'friends_plugin_version' );
 
+		if ( version_compare( $previous_version, '2.9.0', '<' ) ) {
+			$users = User_Query::all_associated_users();
+			foreach ( $users->get_results() as $user ) {
+				if ( ! ( $user instanceof Subscription ) ) {
+					// We have a user that is not a virtual user, so the friendship functionality had been used.
+					update_option( 'friends_enable_wp_friendships', 1 );
+					break;
+				}
+			}
+		}
 		if ( version_compare( $previous_version, '0.20.1', '<' ) ) {
 			$users = User_Query::all_associated_users();
 			foreach ( $users->get_results() as $user ) {

--- a/templates/admin/import-export.php
+++ b/templates/admin/import-export.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * This template contains the Friends Settings.
+ *
+ * @package Friends
+ */
+
+do_action( 'friends_settings_before_form' );
+
+?>
+<form method="post">
+	<?php wp_nonce_field( 'friends-settings' ); ?>
+	<table class="form-table">
+		<tbody>
+			<tr>
+				<th scope="row" rowspan="2"><?php esc_html_e( 'Feed Reader', 'friends' ); ?></th>
+				<td>
+					<span>
+					<?php
+					// translators: %s is a URL.
+					echo wp_kses( sprintf( __( 'Download the <a href=%s>Private OPML file (contains private urls!)</a> and import it to your feed reader.', 'friends' ), esc_url( home_url( '/friends/opml/?auth=' . $args['private_rss_key'] ) ) ), array( 'a' => array( 'href' => array() ) ) );
+					?>
+					</span>
+					<span>
+					<?php
+					// translators: %s is a URL.
+					echo wp_kses( sprintf( __( 'Alternative: <a href=%s>Public OPML file (only public urls)</a>.', 'friends' ), esc_url( home_url( '/friends/opml/?public' ) ) ), array( 'a' => array( 'href' => array() ) ) );
+					?>
+					</span>
+					<p class="description">
+					<?php
+					echo __( 'If your feed reader supports it, you can also subscribe to this URL as the OPML file gets updated as you add or remove friends.', 'friends' );
+					?>
+					</p>
+				</td>
+			</tr>
+			<tr>
+				<td>
+					<span>
+					<?php
+					// translators: %s is a URL.
+					echo wp_kses( sprintf( __( 'You can also subscribe to a <a href=%s>compiled RSS feed of friend posts</a>.', 'friends' ), esc_url( home_url( '/friends/feed/?auth=' . $args['private_rss_key'] ) ) ), array( 'a' => array( 'href' => array() ) ) );
+					?>
+					</span>
+					<p class="description">
+					<?php
+					echo __( 'Please be careful what you do with these feeds as they might contain private posts of your friends.', 'friends' );
+					?>
+					</p>
+
+				</td>
+			</tr>
+		</tbody>
+	</table>
+	<?php do_action( 'friends_settings_form_bottom' ); ?>
+	<p class="submit">
+		<input type="submit" id="submit" class="button button-primary" value="<?php /* phpcs:ignore WordPress.WP.I18n.MissingArgDomain */ esc_html_e( 'Save Changes' ); ?>">
+	</p>
+</form>
+<?php
+do_action( 'friends_settings_after_form' );

--- a/templates/admin/notification-manager.php
+++ b/templates/admin/notification-manager.php
@@ -6,32 +6,59 @@
  * @package Friends
  */
 
-if ( $args['no_new_post_notification'] ) : ?>
-	<p class="description"><?php esc_html_e( 'You have generally disabled new post notifications for yourself.', 'friends' ); ?> <a href="<?php echo esc_url( $args['friends_settings_url'] ); ?>"><?php /* phpcs:ignore WordPress.WP.I18n.MissingArgDomain */ esc_html_e( '(Edit)' ); ?></a></p>
-<?php endif; ?>
-
-<p class="description">
-	<span>
-	<?php
-	if ( $args['active_keywords'] ) {
-		echo esc_html(
-			sprintf(
-				// translators: %1$s is the number of active keywords, %2$s is the list of those keywords.
-				_n( 'There is %1$s active keyword: %2$s', 'There are %1$s active keywords: %2$s', count( $args['active_keywords'] ), 'friends' ),
-				count( $args['active_keywords'] ),
-				esc_html( implode( ', ', $args['active_keywords'] ) )
-			)
-		);
-	} else {
-		esc_html_e( 'No notification keywords have been specified.', 'friends' );
-	}
-	?>
-	</span>
-	<a href="<?php echo esc_url( $args['friends_settings_url'] ); ?>"><?php /* phpcs:ignore WordPress.WP.I18n.MissingArgDomain */ esc_html_e( '(Edit)' ); ?></a>
-</p>
-
-<form method="post">
+?><form method="post">
 	<?php wp_nonce_field( 'notification-manager' ); ?>
+	<table class="form-table">
+		<tbody>
+			<tr>
+				<th scope="row">
+				<?php
+				esc_html_e( 'E-Mail Notifications', 'friends' );
+				?>
+				</th>
+				<td>
+					<fieldset>
+						<label for="friend_request_notification">
+							<input name="friend_request_notification" type="checkbox" id="friend_request_notification" value="1" <?php checked( '1', ! $args['no_friend_request_notification'] ); ?>>
+							<span><?php esc_html_e( 'Friend Requests', 'friends' ); ?></span>
+						</label>
+						<br />
+						<label for="new_post_notification">
+							<input name="new_post_notification" type="checkbox" id="new_post_notification" value="1" <?php checked( '1', ! $args['no_new_post_notification'] ); ?>>
+							<span><?php esc_html_e( 'New Posts', 'friends' ); ?></span>
+						</label>
+					</fieldset>
+					<p class="description"><?php esc_html_e( 'When you disable post notifications, their individual configuration is disabled also.', 'friends' ); ?></p>
+				</td>
+			</tr>
+			<tr>
+				<th scope="row">
+				<?php
+				esc_html_e( 'Keyword Notifications', 'friends' );
+				?>
+				</th>
+				<td>
+					<fieldset>
+
+						<ol id="keyword-notifications">
+							<li id="keyword-template" style="display: none">
+								<input type="checkbox" name="notification_keywords_enabled[0]" value="1" checked />
+								<input type="text" name="notification_keywords[0]" value="" placeholder="<?php esc_html_e( 'Keyword (regex allowed)', 'friends' ); ?>">
+							</li>
+						<?php foreach ( $args['notification_keywords'] as $i => $entry ) : ?>
+							<li>
+								<input type="checkbox" name="notification_keywords_enabled[<?php echo esc_attr( $i + 1 ); ?>]" value="1" <?php checked( $entry['enabled'] ); ?> />
+								<input type="text" name="notification_keywords[<?php echo esc_attr( $i + 1 ); ?>]" value="<?php echo esc_attr( $entry['keyword'] ); ?>" placeholder="<?php esc_html_e( 'Keyword (regex allowed)', 'friends' ); ?>">
+							</li>
+						<?php endforeach; ?>
+						</ol>
+						<a href="" id="admin-add-keyword"><?php esc_html_e( 'Add a notification keyword', 'friends' ); ?></a>
+					</fieldset>
+					<p class="description"><?php esc_html_e( 'Empty keywords will be deleted after saving. You can temporarily disable them with the checkbox.', 'friends' ); ?></p>
+				</td>
+			</tr>
+		</tbody>
+	</table>
 	<table class="wp-list-table widefat fixed striped" style="margin-top: 2em; margin-bottom: 2em; margin-right: 1em">
 		<thead>
 			<tr>
@@ -53,8 +80,13 @@ if ( $args['no_new_post_notification'] ) : ?>
 						<input name="show_on_friends_page[<?php echo esc_attr( $friend_user->user_login ); ?>]" type="checkbox" id="show_on_friends_page" value="1" <?php checked( '1', ! in_array( $friend_user->user_login, $args['hide_from_friends_page'] ) ); ?> />
 					</td>
 					<td class="column-email-notification">
-						<input name="new_post_notification[<?php echo esc_attr( $friend_user->user_login ); ?>]" type="checkbox" id="friends_new_post_notification" value="1" <?php checked( '1', ! get_user_option( 'friends_no_new_post_notification_' . $friend_user->user_login ) ); ?> <?php echo $args['no_new_post_notification'] ? 'disabled="disabled"' : ''; ?>
+						<?php if ( $args['no_new_post_notification'] ) : ?>
+							<input disabled="disabled" type="checkbox" <?php checked( '1', ! get_user_option( 'friends_no_new_post_notification_' . $friend_user->user_login ) ); ?> />
+							<input name="new_friend_post_notification[<?php echo esc_attr( $friend_user->user_login ); ?>]" type="hidden" value="<?php echo get_user_option( 'friends_no_new_post_notification_' . $friend_user->user_login ) ? '0' : '1'; ?>" />
+						<?php else : ?>
+						<input name="new_friend_post_notification[<?php echo esc_attr( $friend_user->user_login ); ?>]" type="checkbox" id="friends_new_friend_post_notification" value="1" <?php checked( '1', ! get_user_option( 'friends_no_new_post_notification_' . $friend_user->user_login ) ); ?> <?php echo $args['no_new_post_notification'] ? 'disabled="disabled"' : ''; ?>
 						/>
+						<?php endif; ?>
 					</td>
 					<td class="column-keyword-notification">
 						<input name="keyword_notification[<?php echo esc_attr( $friend_user->user_login ); ?>]" type="checkbox" id="friends_keyword_notification" value="1" <?php checked( '1', ! get_user_option( 'friends_no_keyword_notification_' . $friend_user->user_login ) ); ?> <?php echo $args['no_keyword_notification'] ? 'disabled="disabled"' : ''; ?>

--- a/templates/admin/notification-manager.php
+++ b/templates/admin/notification-manager.php
@@ -59,6 +59,11 @@
 			</tr>
 		</tbody>
 	</table>
+	<p class="submit">
+		<input type="submit" id="submit" class="button button-primary" value="<?php /* phpcs:ignore WordPress.WP.I18n.MissingArgDomain */ esc_html_e( 'Save Changes' ); ?>">
+	</p>
+
+	<h2><?php esc_html_e( 'Individual Friend Settings', 'friends' ); ?></h2>
 	<table class="wp-list-table widefat fixed striped" style="margin-top: 2em; margin-bottom: 2em; margin-right: 1em">
 		<thead>
 			<tr>

--- a/templates/admin/select-feeds.php
+++ b/templates/admin/select-feeds.php
@@ -111,7 +111,7 @@ foreach ( $args['feeds'] as $feed_url => $details ) {
 					</p>
 				</td>
 			</tr>
-			<?php else : ?>
+			<?php elseif ( get_option( 'friends_enable_wp_friendships' ) ) : ?>
 			<tr>
 				<th scope="row"><label for="friendship"><?php esc_html_e( 'Friendship', 'friends' ); ?></label></th>
 				<td>

--- a/templates/admin/settings-header.php
+++ b/templates/admin/settings-header.php
@@ -9,9 +9,11 @@ if ( empty( $args['menu'] ) ) {
 	$args['menu'] = apply_filters(
 		'friends_admin_tabs',
 		array(
-			__( 'Welcome', 'friends' )              => 'friends',
-			__( 'Settings' )                        => 'friends-settings',  // phpcs:ignore WordPress.WP.I18n.MissingArgDomain
-			__( 'Notification Manager', 'friends' ) => 'friends-notification-manager',
+			__( 'Welcome', 'friends' )       => 'friends',
+			__( 'Settings' )                 => 'friends-settings', // phpcs:ignore WordPress.WP.I18n.MissingArgDomain
+			__( 'Friendships', 'friends' )   => 'friends-wp-friendships',
+			__( 'Notifications', 'friends' ) => 'friends-notification-manager',
+			__( 'Import/Export', 'friends' ) => 'friends-import-export',
 		)
 	);
 }

--- a/templates/admin/settings-wp-friendships.php
+++ b/templates/admin/settings-wp-friendships.php
@@ -1,0 +1,181 @@
+<?php
+/**
+ * This template contains the Friends Settings.
+ *
+ * @package Friends
+ */
+
+$comment_registration_class = '';
+if ( ! $args['comment_registration'] ) {
+	$comment_registration_class = 'hidden';
+}
+
+$codeword_class = '';
+if ( 'friends' === $args['codeword'] || ! $args['require_codeword'] ) {
+	$codeword_class = 'hidden';
+}
+
+do_action( 'friends_settings_before_form' );
+
+?>
+<form method="post">
+	<?php wp_nonce_field( 'friends-settings' ); ?>
+	<table class="form-table">
+		<tbody>
+			<?php if ( current_user_can( 'manage_options' ) ) : ?>
+			<tr>
+				<th scope="row"><?php /* phpcs:ignore WordPress.WP.I18n.MissingArgDomain */ esc_html_e( 'Comments' ); ?></th>
+				<td>
+					<fieldset>
+						<label for="comment_registration">
+							<input name="comment_registration" type="checkbox" id="comment_registration" value="1" <?php checked( '1', $args['comment_registration'] ); ?> />
+							<span><?php esc_html_e( 'Only people in your network can comment.', 'friends' ); ?></span>
+						</label>
+					</fieldset>
+					<div id="comment_registration_options" class="<?php echo esc_attr( $comment_registration_class ); ?>">
+						<fieldset>
+							<label for="comment_registration_message">
+								<p><?php esc_html_e( 'Display this message for logged-out users:', 'friends' ); ?></p>
+							</label>
+							<p>
+								<textarea name="comment_registration_message" id="comment_registration_message" class="regular-text" rows="3" cols="80" placeholder="<?php echo esc_attr( $args['comment_registration_default'] ); ?>"><?php echo esc_html( $args['comment_registration_message'] ); ?></textarea>
+							</p>
+							<p class="description">
+								<?php
+								echo wp_kses(
+									sprintf(
+										// translators: %1$s is the translation for "my network", %2$s is the URL for your public profile page.
+										__( 'We\'ll link "%1$s" to <a href=%2$s>your public profile page</a>.', 'friends' ),
+										$args['my_network'],
+										$args['public_profile_link']
+									),
+									array(
+										'a' => array(
+											'href' => array(),
+										),
+									)
+								);
+								?>
+							</p>
+						</fieldset>
+					</div>
+				</td>
+			</tr>
+					<?php
+			endif;
+			if ( $args['potential_main_users']->get_total() > 1 ) :
+				?>
+				<tr>
+					<th scope="row"><?php esc_html_e( 'Main Friend User', 'friends' ); ?></th>
+					<td>
+					<?php if ( current_user_can( 'manage_options' ) ) { ?>
+						<select name="main_user_id">
+							<?php foreach ( $args['potential_main_users']->get_results() as $potential_main_user ) : ?>
+								<option value="<?php echo esc_attr( $potential_main_user->ID ); ?>" <?php selected( $args['main_user_id'], $potential_main_user->ID ); ?>><?php echo esc_html( $potential_main_user->display_name ); ?></option>
+
+							<?php endforeach; ?>
+						</select>
+						<p class="description"><span><?php esc_html_e( 'Since there are multiple users on this site, we need to know which one should be considered the main one.', 'friends' ); ?></span> <span><?php esc_html_e( 'They can edit friends-related settings.', 'friends' ); ?></span> <span><?php esc_html_e( 'Whenever a friends-related action needs to be associated with a user, this one will be chosen.', 'friends' ); ?></span></p>
+							<?php
+					} else {
+						$c = 0;
+						foreach ( $args['potential_main_users']->get_results() as $potential_main_user ) {
+							$c += 1;
+							if ( $potential_main_user->ID === $args['main_user_id'] ) {
+								?>
+									<span id="main_user_id"><?php echo esc_html( $potential_main_user->display_name ); ?></span>
+									<?php
+							}
+						}
+						?>
+							<span> (
+						<?php
+						echo esc_html(
+							sprintf(
+							// translators: %s is a number of users.
+								_n( '%s potential user', '%s potential users', $c, 'friends' ),
+								$c
+							)
+						);
+						?>
+							) </span>
+							<p class="description"><?php esc_html_e( 'An administrator can change this.', 'friends' ); ?></p>
+							<?php
+					}
+					?>
+					</td>
+				</tr>
+					<?php
+			endif;
+			?>
+			<tr>
+				<th scope="row"><?php esc_html_e( 'Friend Requests', 'friends' ); ?></th>
+				<td>
+					<fieldset>
+						<label for="require_codeword">
+							<input name="require_codeword" type="checkbox" id="require_codeword" value="1" <?php checked( '', $codeword_class ); ?>>
+							<span><?php esc_html_e( 'Require a code word to send you friend request', 'friends' ); ?></span>
+						</label>
+					</fieldset>
+					<div id="codeword_options" class="<?php echo esc_attr( $codeword_class ); ?>">
+						<fieldset>
+							<label for="codeword">
+								<span><?php esc_html_e( 'This code word must be provided to send you a friend request:', 'friends' ); ?></span>
+								<input name="codeword" type="text" id="codeword" placeholder="friends" value="<?php echo esc_attr( $args['codeword'] ); ?>" />
+							</label>
+							<p class="description">
+								<?php esc_html_e( "You'll need to communicate the code word to potential friends through another medium.", 'friends' ); ?>
+							</p>
+						</fieldset>
+						<fieldset>
+							<label for="wrong_codeword_message">
+								<p><?php esc_html_e( 'Error message for a wrong code word:', 'friends' ); ?></p>
+							</label>
+							<p>
+								<textarea name="wrong_codeword_message" id="wrong_codeword_message" class="regular-text" rows="3" cols="80" placeholder="<?php echo esc_attr( __( 'Return this message to the friend requestor if a wrong code word was provided.', 'friends' ) ); ?>"><?php echo esc_html( $args['wrong_codeword_message'] ); ?></textarea>
+							</p>
+						</fieldset>
+					</div>
+				</td>
+			</tr>
+			<tr>
+				<th scope="row"><?php esc_html_e( 'Roles', 'friends' ); ?></th>
+				<td>
+					<select name="default_role">
+						<?php
+						foreach ( $args['friend_roles'] as $role => $title ) :
+							?>
+							<option value="<?php echo esc_attr( $role ); ?>" <?php selected( $args['default_role'], $role ); ?>><?php echo esc_html( $title ); ?></option>
+
+						<?php endforeach; ?>
+					</select>
+					<p class="description">
+						<span><?php esc_html_e( 'When accepting a friend request, first assign this role.', 'friends' ); ?></span>
+						<span><?php esc_html_e( 'An Acquaintance has friend status but cannot read private posts.', 'friends' ); ?></span>
+					</p>
+				</td>
+			</tr>
+		</tbody>
+	</table>
+	<?php do_action( 'friends_settings_form_bottom' ); ?>
+	<p class="submit">
+		<input type="submit" id="submit" class="button button-primary" value="<?php /* phpcs:ignore WordPress.WP.I18n.MissingArgDomain */ esc_html_e( 'Save Changes' ); ?>">
+	</p>
+	<?php if ( ! current_user_can( 'manage_options' ) ) : ?>
+		<p class="description">
+			<?php esc_html_e( 'Administrators have access to these additional settings:', 'friends' ); ?>
+			<ul class="ul-disc">
+				<?php
+				foreach ( array(
+					__( 'Comments' ), // phpcs:ignore WordPress.WP.I18n.MissingArgDomain
+					__( 'Post Formats', 'friends' ),
+				) as $setting ) :
+					?>
+					<li><?php echo esc_html( $setting ); ?></li>
+				<?php endforeach; ?>
+			</ul>
+		</p>
+	<?php endif; ?>
+</form>
+<?php
+do_action( 'friends_settings_after_form' );

--- a/templates/admin/settings.php
+++ b/templates/admin/settings.php
@@ -5,16 +5,6 @@
  * @package Friends
  */
 
-$comment_registration_class = '';
-if ( ! $args['comment_registration'] ) {
-	$comment_registration_class = 'hidden';
-}
-
-$codeword_class = '';
-if ( 'friends' === $args['codeword'] || ! $args['require_codeword'] ) {
-	$codeword_class = 'hidden';
-}
-
 do_action( 'friends_settings_before_form' );
 
 ?>
@@ -24,184 +14,19 @@ do_action( 'friends_settings_before_form' );
 		<tbody>
 			<?php if ( current_user_can( 'manage_options' ) ) : ?>
 			<tr>
-				<th scope="row"><?php /* phpcs:ignore WordPress.WP.I18n.MissingArgDomain */ esc_html_e( 'Comments' ); ?></th>
+				<th scope="row"><?php /* phpcs:ignore WordPress.WP.I18n.MissingArgDomain */ esc_html_e( 'Friendships' ); ?></th>
 				<td>
 					<fieldset>
-						<label for="comment_registration">
-							<input name="comment_registration" type="checkbox" id="comment_registration" value="1" <?php checked( '1', $args['comment_registration'] ); ?> />
-							<span><?php esc_html_e( 'Only people in your network can comment.', 'friends' ); ?></span>
+						<label for="enable_wp_friendships">
+							<input name="enable_wp_friendships" type="checkbox" id="enable_wp_friendships" value="1" <?php checked( '1', $args['enable_wp_friendships'] ); ?> />
+							<span><?php esc_html_e( 'Enable friendships between WordPresses.', 'friends' ); ?></span>
 						</label>
 					</fieldset>
-					<div id="comment_registration_options" class="<?php echo esc_attr( $comment_registration_class ); ?>">
-						<fieldset>
-							<label for="comment_registration_message">
-								<p><?php esc_html_e( 'Display this message for logged-out users:', 'friends' ); ?></p>
-							</label>
-							<p>
-								<textarea name="comment_registration_message" id="comment_registration_message" class="regular-text" rows="3" cols="80" placeholder="<?php echo esc_attr( $args['comment_registration_default'] ); ?>"><?php echo esc_html( $args['comment_registration_message'] ); ?></textarea>
-							</p>
-							<p class="description">
-								<?php
-								echo wp_kses(
-									sprintf(
-										// translators: %1$s is the translation for "my network", %2$s is the URL for your public profile page.
-										__( 'We\'ll link "%1$s" to <a href=%2$s>your public profile page</a>.', 'friends' ),
-										$args['my_network'],
-										$args['public_profile_link']
-									),
-									array(
-										'a' => array(
-											'href' => array(),
-										),
-									)
-								);
-								?>
-							</p>
-						</fieldset>
-					</div>
 				</td>
 			</tr>
-					<?php
-			endif;
-			if ( $args['potential_main_users']->get_total() > 1 ) :
-				?>
-				<tr>
-					<th scope="row"><?php esc_html_e( 'Main Friend User', 'friends' ); ?></th>
-					<td>
-					<?php if ( current_user_can( 'manage_options' ) ) { ?>
-						<select name="main_user_id">
-							<?php foreach ( $args['potential_main_users']->get_results() as $potential_main_user ) : ?>
-								<option value="<?php echo esc_attr( $potential_main_user->ID ); ?>" <?php selected( $args['main_user_id'], $potential_main_user->ID ); ?>><?php echo esc_html( $potential_main_user->display_name ); ?></option>
-
-							<?php endforeach; ?>
-						</select>
-						<p class="description"><span><?php esc_html_e( 'Since there are multiple users on this site, we need to know which one should be considered the main one.', 'friends' ); ?></span> <span><?php esc_html_e( 'They can edit friends-related settings.', 'friends' ); ?></span> <span><?php esc_html_e( 'Whenever a friends-related action needs to be associated with a user, this one will be chosen.', 'friends' ); ?></span></p>
-							<?php
-					} else {
-						$c = 0;
-						foreach ( $args['potential_main_users']->get_results() as $potential_main_user ) {
-							$c += 1;
-							if ( $potential_main_user->ID === $args['main_user_id'] ) {
-								?>
-									<span id="main_user_id"><?php echo esc_html( $potential_main_user->display_name ); ?></span>
-									<?php
-							}
-						}
-						?>
-							<span> (
-						<?php
-						echo esc_html(
-							sprintf(
-							// translators: %s is a number of users.
-								_n( '%s potential user', '%s potential users', $c, 'friends' ),
-								$c
-							)
-						);
-						?>
-							) </span>
-							<p class="description"><?php esc_html_e( 'An administrator can change this.', 'friends' ); ?></p>
-							<?php
-					}
-					?>
-					</td>
-				</tr>
 					<?php
 			endif;
 			?>
-			<tr>
-				<th scope="row"><?php esc_html_e( 'Friend Requests', 'friends' ); ?></th>
-				<td>
-					<fieldset>
-						<label for="require_codeword">
-							<input name="require_codeword" type="checkbox" id="require_codeword" value="1" <?php checked( '', $codeword_class ); ?>>
-							<span><?php esc_html_e( 'Require a code word to send you friend request', 'friends' ); ?></span>
-						</label>
-					</fieldset>
-					<div id="codeword_options" class="<?php echo esc_attr( $codeword_class ); ?>">
-						<fieldset>
-							<label for="codeword">
-								<span><?php esc_html_e( 'This code word must be provided to send you a friend request:', 'friends' ); ?></span>
-								<input name="codeword" type="text" id="codeword" placeholder="friends" value="<?php echo esc_attr( $args['codeword'] ); ?>" />
-							</label>
-							<p class="description">
-								<?php esc_html_e( "You'll need to communicate the code word to potential friends through another medium.", 'friends' ); ?>
-							</p>
-						</fieldset>
-						<fieldset>
-							<label for="wrong_codeword_message">
-								<p><?php esc_html_e( 'Error message for a wrong code word:', 'friends' ); ?></p>
-							</label>
-							<p>
-								<textarea name="wrong_codeword_message" id="wrong_codeword_message" class="regular-text" rows="3" cols="80" placeholder="<?php echo esc_attr( __( 'Return this message to the friend requestor if a wrong code word was provided.', 'friends' ) ); ?>"><?php echo esc_html( $args['wrong_codeword_message'] ); ?></textarea>
-							</p>
-						</fieldset>
-					</div>
-				</td>
-			</tr>
-			<tr>
-				<th scope="row">
-				<?php
-				esc_html_e( 'E-Mail Notifications', 'friends' );
-				?>
-				</th>
-				<td>
-					<fieldset>
-						<label for="friend_request_notification">
-							<input name="friend_request_notification" type="checkbox" id="friend_request_notification" value="1" <?php checked( '1', ! $args['no_friend_request_notification'] ); ?>>
-							<span><?php esc_html_e( 'Friend Requests', 'friends' ); ?></span>
-						</label>
-						<br />
-						<label for="new_post_notification">
-							<input name="new_post_notification" type="checkbox" id="new_post_notification" value="1" <?php checked( '1', ! $args['no_new_post_notification'] ); ?>>
-							<span><?php esc_html_e( 'New Posts', 'friends' ); ?></span>
-						</label>
-					</fieldset>
-					<p class="description"><?php esc_html_e( 'You can also change this setting for each friend separately.', 'friends' ); ?></p>
-				</td>
-			</tr>
-			<tr>
-				<th scope="row">
-				<?php
-				esc_html_e( 'Keyword Notifications', 'friends' );
-				?>
-				</th>
-				<td>
-					<fieldset>
-
-						<ol id="keyword-notifications">
-							<li id="keyword-template" style="display: none">
-								<input type="checkbox" name="notification_keywords_enabled[0]" value="1" checked />
-								<input type="text" name="notification_keywords[0]" value="" placeholder="<?php esc_html_e( 'Keyword (regex allowed)', 'friends' ); ?>">
-							</li>
-						<?php foreach ( $args['notification_keywords'] as $i => $entry ) : ?>
-							<li>
-								<input type="checkbox" name="notification_keywords_enabled[<?php echo esc_attr( $i + 1 ); ?>]" value="1" <?php checked( $entry['enabled'] ); ?> />
-								<input type="text" name="notification_keywords[<?php echo esc_attr( $i + 1 ); ?>]" value="<?php echo esc_attr( $entry['keyword'] ); ?>" placeholder="<?php esc_html_e( 'Keyword (regex allowed)', 'friends' ); ?>">
-							</li>
-						<?php endforeach; ?>
-						</ol>
-						<a href="" id="admin-add-keyword"><?php esc_html_e( 'Add a notification keyword', 'friends' ); ?></a>
-					</fieldset>
-					<p class="description"><?php esc_html_e( 'Empty keywords will be deleted after saving. You can temporarily disable them with the checkbox.', 'friends' ); ?></p>
-				</td>
-			</tr>
-			<tr>
-				<th scope="row"><?php esc_html_e( 'Roles', 'friends' ); ?></th>
-				<td>
-					<select name="default_role">
-						<?php
-						foreach ( $args['friend_roles'] as $role => $title ) :
-							?>
-							<option value="<?php echo esc_attr( $role ); ?>" <?php selected( $args['default_role'], $role ); ?>><?php echo esc_html( $title ); ?></option>
-
-						<?php endforeach; ?>
-					</select>
-					<p class="description">
-						<span><?php esc_html_e( 'When accepting a friend request, first assign this role.', 'friends' ); ?></span>
-						<span><?php esc_html_e( 'An Acquaintance has friend status but cannot read private posts.', 'friends' ); ?></span>
-					</p>
-				</td>
-			</tr>
 			<tr>
 				<th><?php esc_html_e( 'Retention', 'friends' ); ?></th>
 				<td>
@@ -430,44 +255,6 @@ do_action( 'friends_settings_before_form' );
 				</td>
 			</tr>
 			<?php endif; ?>
-			<tr>
-				<th scope="row" rowspan="2"><?php esc_html_e( 'Feed Reader', 'friends' ); ?></th>
-				<td>
-					<span>
-					<?php
-					// translators: %s is a URL.
-					echo wp_kses( sprintf( __( 'Download the <a href=%s>Private OPML file (contains private urls!)</a> and import it to your feed reader.', 'friends' ), esc_url( home_url( '/friends/opml/?auth=' . $args['private_rss_key'] ) ) ), array( 'a' => array( 'href' => array() ) ) );
-					?>
-					</span>
-					<span>
-					<?php
-					// translators: %s is a URL.
-					echo wp_kses( sprintf( __( 'Alternative: <a href=%s>Public OPML file (only public urls)</a>.', 'friends' ), esc_url( home_url( '/friends/opml/?public' ) ) ), array( 'a' => array( 'href' => array() ) ) );
-					?>
-					</span>
-					<p class="description">
-					<?php
-					echo __( 'If your feed reader supports it, you can also subscribe to this URL as the OPML file gets updated as you add or remove friends.', 'friends' );
-					?>
-					</p>
-				</td>
-			</tr>
-			<tr>
-				<td>
-					<span>
-					<?php
-					// translators: %s is a URL.
-					echo wp_kses( sprintf( __( 'You can also subscribe to a <a href=%s>compiled RSS feed of friend posts</a>.', 'friends' ), esc_url( home_url( '/friends/feed/?auth=' . $args['private_rss_key'] ) ) ), array( 'a' => array( 'href' => array() ) ) );
-					?>
-					</span>
-					<p class="description">
-					<?php
-					echo __( 'Please be careful what you do with these feeds as they might contain private posts of your friends.', 'friends' );
-					?>
-					</p>
-
-				</td>
-			</tr>
 		</tbody>
 	</table>
 	<?php do_action( 'friends_settings_form_bottom' ); ?>

--- a/tests/test-activitypub.php
+++ b/tests/test-activitypub.php
@@ -37,38 +37,41 @@ class ActivityPubTest extends Friends_TestCase_Cache_HTTP {
 		$date = gmdate( \DATE_W3C, $now++ );
 		$id = 'test' . $status_id;
 		$content = 'Test ' . $date . ' ' . wp_rand();
-
-		$request = new \WP_REST_Request( 'POST', '/activitypub/1.0/users/' . get_current_user_id() . '/inbox' );
-		$request->set_param( 'type', 'Create' );
-		$request->set_param( 'id', $id );
-		$request->set_param( 'actor', $this->actor );
-
 		$attachment_url = 'https://mastodon.local/files/original/1234.png';
 		$attachment_width = 400;
 		$attachment_height = 600;
-		$request->set_param(
-			'object',
-			array(
-				'type'         => 'Note',
-				'id'           => $id,
-				'attributedTo' => $this->actor,
-				'content'      => $content,
-				'url'          => 'https://mastodon.local/users/akirk/statuses/' . ( $status_id++ ),
-				'published'    => $date,
-				'attachment'   => array(
-					array(
-						'type'      => 'Document',
-						'mediaType' => 'image/png',
-						'url'       => $attachment_url,
-						'name'      => '',
-						'blurhash'  => '',
-						'width'     => $attachment_width,
-						'height'    => $attachment_height,
 
+		$request = new \WP_REST_Request( 'POST', '/activitypub/1.0/users/' . get_current_user_id() . '/inbox' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'type'   => 'Create',
+					'id'     => $id,
+					'actor'  => $this->actor,
+					'object' => array(
+						'type'         => 'Note',
+						'id'           => $id,
+						'attributedTo' => $this->actor,
+						'content'      => $content,
+						'url'          => 'https://mastodon.local/users/akirk/statuses/' . ( $status_id++ ),
+						'published'    => $date,
+						'attachment'   => array(
+							array(
+								'type'      => 'Document',
+								'mediaType' => 'image/png',
+								'url'       => $attachment_url,
+								'name'      => '',
+								'blurhash'  => '',
+								'width'     => $attachment_width,
+								'height'    => $attachment_height,
+
+							),
+						),
 					),
-				),
+				)
 			)
 		);
+		$request->set_header( 'Content-type', 'application/json' );
 
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 202, $response->get_status() );
@@ -91,20 +94,27 @@ class ActivityPubTest extends Friends_TestCase_Cache_HTTP {
 		$content = 'Test ' . $date . ' ' . wp_rand();
 
 		$request = new \WP_REST_Request( 'POST', '/activitypub/1.0/users/' . get_current_user_id() . '/inbox' );
-		$request->set_param( 'type', 'Create' );
-		$request->set_param( 'id', $id );
-		$request->set_param( 'actor', 'https://mastodon.local/@akirk' );
-		$request->set_param(
-			'object',
-			array(
-				'type'         => 'Note',
-				'id'           => $id,
-				'attributedTo' => 'https://mastodon.local/@akirk',
-				'content'      => $content,
-				'url'          => 'https://mastodon.local/users/akirk/statuses/' . ( $status_id++ ),
-				'published'    => $date,
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'type'   => 'Create',
+					'id'     => $id,
+					'actor'  => 'https://mastodon.local/@akirk',
+
+					'object' =>
+					array(
+						'type'         => 'Note',
+						'id'           => $id,
+						'attributedTo' => 'https://mastodon.local/@akirk',
+						'content'      => $content,
+						'url'          => 'https://mastodon.local/users/akirk/statuses/' . ( $status_id++ ),
+						'published'    => $date,
+					),
+				)
 			)
 		);
+
+		$request->set_header( 'Content-type', 'application/json' );
 
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 202, $response->get_status() );
@@ -143,21 +153,26 @@ class ActivityPubTest extends Friends_TestCase_Cache_HTTP {
 		$content = '<a rel="mention" class="u-url mention" href="https://example.org/users/abc">@<span>abc</span></a> Test ' . $date . ' ' . wp_rand();
 
 		$request = new \WP_REST_Request( 'POST', '/activitypub/1.0/users/' . get_current_user_id() . '/inbox' );
-		$request->set_param( 'type', 'Create' );
-		$request->set_param( 'id', $id );
-		$request->set_param( 'actor', $this->actor );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'type'   => 'Create',
+					'id'     => $id,
+					'actor'  => $this->actor,
 
-		$request->set_param(
-			'object',
-			array(
-				'type'         => 'Note',
-				'id'           => $id,
-				'attributedTo' => $this->actor,
-				'content'      => $content,
-				'url'          => 'https://mastodon.local/users/akirk/statuses/' . ( $status_id++ ),
-				'published'    => $date,
+					'object' =>
+					array(
+						'type'         => 'Note',
+						'id'           => $id,
+						'attributedTo' => $this->actor,
+						'content'      => $content,
+						'url'          => 'https://mastodon.local/users/akirk/statuses/' . ( $status_id++ ),
+						'published'    => $date,
+					),
+				)
 			)
 		);
+		$request->set_header( 'Content-type', 'application/json' );
 
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 202, $response->get_status() );
@@ -200,11 +215,18 @@ class ActivityPubTest extends Friends_TestCase_Cache_HTTP {
 		$object = 'https://notiz.blog/2022/11/14/the-at-protocol/';
 
 		$request = new \WP_REST_Request( 'POST', '/activitypub/1.0/users/' . get_current_user_id() . '/inbox' );
-		$request->set_param( 'type', 'Announce' );
-		$request->set_param( 'id', $id );
-		$request->set_param( 'actor', $this->actor );
-		$request->set_param( 'published', $date );
-		$request->set_param( 'object', $object );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'type'      => 'Announce',
+					'id'        => $id,
+					'actor'     => $this->actor,
+					'published' => $date,
+					'object'    => $object,
+				)
+			)
+		);
+		$request->set_header( 'Content-type', 'application/json' );
 
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 202, $response->get_status() );
@@ -230,17 +252,15 @@ class ActivityPubTest extends Friends_TestCase_Cache_HTTP {
 
 	public function test_friend_mentions() {
 		add_filter( 'activitypub_cache_possible_friend_mentions', '__return_false' );
-		$post = \wp_insert_post(
+		$post_id = \wp_insert_post(
 			array(
 				'post_author'  => 1,
 				'post_content' => '@' . sanitize_title( $this->friend_nicename ) . '  hello',
 			)
 		);
 
-		$activitypub_post = new \Activitypub\Model\Post( $post );
-
-		$activitypub_activity = new \Activitypub\Model\Activity( 'Create' );
-		$activitypub_activity->from_post( $activitypub_post );
+		$activitypub_post = new \Activitypub\Transformer\Post( get_post( $post_id ) );
+		$object = $activitypub_post->to_object();
 
 		$this->assertContains(
 			array(
@@ -248,16 +268,16 @@ class ActivityPubTest extends Friends_TestCase_Cache_HTTP {
 				'href' => $this->actor,
 				'name' => '@' . $this->friend_nicename,
 			),
-			$activitypub_post->get_tags()
+			$object->get_tag()
 		);
 
-		$this->assertContains( \get_rest_url( null, '/activitypub/1.0/users/1/followers' ), $activitypub_activity->get_to() );
-		$this->assertContains( $this->actor, $activitypub_activity->get_cc() );
+		$this->assertContains( \get_rest_url( null, '/activitypub/1.0/users/1/followers' ), $object->get_to() );
+		$this->assertContains( $this->actor, $object->get_cc() );
 
 		remove_all_filters( 'activitypub_from_post_object' );
 		remove_all_filters( 'activitypub_cache_possible_friend_mentions' );
 
-		\wp_trash_post( $post );
+		\wp_trash_post( $post_id );
 	}
 
 	/**
@@ -304,6 +324,7 @@ class ActivityPubTest extends Friends_TestCase_Cache_HTTP {
 		}
 		parent::set_up();
 
+		add_filter( 'activitypub_defer_signature_verification', '__return_true' );
 		add_filter( 'pre_get_remote_metadata_by_actor', array( get_called_class(), 'friends_get_activitypub_metadata' ), 10, 2 );
 		add_filter( 'friends_get_activitypub_metadata', array( get_called_class(), 'friends_get_activitypub_metadata' ), 5, 2 );
 

--- a/tests/test-feed.php
+++ b/tests/test-feed.php
@@ -55,6 +55,7 @@ class FeedTest extends \WP_UnitTestCase {
 	 */
 	public function set_up() {
 		parent::set_up();
+		update_option( 'friends_enable_wp_friendships', true );
 
 		$this->factory->post->create(
 			array(

--- a/tests/test-messages.php
+++ b/tests/test-messages.php
@@ -37,6 +37,7 @@ class MessagesTest extends Friends_TestCase_Cache_HTTP {
 	 */
 	public function set_up() {
 		parent::set_up();
+		update_option( 'friends_enable_wp_friendships', true );
 
 		$this->user_id = $this->factory->user->create(
 			array(

--- a/tests/test-notifications.php
+++ b/tests/test-notifications.php
@@ -24,6 +24,7 @@ class NotificationTest extends \WP_UnitTestCase {
 	 */
 	public function set_up() {
 		parent::set_up();
+		update_option( 'friends_enable_wp_friendships', true );
 
 		$this->factory->post->create(
 			array(


### PR DESCRIPTION
You can now disable the friendship component. Some people just want to use the Friends plugin to follow people.

Here is the new setting, it will be off by default for now, but enabled when upgrading when this had already been used.
![Settings](https://github.com/akirk/friends/assets/203408/d63e4ccb-cadd-4973-9572-599133c8bf9e)

Lots of settings have been moved to these new screens:

Friendship settings moved here, it will only show up if Friendships are enabled:
![Friendships](https://github.com/akirk/friends/assets/203408/7769fdcd-5bd7-40ab-aed2-d969b635f0e9)

Global notification settings moved here:
![Notifications](https://github.com/akirk/friends/assets/203408/5a6df9ef-7f78-470e-8230-03b1f7224375)

I hope to add some imports here soon (moved from main settings):
![Import/Export](https://github.com/akirk/friends/assets/203408/cff771aa-905c-4347-b6f1-0cd3e0eb9eb3)
