### PR TITLE
Fix Notification Author and Highlight a Matched Keyword

### DIFF
--- a/includes/class-notifications.php
+++ b/includes/class-notifications.php
@@ -153,7 +153,7 @@ class Notifications {
 			return $notified;
 		}
 
-		$author = new User( $post->post_author );
+		$author = User::get_post_author( $post );
 		// translators: %s is a keyword string specified by the user.
 		$email_title = sprintf( __( 'Keyword matched: %s', 'friends' ), $keyword );
 

--- a/includes/class-notifications.php
+++ b/includes/class-notifications.php
@@ -39,7 +39,8 @@ class Notifications {
 	 * Register the WordPress hooks
 	 */
 	private function register_hooks() {
-		add_action( 'friends_rewrite_mail_html', array( $this, 'rewrite_mail_html' ) );
+		add_filter( 'friends_rewrite_mail_html', array( $this, 'rewrite_mail_html' ) );
+		add_filter( 'friends_rewrite_mail_html', array( $this, 'highlight_keywords' ), 10, 2 );
 		add_action( 'notify_new_friend_post', array( $this, 'notify_new_friend_post' ), 10, 2 );
 		add_filter( 'notify_keyword_match_post', array( $this, 'notify_keyword_match_post' ), 10, 3 );
 		add_action( 'notify_new_friend_request', array( $this, 'notify_new_friend_request' ) );
@@ -330,6 +331,61 @@ class Notifications {
 		$html = preg_replace( '/(' . $img_regex . '.*?)width=[\'"]\d+[\'"]/i', '$1', $html );
 		$html = preg_replace( '/(' . $img_regex . '.*?)height=[\'"]\d+[\'"]/i', '$1', $html );
 		return $html;
+	}
+
+	public function highlight_keywords( $the_content, $args ) {
+		if ( ! isset( $args['keyword'] ) ) {
+			return $the_content;
+		}
+
+		$tag_stack = array();
+		$protected_tags = array(
+			'pre',
+			'code',
+			'textarea',
+			'style',
+		);
+		$new_content = '';
+		$in_protected_tag = false;
+		foreach ( wp_html_split( $the_content ) as $chunk ) {
+			if ( preg_match( '#^<!--[\s\S]*-->$#i', $chunk, $m ) ) {
+				$new_content .= $chunk;
+				continue;
+			}
+
+			if ( preg_match( '#^<(/)?([a-z-]+)\b[^>]*>$#i', $chunk, $m ) ) {
+				$tag = strtolower( $m[2] );
+				if ( '/' === $m[1] ) {
+					// Closing tag.
+					$i = array_search( $tag, $tag_stack );
+					// We can only remove the tag from the stack if it is in the stack.
+					if ( false !== $i ) {
+						$tag_stack = array_slice( $tag_stack, 0, $i );
+					}
+				} else {
+					// Opening tag, add it to the stack.
+					$tag_stack[] = $tag;
+				}
+
+				// If we're in a protected tag, the tag_stack contains at least one protected tag string.
+				// The protected tag state can only change when we encounter a start or end tag.
+				$in_protected_tag = array_intersect( $tag_stack, $protected_tags );
+
+				// Never inspect tags.
+				$new_content .= $chunk;
+				continue;
+			}
+
+			if ( $in_protected_tag ) {
+				// Don't inspect a chunk inside an inspected tag.
+				$new_content .= $chunk;
+				continue;
+			}
+			// Only reachable when there is no protected tag in the stack.
+			$new_content .= preg_replace( '/(' . preg_quote( $args['keyword'], '/' ) . ')/i', '<mark>$1</mark>', $chunk );
+		}
+
+		return $new_content;
 	}
 
 	/**

--- a/templates/email/friend-message-received.php
+++ b/templates/email/friend-message-received.php
@@ -23,7 +23,7 @@
 
 <blockquote class="message-content">
 <?php
-	echo wp_kses_post( apply_filters( 'friends_rewrite_mail_html', $args['message'] ) );
+	echo wp_kses_post( apply_filters( 'friends_rewrite_mail_html', $args['message'], $args ) );
 ?>
 </blockquote>
 

--- a/templates/email/keyword-match-post.php
+++ b/templates/email/keyword-match-post.php
@@ -10,15 +10,15 @@
 $override_author_name = apply_filters( 'friends_override_author_name', '', $args['author']->display_name, $args['post']->ID );
 
 ?>
+	<?php
+	echo wp_kses(
+		// translators: %s is a keyword string specified by the user.
+		sprintf( __( 'Keyword matched: %s', 'friends' ), '<strong>' . esc_html( $args['keyword'] ) . '</strong>' ),
+		array( 'strong' => array() )
+	);
+	?>
+<br/><br/>
 <div class="post-meta">
-	<strong>
-		<?php
-		echo esc_html(
-			// translators: %s is a keyword string specified by the user.
-			sprintf( __( 'Keyword matched: %s', 'friends' ), $args['keyword'] )
-		);
-		?>
-	</strong>
 	<a href="<?php echo esc_attr( $args['author']->get_local_friends_page_url() ); ?>" class="author">
 		<strong><?php echo esc_html( $args['author']->display_name ); ?></strong>
 		<?php if ( $override_author_name && trim( str_replace( $override_author_name, '', $args['author']->display_name ) ) === $args['author']->display_name ) : ?>
@@ -32,7 +32,7 @@ $override_author_name = apply_filters( 'friends_override_author_name', '', $args
 
 <div class="post-content">
 <?php
-	echo wp_kses_post( apply_filters( 'friends_rewrite_mail_html', $args['post']->post_content ) );
+	echo wp_kses_post( apply_filters( 'friends_rewrite_mail_html', $args['post']->post_content, $args ) );
 ?>
 </div>
 

--- a/templates/email/new-friend-post.php
+++ b/templates/email/new-friend-post.php
@@ -24,7 +24,7 @@ $override_author_name = apply_filters( 'friends_override_author_name', '', $args
 
 <div class="post-content">
 <?php
-	echo wp_kses_post( apply_filters( 'friends_rewrite_mail_html', $args['post']->post_content ) );
+	echo wp_kses_post( apply_filters( 'friends_rewrite_mail_html', $args['post']->post_content, $args ) );
 ?>
 </div>
 


### PR DESCRIPTION
Note that the missing author caused these issues:
- Shows the blog name in brackets in the subject, not the author
- The header in the email was missing
- The Show in Friends page link was partially broken (it worked but the author was missing from the URL)

Before:
![Screenshot 2024-04-15 at 06 21 03](https://github.com/akirk/friends/assets/203408/f4675efe-d762-4a03-b7c8-3e1a18aaac78)

After:
![Screenshot 2024-04-15 at 06 19 58](https://github.com/akirk/friends/assets/203408/ec057581-754e-42b1-9ec3-86b18e5fce42)
