### PR TITLE
EMA: Cache the post when replying to it

### DIFF
--- a/tests/test-combined-activitypub-ema.php
+++ b/tests/test-combined-activitypub-ema.php
@@ -32,7 +32,6 @@ class Combined_ActivityPub_EnableMastdodonApps_Test extends ActivityPubTest {
 		$userdata = get_userdata( $administrator );
 		$oauth->get_token_storage()->setAccessToken( $this->token, $app->get_client_id(), $userdata->ID, time() + HOUR_IN_SECONDS, $app->get_scopes() );
 
-
 		self::$users['https://notiz.blog/author/matthias-pfefferle/'] = array(
 			'id'   => 'https://notiz.blog/author/matthias-pfefferle/',
 			'url'  => 'https://notiz.blog/author/matthias-pfefferle/',
@@ -41,8 +40,15 @@ class Combined_ActivityPub_EnableMastdodonApps_Test extends ActivityPubTest {
 	}
 
 	public function tear_down() {
+
 		foreach ( $this->posts as $post_id ) {
 			wp_delete_post( $post_id, true );
+		}
+
+		if ( \Enable_Mastodon_Apps\Mastodon_API::get_last_error() ) {
+			$stderr = fopen( 'php://stderr', 'w' );
+			fwrite( $stderr, PHP_EOL . \Enable_Mastodon_Apps\Mastodon_API::get_last_error() . PHP_EOL );
+			fclose( $stderr );
 		}
 	}
 
@@ -190,5 +196,186 @@ class Combined_ActivityPub_EnableMastdodonApps_Test extends ActivityPubTest {
 		$this->assertNotEquals( $status->reblog->id, $status->id );
 		$this->assertNotEquals( $status->reblog->account->id, $status->account->id );
 		$this->assertNotEquals( $status->reblog->account->username, $status->account->username );
+	}
+
+	public function test_submit_external_user_and_status_reply() {
+		$external_user_url = 'https://mastodon.elsewhere/@user';
+		$external_url = $external_user_url . '/1';
+
+		$friend_id = \Enable_Mastodon_Apps\Mastodon_API::remap_user_id( $external_user_url );
+
+		add_filter(
+			'mastodon_api_get_posts_query_args',
+			function ( $args ) use ( $friend_id, $external_user_url ) {
+				if ( $external_user_url === $args['author'] ) {
+					$args['author'] = $friend_id;
+				}
+				return $args;
+			}
+		);
+
+		add_filter(
+			'mastodon_api_account',
+			function ( $account, $user_id ) use ( $friend_id, $external_user_url ) {
+				if ( $user_id !== $friend_id ) {
+					return $account;
+				}
+				$account = new \Enable_Mastodon_Apps\Entity\Account();
+				$account->id = $external_user_url;
+				$account->username = 'user';
+				$account->display_name = 'User';
+				$account->acct = 'user@mastodon.elsewhere';
+				$account->url = $external_user_url;
+				return $account;
+			},
+			10,
+			2
+		);
+
+		$filter_external_status = function ( $statuses, $args ) use ( $friend_id, $external_url ) {
+			if ( isset( $args['author'] ) && $args['author'] === $friend_id ) {
+				$status = new \Enable_Mastodon_Apps\Entity\Status();
+				$status->id = $external_url;
+				$status->uri = $status->id;
+				$status->account = apply_filters( 'mastodon_api_account', null, $friend_id );
+				$status->content = 'Hello, World!';
+				$statuses->data[] = $status;
+			}
+			return $statuses;
+		};
+
+		add_filter( 'mastodon_api_statuses', $filter_external_status, 10, 2 );
+		$request = $this->api_request( 'GET', '/api/v1/accounts/' . $friend_id . '/statuses' );
+		$response = $this->dispatch_authenticated( $request );
+		$statuses = json_decode( json_encode( $response->get_data() ) );
+
+		$this->assertNotEmpty( $statuses );
+		$this->assertTrue( is_numeric( $statuses[0]->id ) );
+
+		$mock = new \MockAction();
+		$cached_external_post_id = null;
+		add_filter(
+			'friends_cache_url_post_id',
+			function ( $post_id, $url ) use ( $friend_id, $filter_external_status, &$cached_external_post_id ) {
+				$response = $filter_external_status( new \WP_REST_Response(), array( 'author' => $friend_id ) );
+				foreach ( $response->data as $status ) {
+					if ( $url === $status->uri ) {
+						if ( $cached_external_post_id ) {
+							return $cached_external_post_id;
+						}
+						$cached_external_post_id = wp_insert_post(
+							array(
+								'post_title'   => '',
+								'post_content' => $status->content,
+								'post_type'    => Friends::CPT,
+								'post_status'  => 'publish',
+								'post_author'  => $friend_id,
+							)
+						);
+						return $cached_external_post_id;
+					}
+				}
+				return $post_id;
+			},
+			10,
+			2
+		);
+		add_filter( 'friends_cache_url_post_id', array( $mock, 'action' ), 10 );
+
+		$request = $this->api_request( 'POST', '/api/v1/statuses' );
+		$request->set_body_params(
+			array(
+				'in_reply_to_id' => $statuses[0]->id,
+				'status'         => 'Hello, World!',
+			)
+		);
+		$response = $this->dispatch_authenticated( $request );
+		$reply = $response->get_data();
+
+		$this->assertNotNull( $cached_external_post_id );
+		// The id should be updated because we cache the post.
+		$this->assertNotEquals( $statuses[0]->id, $reply->in_reply_to_id );
+
+		$this->assertEquals( 1, $mock->get_call_count() );
+		$this->assertEquals( 1, get_comments_number( $cached_external_post_id ) );
+		remove_filter( 'mastodon_api_statuses', $filter_external_status, 10 );
+	}
+
+	public function test_submit_external_status_reply() {
+		$friend_id = $this->factory->user->create(
+			array(
+				'role' => 'friend',
+			)
+		);
+		$external_url = 'https://mastodon.elsewhere/@user/1';
+
+		$filter_external_status = function ( $statuses, $args ) use ( $friend_id, $external_url ) {
+			if ( $args['author'] === $friend_id ) {
+				$status = new \Enable_Mastodon_Apps\Entity\Status();
+				$status->id = $external_url;
+				$status->uri = $status->id;
+				$status->account = apply_filters( 'mastodon_api_account', null, $friend_id );
+				$status->content = 'Hello, World!';
+				$status->created_at = new \DateTime( 'now' );
+				$statuses->data[] = $status;
+			}
+			return $statuses;
+		};
+
+		add_filter( 'mastodon_api_statuses', $filter_external_status, 10, 2 );
+		$request = $this->api_request( 'GET', '/api/v1/accounts/' . $friend_id . '/statuses' );
+		$response = $this->dispatch_authenticated( $request );
+		$statuses = json_decode( json_encode( $response->get_data() ) );
+
+		$this->assertNotEmpty( $statuses );
+		$this->assertTrue( is_numeric( $statuses[0]->id ) );
+
+		$mock = new \MockAction();
+		$cached_external_post_id = null;
+		add_filter(
+			'friends_cache_url_post_id',
+			function ( $post_id, $url ) use ( $friend_id, $filter_external_status, &$cached_external_post_id ) {
+				$response = $filter_external_status( new \WP_REST_Response(), array( 'author' => $friend_id ) );
+				foreach ( $response->data as $status ) {
+					if ( $url === $status->uri ) {
+						if ( $cached_external_post_id ) {
+							return $cached_external_post_id;
+						}
+						$cached_external_post_id = wp_insert_post(
+							array(
+								'post_title'   => '',
+								'post_content' => $status->content,
+								'post_type'    => Friends::CPT,
+								'post_status'  => 'publish',
+								'post_author'  => $friend_id,
+							)
+						);
+						return $cached_external_post_id;
+					}
+				}
+				return $post_id;
+			},
+			10,
+			2
+		);
+		add_filter( 'friends_cache_url_post_id', array( $mock, 'action' ), 10 );
+
+		$request = $this->api_request( 'POST', '/api/v1/statuses' );
+		$request->set_body_params(
+			array(
+				'in_reply_to_id' => $statuses[0]->id,
+				'status'         => 'Hello, World!',
+			)
+		);
+		$response = $this->dispatch_authenticated( $request );
+		$reply = $response->get_data();
+
+		$this->assertNotNull( $cached_external_post_id );
+		// The id should be updated because we cache the post.
+		$this->assertNotEquals( $statuses[0]->id, $reply->in_reply_to_id );
+
+		$this->assertEquals( 1, $mock->get_call_count() );
+		$this->assertEquals( 1, get_comments_number( $cached_external_post_id ) );
+		remove_filter( 'mastodon_api_statuses', $filter_external_status, 10 );
 	}
 }

--- a/tests/test-combined-activitypub-ema.php
+++ b/tests/test-combined-activitypub-ema.php
@@ -45,6 +45,10 @@ class Combined_ActivityPub_EnableMastdodonApps_Test extends ActivityPubTest {
 			wp_delete_post( $post_id, true );
 		}
 
+		if ( ! class_exists( '\Enable_Mastodon_Apps\Mastodon_API' ) ) {
+			return;
+		}
+
 		if ( \Enable_Mastodon_Apps\Mastodon_API::get_last_error() ) {
 			$stderr = fopen( 'php://stderr', 'w' );
 			fwrite( $stderr, PHP_EOL . \Enable_Mastodon_Apps\Mastodon_API::get_last_error() . PHP_EOL );

--- a/tests/test-only-ema.php
+++ b/tests/test-only-ema.php
@@ -55,6 +55,16 @@ class Only_EnableMastdodonApps_Test extends Friends_TestCase_Cache_HTTP {
 			wp_delete_post( $post_id, true );
 		}
 		remove_filter( 'pre_http_request', array( $this, 'block_http_requests' ) );
+
+		if ( ! class_exists( '\Enable_Mastodon_Apps\Mastodon_API' ) ) {
+			return;
+		}
+
+		if ( \Enable_Mastodon_Apps\Mastodon_API::get_last_error() ) {
+			$stderr = fopen( 'php://stderr', 'w' );
+			fwrite( $stderr, PHP_EOL . \Enable_Mastodon_Apps\Mastodon_API::get_last_error() . PHP_EOL );
+			fclose( $stderr );
+		}
 	}
 
 	public function block_http_requests() {

--- a/tests/test-only-ema.php
+++ b/tests/test-only-ema.php
@@ -163,14 +163,4 @@ class Only_EnableMastdodonApps_Test extends Friends_TestCase_Cache_HTTP {
 		$re_resolved_account_id = apply_filters( 'mastodon_api_mapback_user_id', $account->id );
 		$this->assertEquals( $friend->ID, $re_resolved_account_id );
 	}
-
-
-	public function filter_external_status() {
-
-	}
-
-	public function test_submit_external_status_reply() {
-		add_filter( 'mastodon_api_statuses', array( $this, 'filter_external_status' ), 10, 2 );
-		$this->assertTrue( true );
-	}
 }


### PR DESCRIPTION
Now you can also reply to an external status (provided via ActivityPub, for example if you view someone else through an app that you are not following), and analog to #307 this caches the post before the reply happens so that the comment can appear inside the Friends plugin as a comment.

Thus, as soon as you reply to a status of someone you are not following, that status will then appear in your Friends page under the External user.

This makes use of changes in https://github.com/akirk/enable-mastodon-apps/pull/134.