### PR TITLE
Map back the canonical user id to a user

### DIFF
--- a/feed-parsers/class-feed-parser-activitypub.php
+++ b/feed-parsers/class-feed-parser-activitypub.php
@@ -99,6 +99,7 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 
 		add_filter( 'mastodon_api_mapback_user_id', array( $this, 'mastodon_api_mapback_user_id' ), 30, 4 );
 		add_filter( 'friends_mastodon_api_username', array( $this, 'friends_mastodon_api_username' ) );
+		add_filter( 'mastodon_api_account', array( $this, 'mastodon_api_account_update_remapped' ), 30, 4 );
 		add_filter( 'mastodon_api_account', array( $this, 'mastodon_api_account_augment_friend_posts' ), 9, 4 );
 		add_filter( 'mastodon_api_status', array( $this, 'mastodon_api_status_add_reblogs' ), 20, 3 );
 		add_filter( 'mastodon_api_canonical_user_id', array( $this, 'mastodon_api_canonical_user_id' ), 20, 3 );
@@ -189,6 +190,19 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 		return $user_id;
 	}
 
+	public function mastodon_api_account_update_remapped( $account, $user_id, $request = null, $post = null ) {
+		if ( ! $account instanceof \Enable_Mastodon_Apps\Entity\Account ) {
+			return $account;
+		}
+
+		if ( ! preg_match( '/^@?' . self::ACTIVITYPUB_USERNAME_REGEXP . '$/i', $account->id ) ) {
+			return $account;
+		}
+
+		remove_filter( 'mastodon_api_account', array( $this, 'mastodon_api_account_update_remapped' ), 30 );
+
+		return apply_filters( 'mastodon_api_account', null, $account->id, null, null );
+	}
 
 	public function mastodon_api_account_augment_friend_posts( $account, $user_id, $request = null, $post = null ) {
 		if ( ! $post instanceof \WP_Post ) {

--- a/feed-parsers/class-feed-parser-activitypub.php
+++ b/feed-parsers/class-feed-parser-activitypub.php
@@ -100,7 +100,7 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 		add_filter( 'mastodon_api_mapback_user_id', array( $this, 'mastodon_api_mapback_user_id' ), 30, 4 );
 		add_filter( 'friends_mastodon_api_username', array( $this, 'friends_mastodon_api_username' ) );
 		add_filter( 'mastodon_api_account', array( $this, 'mastodon_api_account_augment_friend_posts' ), 9, 4 );
-		add_filter( 'mastodon_api_status', array( $this, 'mastodon_api_status_add_reblogs' ), 20, 3 );
+		add_filter( 'mastodon_api_status', array( $this, 'mastodon_api_status_add_reblogs' ), 40, 3 );
 		add_filter( 'mastodon_api_canonical_user_id', array( $this, 'mastodon_api_canonical_user_id' ), 20, 3 );
 	}
 

--- a/feed-parsers/class-feed-parser-activitypub.php
+++ b/feed-parsers/class-feed-parser-activitypub.php
@@ -192,20 +192,23 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 
 	public function mastodon_api_account_update_remapped( $account, $user_id, $request = null, $post = null ) {
 		if ( ! $account instanceof \Enable_Mastodon_Apps\Entity\Account ) {
-			return $account;
+				return $account;
 		}
 
-		if ( ! isset( $this->mapped_usernames[ $account->id ] ) ) {
-			return $account;
+		if ( ! in_array( $account->id, $this->mapped_usernames, true ) ) {
+				return $account;
 		}
 
-		static $updated_accounts = array();
+			static $updated_accounts = array();
 		if ( ! isset( $updated_accounts[ $account->id ] ) ) {
-			remove_filter( 'mastodon_api_account', array( $this, 'mastodon_api_account_update_remapped' ), 30 );
-			$updated_accounts[ $account->id ] = apply_filters( 'mastodon_api_account', null, $account->id, null, null );
-			add_filter( 'mastodon_api_account', array( $this, 'mastodon_api_account_update_remapped' ), 30, 4 );
+				$updated_account = \Activitypub\Integration\Enable_Mastodon_Apps::api_account_external( null, $account->id );
+			if ( ! $updated_account || is_wp_error( $updated_account ) || is_wp_error( $updated_account->acct ) ) {
+					$updated_accounts[ $account->id ] = $account;
+			} else {
+					$updated_accounts[ $account->id ] = $updated_account;
+			}
 		}
-		return $updated_accounts[ $account->id ];
+			return $updated_accounts[ $account->id ];
 	}
 
 	public function mastodon_api_account_augment_friend_posts( $account, $user_id, $request = null, $post = null ) {

--- a/feed-parsers/class-feed-parser-activitypub.php
+++ b/feed-parsers/class-feed-parser-activitypub.php
@@ -99,7 +99,6 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 
 		add_filter( 'mastodon_api_mapback_user_id', array( $this, 'mastodon_api_mapback_user_id' ), 30, 4 );
 		add_filter( 'friends_mastodon_api_username', array( $this, 'friends_mastodon_api_username' ) );
-		add_filter( 'mastodon_api_account', array( $this, 'mastodon_api_account_update_remapped' ), 30, 4 );
 		add_filter( 'mastodon_api_account', array( $this, 'mastodon_api_account_augment_friend_posts' ), 9, 4 );
 		add_filter( 'mastodon_api_status', array( $this, 'mastodon_api_status_add_reblogs' ), 20, 3 );
 		add_filter( 'mastodon_api_canonical_user_id', array( $this, 'mastodon_api_canonical_user_id' ), 20, 3 );
@@ -195,7 +194,7 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 				return $account;
 		}
 
-		if ( ! in_array( $account->id, $this->mapped_usernames, true ) ) {
+		if ( in_array( $account->id, $this->mapped_usernames, true ) ) {
 				return $account;
 		}
 
@@ -302,6 +301,7 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 				}
 			} else {
 				$account = apply_filters( 'mastodon_api_account', null, $friend_user->ID );
+
 			}
 
 			if ( $account instanceof \Enable_Mastodon_Apps\Entity\Account ) {

--- a/feed-parsers/class-feed-parser-activitypub.php
+++ b/feed-parsers/class-feed-parser-activitypub.php
@@ -265,6 +265,7 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 		if ( isset( $meta['attributedTo']['id'] ) && $meta['attributedTo']['id'] ) {
 			if ( isset( $meta['reblog'] ) && $meta['reblog'] ) {
 				$status->reblog = clone $status;
+				$status->reblog->account = clone $status->account;
 				$status->reblog->id = \Enable_Mastodon_Apps\Mastodon_API::remap_reblog_id( $status->reblog->id );
 			}
 			$friend_user = User::get_post_author( get_post( $post_id ) );

--- a/feed-parsers/class-feed-parser-activitypub.php
+++ b/feed-parsers/class-feed-parser-activitypub.php
@@ -51,7 +51,6 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 		\add_action( 'friends_user_feed_activated', array( $this, 'queue_follow_user' ), 10 );
 		\add_action( 'friends_user_feed_deactivated', array( $this, 'queue_unfollow_user' ), 10 );
 		\add_action( 'friends_suggest_display_name', array( $this, 'suggest_display_name' ), 10, 2 );
-		\add_action( 'mastodon_api_account_follow', array( $this, 'mastodon_api_account_follow' ), 10, 2 );
 		\add_action( 'friends_feed_parser_activitypub_follow', array( $this, 'activitypub_follow_user' ), 10, 2 );
 		\add_action( 'friends_feed_parser_activitypub_unfollow', array( $this, 'activitypub_unfollow_user' ), 10, 2 );
 		\add_action( 'friends_feed_parser_activitypub_like', array( $this, 'activitypub_like_post' ), 10, 3 );
@@ -98,7 +97,7 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 		add_filter( 'friends_get_feed_metadata', array( $this, 'friends_get_feed_metadata' ), 10, 2 );
 		add_filter( 'friends_get_activitypub_metadata', array( $this, 'friends_activitypub_metadata' ), 10, 2 );
 
-		add_filter( 'mastodon_api_timelines_args', array( $this, 'mastodon_api_timelines_args' ) );
+		add_filter( 'mastodon_api_mapback_user_id', array( $this, 'mastodon_api_mapback_user_id' ), 30, 4 );
 		add_filter( 'mastodon_api_account', array( $this, 'mastodon_api_account_augment_friend_posts' ), 9, 4 );
 		add_filter( 'mastodon_api_status', array( $this, 'mastodon_api_status_add_reblogs' ), 20, 3 );
 		add_filter( 'mastodon_api_canonical_user_id', array( $this, 'mastodon_api_canonical_user_id' ), 20, 3 );
@@ -177,10 +176,18 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 	}
 
 
-	public function mastodon_api_timelines_args( $args ) {
-		$args['post_type'][] = Friends::CPT;
-		return $args;
+	public function mastodon_api_mapback_user_id( $user_id ) {
+		if ( ! is_string( $user_id ) ) {
+			return $user_id;
+		}
+
+		$user = self::determine_mastodon_api_user( $user_id );
+		if ( $user ) {
+			return $user->ID;
+		}
+		return $user_id;
 	}
+
 
 	public function mastodon_api_account_augment_friend_posts( $account, $user_id, $request = null, $post = null ) {
 		if ( ! $post instanceof \WP_Post ) {
@@ -299,13 +306,10 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 		return $display_name;
 	}
 
-	public function mastodon_api_account_follow( $user_id, $request ) {
-		return apply_filters( 'friends_create_and_follow', null, $user_id );
-	}
 
 	public function mastodon_api_canonical_user_id( $user_id ) {
 		static $user_id_map = array();
-		if ( ! isset( $user_id_map[ $user_id ] ) ) {
+		if ( ! isset( $user_id_map[ $user_id ] ) && is_string( $user_id ) ) {
 			$user_feed = User_Feed::get_by_url( $user_id );
 			if ( $user_feed && ! is_wp_error( $user_feed ) ) {
 				$user_id_map[ $user_id ] = self::convert_actor_to_mastodon_handle( $user_feed->get_url() );
@@ -446,9 +450,20 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 	 * @return     string  The rewritten URL.
 	 */
 	public static function friends_webfinger_resolve( $url, $incoming_url ) {
+		$pre = apply_filters( 'pre_friends_webfinger_resolve', false, $url, $incoming_url );
+		if ( $pre ) {
+			return $pre;
+		}
+
+		static $cache = array();
+		if ( isset( $cache[ $incoming_url ] ) ) {
+			return $cache[ $incoming_url ];
+		}
+
 		if ( preg_match( '/^@?' . self::ACTIVITYPUB_USERNAME_REGEXP . '$/i', $incoming_url ) ) {
 			$resolved_url = \Activitypub\Webfinger::resolve( $incoming_url );
 			if ( ! is_wp_error( $resolved_url ) ) {
+				$cache[ $incoming_url ] = $resolved_url;
 				return $resolved_url;
 			}
 		}

--- a/includes/class-user.php
+++ b/includes/class-user.php
@@ -1306,7 +1306,7 @@ class User extends \WP_User {
 			if ( ! $note ) {
 				$note = '';
 			}
-			$account->id             = $user->ID;
+			$account->id             = apply_filters( 'friends_mastodon_api_username', $user->ID );
 			$account->username       = $user->user_login;
 			$account->display_name   = $user->display_name;
 			$account->avatar         = $user->get_avatar_url();

--- a/includes/class-user.php
+++ b/includes/class-user.php
@@ -1330,6 +1330,7 @@ class User extends \WP_User {
 				'fields'    => array(),
 			);
 		}
+
 		return $account;
 	}
 

--- a/includes/class-user.php
+++ b/includes/class-user.php
@@ -1286,7 +1286,12 @@ class User extends \WP_User {
 		if ( $account instanceof \Enable_Mastodon_Apps\Entity\Account ) {
 			return $account;
 		}
+		if ( ! class_exists( Feed_Parser_ActivityPub::class ) ) {
+			return $account;
+		}
+
 		$user = Feed_Parser_ActivityPub::determine_mastodon_api_user( $user_id );
+
 		if ( ! $user ) {
 			if ( ! $post instanceof \WP_Post ) {
 				return $account;
@@ -1301,7 +1306,7 @@ class User extends \WP_User {
 			if ( ! $note ) {
 				$note = '';
 			}
-			$account->id             = $user->user_login;
+			$account->id             = $user->ID;
 			$account->username       = $user->user_login;
 			$account->display_name   = $user->display_name;
 			$account->avatar         = $user->get_avatar_url();

--- a/integrations/class-enable-mastodon-apps.php
+++ b/integrations/class-enable-mastodon-apps.php
@@ -16,5 +16,16 @@ class Enable_Mastodon_Apps {
 		add_filter( 'mastodon_api_account', array( 'Friends\User', 'mastodon_api_account' ), 8, 4 );
 		add_filter( 'mastodon_api_get_posts_query_args', array( 'Friends\User', 'mastodon_api_get_posts_query_args' ) );
 		add_filter( 'mastodon_entity_relationship', array( 'Friends\User', 'mastodon_entity_relationship' ), 10, 2 );
+		add_action( 'mastodon_api_account_follow', array( get_called_class(), 'mastodon_api_account_follow' ), 10, 2 );
+		add_filter( 'mastodon_api_timelines_args', array( get_called_class(), 'mastodon_api_timelines_args' ) );
+	}
+
+	public static function mastodon_api_account_follow( $user_id, $request ) {
+		return apply_filters( 'friends_create_and_follow', null, $user_id );
+	}
+
+	public static function mastodon_api_timelines_args( $args ) {
+		$args['post_type'][] = Friends::CPT;
+		return $args;
 	}
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -39,6 +39,11 @@ function _manually_load_plugin() {
 		require $activitypub_plugin_alternate;
 	}
 
+	$enable_mastodon_apps_plugin = dirname( dirname( __DIR__ ) ) . '/enable-mastodon-apps/enable-mastodon-apps.php'; // phpcs:ignore
+	if ( file_exists( $enable_mastodon_apps_plugin ) ) {
+		require $enable_mastodon_apps_plugin;
+	}
+
 	require dirname( __DIR__ ) . '/friends.php';
 }
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );

--- a/tests/test-activitypub.php
+++ b/tests/test-activitypub.php
@@ -325,6 +325,7 @@ class ActivityPubTest extends Friends_TestCase_Cache_HTTP {
 		$metadata = \ActivityPub\get_remote_metadata_by_actor( $actor );
 		$this->assertEquals( sprintf( 'https://%s/users/%s/', $domain, $username ), $metadata['url'], $actor );
 		$this->assertEquals( $username, $metadata['name'], $actor );
+		remove_filter( 'pre_http_request', array( $this, 'invalid_http_response' ), 8, 3 );
 	}
 
 	public function set_up() {

--- a/tests/test-activitypub.php
+++ b/tests/test-activitypub.php
@@ -14,10 +14,10 @@ namespace Friends;
  */
 class ActivityPubTest extends Friends_TestCase_Cache_HTTP {
 	public static $users = array();
-	private $friend_id;
-	private $friend_name;
-	private $friend_nicename;
-	private $actor;
+	protected $friend_id;
+	protected $friend_name;
+	protected $friend_nicename;
+	protected $actor;
 
 	public function test_incoming_post() {
 		update_user_option( 'activitypub_friends_show_replies', '1', $this->friend_id );
@@ -336,6 +336,7 @@ class ActivityPubTest extends Friends_TestCase_Cache_HTTP {
 		add_filter( 'activitypub_defer_signature_verification', '__return_true' );
 		add_filter( 'pre_get_remote_metadata_by_actor', array( get_called_class(), 'friends_get_activitypub_metadata' ), 10, 2 );
 		add_filter( 'friends_get_activitypub_metadata', array( get_called_class(), 'friends_get_activitypub_metadata' ), 5, 2 );
+		add_filter( 'pre_friends_webfinger_resolve', array( get_called_class(), 'pre_friends_webfinger_resolve' ), 5, 2 );
 
 		$user_id = $this->factory->user->create(
 			array(
@@ -349,27 +350,24 @@ class ActivityPubTest extends Friends_TestCase_Cache_HTTP {
 
 		$user_feed = User_Feed::get_by_url( $this->actor );
 		if ( is_wp_error( $user_feed ) ) {
-			$this->friend_id = $this->factory->user->create(
-				array(
-					'user_login'   => 'akirk.blog',
-					'display_name' => $this->friend_name,
-					'nicename'     => $this->friend_nicename,
-					'role'         => 'friend',
-				)
-			);
-			$user_feed = User_Feed::save(
-				new User( $this->friend_id ),
+			$friend = User::create( 'akirk.blog', 'subscription', '', $this->friend_name, null, null, null, true );
+			$friend->save_feed(
 				$this->actor,
 				array(
 					'parser' => 'activitypub',
+					'active' => true,
 				)
 			);
 		} else {
-			$this->friend_id = $user_feed->get_friend_user()->ID;
+			$friend = $user_feed->get_friend_user();
 		}
 
-		$userdata = get_userdata( $this->friend_id );
-		$this->friend_nicename = $userdata->user_nicename;
+		$this->friend_id = $friend->ID;
+		$this->friend_nicename = $friend->user_nicename;
+		if ( ! $this->friend_nicename ) {
+			$this->friend_nicename = $friend->user_login;
+		}
+		$this->friend_nicename = sanitize_title( $this->friend_nicename );
 
 		self::$users[ $this->actor ] = array(
 			'id'   => $this->actor,
@@ -388,6 +386,7 @@ class ActivityPubTest extends Friends_TestCase_Cache_HTTP {
 	public function tear_down() {
 		remove_filter( 'pre_get_remote_metadata_by_actor', array( get_called_class(), 'friends_get_activitypub_metadata' ), 10, 2 );
 		remove_filter( 'friends_get_activitypub_metadata', array( get_called_class(), 'friends_get_activitypub_metadata' ), 5, 2 );
+		remove_filter( 'pre_friends_webfinger_resolve', array( get_called_class(), 'pre_friends_webfinger_resolve' ), 5, 2 );
 		remove_filter( 'pre_http_request', array( $this, 'invalid_http_response' ), 8 );
 		parent::tear_down();
 	}
@@ -395,6 +394,16 @@ class ActivityPubTest extends Friends_TestCase_Cache_HTTP {
 	public static function friends_get_activitypub_metadata( $ret, $url ) {
 		if ( isset( self::$users[ $url ] ) ) {
 			return self::$users[ $url ];
+		}
+		return $ret;
+	}
+
+	public static function pre_friends_webfinger_resolve( $ret, $url ) {
+		if ( preg_match( '/^@?' . Feed_Parser_ActivityPub::ACTIVITYPUB_USERNAME_REGEXP . '$/i', $url, $m ) ) {
+			$url = 'https://' . $m[2] . '/@' . $m[1];
+		}
+		if ( isset( self::$users[ $url ] ) ) {
+			return self::$users[ $url ]['url'];
 		}
 		return $ret;
 	}

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -8,7 +8,7 @@
 namespace Friends;
 
 /**
- * Test the Notifications
+ * Test the API
  */
 class APITest extends Friends_TestCase_Cache_HTTP {
 	/**

--- a/tests/test-combined-activitypub-ema.php
+++ b/tests/test-combined-activitypub-ema.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Class Friends_APITest
+ *
+ * @package Friends
+ */
+
+namespace Friends;
+
+/**
+ * Test the Enable Mastodon Apps integration
+ */
+class Combined_ActivityPub_EnableMastdodonApps_Test extends ActivityPubTest {
+	public function set_up() {
+		if ( ! class_exists( '\Enable_Mastodon_Apps\Mastodon_API' ) ) {
+			return $this->markTestSkipped( 'The Enable Mastodon Apps plugin is not loaded.' );
+		}
+		parent::set_up();
+	}
+
+	public function test_account_canonical_id() {
+		$this->assertTrue( \has_filter( 'mastodon_api_account' ) );
+
+		$friend_username = 'friend.local';
+		$feedless_friend_id = $this->factory->user->create(
+			array(
+				'user_login' => $friend_username,
+				'user_email' => 'friend@example.org',
+				'role'       => 'friend',
+			)
+		);
+
+		$account = apply_filters( 'mastodon_api_account', null, $feedless_friend_id, null, null );
+		$this->assertEquals( $feedless_friend_id, $account->id );
+
+		$re_resolved_account_id = apply_filters( 'mastodon_api_mapback_user_id', $account->id );
+		$this->assertEquals( $feedless_friend_id, $re_resolved_account_id );
+
+		$user_feed = User_Feed::get_by_url( $this->actor );
+		$friend = $user_feed->get_friend_user();
+		$post_id = $friend->insert_post(
+			array(
+				'post_type'    => Friends::CPT,
+				'post_content' => 'Hello, World!',
+				'meta_input'   => array(
+					'activitypub' => array(
+						'attributedTo' => array(
+							'id'                => $this->actor,
+							'preferredUsername' => 'user',
+							'name'              => 'Mr User',
+							'summary'           => 'A user that only exists during testing',
+						),
+					),
+				),
+			)
+		);
+		$second_account = apply_filters( 'mastodon_api_account', null, $this->friend_id, null, get_post( $post_id ) );
+		if ( $friend instanceof Subscription ) {
+			$this->assertTrue( $second_account->id > 1e10 );
+		} else {
+			$this->assertEquals( $friend->ID, $second_account->id );
+		}
+		$re_resolved_account_id = apply_filters( 'mastodon_api_mapback_user_id', $second_account->id );
+		$this->assertEquals( $friend->ID, $re_resolved_account_id );
+
+		$third_account = apply_filters( 'mastodon_api_account', null, $this->actor, null, null );
+		$this->assertEquals( $second_account->id, $third_account->id );
+	}
+}

--- a/tests/tests-only-ema.php
+++ b/tests/tests-only-ema.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * Class Friends_APITest
+ *
+ * @package Friends
+ */
+
+namespace Friends;
+
+/**
+ * Test the Enable Mastodon Apps integration
+ */
+class Only_EnableMastdodonApps_Test extends Friends_TestCase_Cache_HTTP {
+	private $unhooked = array();
+	public function set_up() {
+		if ( ! class_exists( '\Enable_Mastodon_Apps\Mastodon_API' ) ) {
+			return $this->markTestSkipped( 'The Enable Mastodon Apps plugin is not loaded.' );
+		}
+		parent::set_up();
+
+		// It's too late and the parser is already loaded, but we can unhook its hooks.
+		global $wp_filter;
+		foreach ( $wp_filter as $hook => $hooked ) {
+			foreach ( $hooked as $priority => $functions ) {
+				foreach ( $functions as $function ) {
+					if ( is_array( $function['function'] ) && $function['function'][0] instanceof Feed_Parser_ActivityPub ) {
+						$this->unhooked[] = array( $hook, $function['function'], $priority, $function['accepted_args'] );
+						remove_filter( $hook, $function['function'], $priority );
+					}
+				}
+			}
+		}
+	}
+
+	public function tear_down() {
+		foreach ( $this->unhooked as $unhooked ) {
+			add_filter( $unhooked[0], $unhooked[1], $unhooked[2], $unhooked[3] );
+		}
+	}
+
+	public function test_ema_account_canonical_id() {
+		$this->assertTrue( \has_filter( 'mastodon_api_account' ) );
+
+		$friend_username = 'friend.local';
+		$friend_id = $this->factory->user->create(
+			array(
+				'user_login' => $friend_username,
+				'user_email' => 'friend@example.org',
+				'role'       => 'friend',
+			)
+		);
+
+		$account = apply_filters( 'mastodon_api_account', null, $friend_id, null, null );
+		$this->assertEquals( $friend_id, $account->id );
+
+		$re_resolved_account_id = apply_filters( 'mastodon_api_mapback_user_id', $account->id );
+		$this->assertEquals( $friend_id, $re_resolved_account_id );
+	}
+
+	public function test_ema_timeline_canonical_id_user() {
+		$this->assertTrue( \has_filter( 'mastodon_api_account' ) );
+
+		$friend_username = 'friend.local';
+		$friend_id = $this->factory->user->create(
+			array(
+				'user_login' => $friend_username,
+				'user_email' => 'friend@example.org',
+				'role'       => 'friend',
+			)
+		);
+		$friend = new User( get_user_by( 'ID', $friend_id ) );
+		$post_id = $friend->insert_post(
+			array(
+				'post_type'     => Friends::CPT,
+				'post_title'    => 'First Friend Post',
+				'post_date_gmt' => '2024-05-01 10:00:00',
+				'post_status'   => 'publish',
+			)
+		);
+
+		$request = new \WP_REST_Request( 'GET', '/api/mastodon/timelines/home' );
+		$statuses = apply_filters( 'mastodon_api_timelines', null, $request );
+		$this->assertNotEmpty( $statuses->data );
+		$status = $statuses->data[0];
+		$this->assertEquals( $post_id, $status->id );
+
+		$account = $statuses->data[0]->account;
+		$re_resolved_account_id = apply_filters( 'mastodon_api_mapback_user_id', $account->id );
+		$this->assertEquals( $friend->ID, $re_resolved_account_id );
+	}
+
+	public function test_ema_timeline_canonical_id_subscription() {
+		$this->assertTrue( \has_filter( 'mastodon_api_account' ) );
+
+		$friend_username = 'friend.local';
+		$friend = Subscription::create( $friend_username, 'subscription', 'https://friend.local' );
+		$post_id = $friend->insert_post(
+			array(
+				'post_type'     => Friends::CPT,
+				'post_title'    => 'First Friend Post',
+				'post_date_gmt' => '2024-05-01 10:00:00',
+				'post_status'   => 'publish',
+			)
+		);
+
+		$request = new \WP_REST_Request( 'GET', '/api/mastodon/timelines/home' );
+		$statuses = apply_filters( 'mastodon_api_timelines', null, $request );
+		$this->assertNotEmpty( $statuses->data );
+		$status = $statuses->data[0];
+		$this->assertEquals( $post_id, $status->id );
+
+		$account = $statuses->data[0]->account;
+		$re_resolved_account_id = apply_filters( 'mastodon_api_mapback_user_id', $account->id );
+		$this->assertEquals( $friend->ID, $re_resolved_account_id );
+	}
+}

--- a/tests/tests-only-ema.php
+++ b/tests/tests-only-ema.php
@@ -12,6 +12,7 @@ namespace Friends;
  */
 class Only_EnableMastdodonApps_Test extends Friends_TestCase_Cache_HTTP {
 	private $unhooked = array();
+	private $posts = array();
 	public function set_up() {
 		if ( ! class_exists( '\Enable_Mastodon_Apps\Mastodon_API' ) ) {
 			return $this->markTestSkipped( 'The Enable Mastodon Apps plugin is not loaded.' );
@@ -36,81 +37,87 @@ class Only_EnableMastdodonApps_Test extends Friends_TestCase_Cache_HTTP {
 		foreach ( $this->unhooked as $unhooked ) {
 			add_filter( $unhooked[0], $unhooked[1], $unhooked[2], $unhooked[3] );
 		}
+		foreach ( $this->posts as $post_id ) {
+			wp_delete_post( $post_id, true );
+		}
 	}
+}
 
-	public function test_ema_account_canonical_id() {
-		$this->assertTrue( \has_filter( 'mastodon_api_account' ) );
+public function test_ema_account_canonical_id() {
+	$this->assertTrue( \has_filter( 'mastodon_api_account' ) );
 
-		$friend_username = 'friend.local';
-		$friend_id = $this->factory->user->create(
-			array(
-				'user_login' => $friend_username,
-				'user_email' => 'friend@example.org',
-				'role'       => 'friend',
-			)
-		);
+	$friend_username = 'friend.local';
+	$friend_id = $this->factory->user->create(
+		array(
+			'user_login' => $friend_username,
+			'user_email' => 'friend@example.org',
+			'role'       => 'friend',
+		)
+	);
 
-		$account = apply_filters( 'mastodon_api_account', null, $friend_id, null, null );
-		$this->assertEquals( $friend_id, $account->id );
+	$account = apply_filters( 'mastodon_api_account', null, $friend_id, null, null );
+	$this->assertEquals( $friend_id, $account->id );
 
-		$re_resolved_account_id = apply_filters( 'mastodon_api_mapback_user_id', $account->id );
-		$this->assertEquals( $friend_id, $re_resolved_account_id );
-	}
+	$re_resolved_account_id = apply_filters( 'mastodon_api_mapback_user_id', $account->id );
+	$this->assertEquals( $friend_id, $re_resolved_account_id );
+}
 
-	public function test_ema_timeline_canonical_id_user() {
-		$this->assertTrue( \has_filter( 'mastodon_api_account' ) );
+public function test_ema_timeline_canonical_id_user() {
+	$this->assertTrue( \has_filter( 'mastodon_api_account' ) );
 
-		$friend_username = 'friend.local';
-		$friend_id = $this->factory->user->create(
-			array(
-				'user_login' => $friend_username,
-				'user_email' => 'friend@example.org',
-				'role'       => 'friend',
-			)
-		);
-		$friend = new User( get_user_by( 'ID', $friend_id ) );
-		$post_id = $friend->insert_post(
-			array(
-				'post_type'     => Friends::CPT,
-				'post_title'    => 'First Friend Post',
-				'post_date_gmt' => '2024-05-01 10:00:00',
-				'post_status'   => 'publish',
-			)
-		);
+	$friend_username = 'friend.local';
+	$friend_id = $this->factory->user->create(
+		array(
+			'user_login' => $friend_username,
+			'user_email' => 'friend@example.org',
+			'role'       => 'friend',
+		)
+	);
+	$friend = new User( get_user_by( 'ID', $friend_id ) );
+	$post_id = $friend->insert_post(
+		array(
+			'post_type'     => Friends::CPT,
+			'post_title'    => 'First Friend Post',
+			'post_date_gmt' => '2024-05-01 10:00:00',
+			'post_status'   => 'publish',
+		)
+	);
+	$this - posts[] = $post_id;
 
-		$request = new \WP_REST_Request( 'GET', '/api/mastodon/timelines/home' );
-		$statuses = apply_filters( 'mastodon_api_timelines', null, $request );
-		$this->assertNotEmpty( $statuses->data );
-		$status = $statuses->data[0];
-		$this->assertEquals( $post_id, $status->id );
+	$request = new \WP_REST_Request( 'GET', '/api/mastodon/timelines/home' );
+	$statuses = apply_filters( 'mastodon_api_timelines', null, $request );
+	$this->assertNotEmpty( $statuses->data );
+	$status = $statuses->data[0];
+	$this->assertEquals( $post_id, $status->id );
 
-		$account = $statuses->data[0]->account;
-		$re_resolved_account_id = apply_filters( 'mastodon_api_mapback_user_id', $account->id );
-		$this->assertEquals( $friend->ID, $re_resolved_account_id );
-	}
+	$account = $statuses->data[0]->account;
+	$re_resolved_account_id = apply_filters( 'mastodon_api_mapback_user_id', $account->id );
+	$this->assertEquals( $friend->ID, $re_resolved_account_id );
+}
 
-	public function test_ema_timeline_canonical_id_subscription() {
-		$this->assertTrue( \has_filter( 'mastodon_api_account' ) );
+public function test_ema_timeline_canonical_id_subscription() {
+	$this->assertTrue( \has_filter( 'mastodon_api_account' ) );
 
-		$friend_username = 'friend.local';
-		$friend = Subscription::create( $friend_username, 'subscription', 'https://friend.local' );
-		$post_id = $friend->insert_post(
-			array(
-				'post_type'     => Friends::CPT,
-				'post_title'    => 'First Friend Post',
-				'post_date_gmt' => '2024-05-01 10:00:00',
-				'post_status'   => 'publish',
-			)
-		);
+	$friend_username = 'friend.local';
+	$friend = Subscription::create( $friend_username, 'subscription', 'https://friend.local' );
+	$post_id = $friend->insert_post(
+		array(
+			'post_type'     => Friends::CPT,
+			'post_title'    => 'First Friend Post',
+			'post_date_gmt' => '2024-05-01 10:00:00',
+			'post_status'   => 'publish',
+		)
+	);
+	$this->posts[] = $post_id;
 
-		$request = new \WP_REST_Request( 'GET', '/api/mastodon/timelines/home' );
-		$statuses = apply_filters( 'mastodon_api_timelines', null, $request );
-		$this->assertNotEmpty( $statuses->data );
-		$status = $statuses->data[0];
-		$this->assertEquals( $post_id, $status->id );
+	$request = new \WP_REST_Request( 'GET', '/api/mastodon/timelines/home' );
+	$statuses = apply_filters( 'mastodon_api_timelines', null, $request );
+	$this->assertNotEmpty( $statuses->data );
+	$status = $statuses->data[0];
+	$this->assertEquals( $post_id, $status->id );
 
-		$account = $statuses->data[0]->account;
-		$re_resolved_account_id = apply_filters( 'mastodon_api_mapback_user_id', $account->id );
-		$this->assertEquals( $friend->ID, $re_resolved_account_id );
-	}
+	$account = $statuses->data[0]->account;
+	$re_resolved_account_id = apply_filters( 'mastodon_api_mapback_user_id', $account->id );
+	$this->assertEquals( $friend->ID, $re_resolved_account_id );
+}
 }

--- a/tests/tests-only-ema.php
+++ b/tests/tests-only-ema.php
@@ -41,83 +41,82 @@ class Only_EnableMastdodonApps_Test extends Friends_TestCase_Cache_HTTP {
 			wp_delete_post( $post_id, true );
 		}
 	}
-}
 
-public function test_ema_account_canonical_id() {
-	$this->assertTrue( \has_filter( 'mastodon_api_account' ) );
+	public function test_ema_account_canonical_id() {
+		$this->assertTrue( \has_filter( 'mastodon_api_account' ) );
 
-	$friend_username = 'friend.local';
-	$friend_id = $this->factory->user->create(
-		array(
-			'user_login' => $friend_username,
-			'user_email' => 'friend@example.org',
-			'role'       => 'friend',
-		)
-	);
+		$friend_username = 'friend.local';
+		$friend_id = $this->factory->user->create(
+			array(
+				'user_login' => $friend_username,
+				'user_email' => 'friend@example.org',
+				'role'       => 'friend',
+			)
+		);
 
-	$account = apply_filters( 'mastodon_api_account', null, $friend_id, null, null );
-	$this->assertEquals( $friend_id, $account->id );
+		$account = apply_filters( 'mastodon_api_account', null, $friend_id, null, null );
+		$this->assertEquals( $friend_id, $account->id );
 
-	$re_resolved_account_id = apply_filters( 'mastodon_api_mapback_user_id', $account->id );
-	$this->assertEquals( $friend_id, $re_resolved_account_id );
-}
+		$re_resolved_account_id = apply_filters( 'mastodon_api_mapback_user_id', $account->id );
+		$this->assertEquals( $friend_id, $re_resolved_account_id );
+	}
 
-public function test_ema_timeline_canonical_id_user() {
-	$this->assertTrue( \has_filter( 'mastodon_api_account' ) );
+	public function test_ema_timeline_canonical_id_user() {
+		$this->assertTrue( \has_filter( 'mastodon_api_account' ) );
 
-	$friend_username = 'friend.local';
-	$friend_id = $this->factory->user->create(
-		array(
-			'user_login' => $friend_username,
-			'user_email' => 'friend@example.org',
-			'role'       => 'friend',
-		)
-	);
-	$friend = new User( get_user_by( 'ID', $friend_id ) );
-	$post_id = $friend->insert_post(
-		array(
-			'post_type'     => Friends::CPT,
-			'post_title'    => 'First Friend Post',
-			'post_date_gmt' => '2024-05-01 10:00:00',
-			'post_status'   => 'publish',
-		)
-	);
-	$this - posts[] = $post_id;
+		$friend_username = 'friend.local';
+		$friend_id = $this->factory->user->create(
+			array(
+				'user_login' => $friend_username,
+				'user_email' => 'friend@example.org',
+				'role'       => 'friend',
+			)
+		);
+		$friend = new User( get_user_by( 'ID', $friend_id ) );
+		$post_id = $friend->insert_post(
+			array(
+				'post_type'     => Friends::CPT,
+				'post_title'    => 'First Friend Post',
+				'post_date_gmt' => '2024-05-01 10:00:00',
+				'post_status'   => 'publish',
+			)
+		);
+		$this - posts[] = $post_id;
 
-	$request = new \WP_REST_Request( 'GET', '/api/mastodon/timelines/home' );
-	$statuses = apply_filters( 'mastodon_api_timelines', null, $request );
-	$this->assertNotEmpty( $statuses->data );
-	$status = $statuses->data[0];
-	$this->assertEquals( $post_id, $status->id );
+		$request = new \WP_REST_Request( 'GET', '/api/mastodon/timelines/home' );
+		$statuses = apply_filters( 'mastodon_api_timelines', null, $request );
+		$this->assertNotEmpty( $statuses->data );
+		$status = $statuses->data[0];
+		$this->assertEquals( $post_id, $status->id );
 
-	$account = $statuses->data[0]->account;
-	$re_resolved_account_id = apply_filters( 'mastodon_api_mapback_user_id', $account->id );
-	$this->assertEquals( $friend->ID, $re_resolved_account_id );
-}
+		$account = $statuses->data[0]->account;
+		$re_resolved_account_id = apply_filters( 'mastodon_api_mapback_user_id', $account->id );
+		$this->assertEquals( $friend->ID, $re_resolved_account_id );
+	}
 
-public function test_ema_timeline_canonical_id_subscription() {
-	$this->assertTrue( \has_filter( 'mastodon_api_account' ) );
+	public function test_ema_timeline_canonical_id_subscription() {
+		$this->assertTrue( \has_filter( 'mastodon_api_account' ) );
 
-	$friend_username = 'friend.local';
-	$friend = Subscription::create( $friend_username, 'subscription', 'https://friend.local' );
-	$post_id = $friend->insert_post(
-		array(
-			'post_type'     => Friends::CPT,
-			'post_title'    => 'First Friend Post',
-			'post_date_gmt' => '2024-05-01 10:00:00',
-			'post_status'   => 'publish',
-		)
-	);
-	$this->posts[] = $post_id;
+		$friend_username = 'friend.local';
+		$friend = Subscription::create( $friend_username, 'subscription', 'https://friend.local' );
+		$post_id = $friend->insert_post(
+			array(
+				'post_type'     => Friends::CPT,
+				'post_title'    => 'First Friend Post',
+				'post_date_gmt' => '2024-05-01 10:00:00',
+				'post_status'   => 'publish',
+			)
+		);
+		$this->posts[] = $post_id;
 
-	$request = new \WP_REST_Request( 'GET', '/api/mastodon/timelines/home' );
-	$statuses = apply_filters( 'mastodon_api_timelines', null, $request );
-	$this->assertNotEmpty( $statuses->data );
-	$status = $statuses->data[0];
-	$this->assertEquals( $post_id, $status->id );
+		$request = new \WP_REST_Request( 'GET', '/api/mastodon/timelines/home' );
+		$statuses = apply_filters( 'mastodon_api_timelines', null, $request );
+		$this->assertNotEmpty( $statuses->data );
+		$status = $statuses->data[0];
+		$this->assertEquals( $post_id, $status->id );
 
-	$account = $statuses->data[0]->account;
-	$re_resolved_account_id = apply_filters( 'mastodon_api_mapback_user_id', $account->id );
-	$this->assertEquals( $friend->ID, $re_resolved_account_id );
-}
+		$account = $statuses->data[0]->account;
+		$re_resolved_account_id = apply_filters( 'mastodon_api_mapback_user_id', $account->id );
+		$this->assertEquals( $friend->ID, $re_resolved_account_id );
+	}
 }

--- a/tests/tests-only-ema.php
+++ b/tests/tests-only-ema.php
@@ -81,7 +81,7 @@ class Only_EnableMastdodonApps_Test extends Friends_TestCase_Cache_HTTP {
 				'post_status'   => 'publish',
 			)
 		);
-		$this - posts[] = $post_id;
+		$this->posts[] = $post_id;
 
 		$request = new \WP_REST_Request( 'GET', '/api/mastodon/timelines/home' );
 		$statuses = apply_filters( 'mastodon_api_timelines', null, $request );


### PR DESCRIPTION
This adds a number of unit tests and improves the behavior when mapping ids to the canonical id (the ActivityPub handle, if the plugin is present ) and back. Works together with https://github.com/akirk/enable-mastodon-apps/pull/133.