### PR TITLE
Improve PHPCS WordPress compliance

### DIFF
--- a/feed-parsers/class-feed-parser-activitypub.php
+++ b/feed-parsers/class-feed-parser-activitypub.php
@@ -1452,8 +1452,9 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 		$url = false;
 		$append_to_redirect = '';
 
-		$in_reply_to = filter_input( INPUT_GET, 'in_reply_to', FILTER_SANITIZE_URL );
-		$boost = filter_input( INPUT_GET, 'boost', FILTER_SANITIZE_URL );
+		// The ignores are not necessary now but when https://github.com/WordPress/WordPress-Coding-Standards/issues/2299 comes into effect.
+		$in_reply_to = filter_input( INPUT_GET, 'in_reply_to', FILTER_SANITIZE_URL ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$boost = filter_input( INPUT_GET, 'boost', FILTER_SANITIZE_URL ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		if ( $in_reply_to ) {
 			$url = $in_reply_to;
 			$append_to_redirect .= '#comment';

--- a/includes/class-access-control.php
+++ b/includes/class-access-control.php
@@ -86,7 +86,7 @@ class Access_Control {
 	 * @return bool The authentication status of the feed.
 	 */
 	public static function private_rss_is_authenticated() {
-		if ( filter_input( INPUT_GET, 'auth' ) === get_option( 'friends_private_rss_key' ) ) {
+		if ( filter_input( INPUT_GET, 'auth' ) === get_option( 'friends_private_rss_key' ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			return true;
 		}
 

--- a/includes/class-access-control.php
+++ b/includes/class-access-control.php
@@ -86,7 +86,7 @@ class Access_Control {
 	 * @return bool The authentication status of the feed.
 	 */
 	public static function private_rss_is_authenticated() {
-		if ( isset( $_GET['auth'] ) && get_option( 'friends_private_rss_key' ) === $_GET['auth'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( filter_input( INPUT_GET, 'auth' ) === get_option( 'friends_private_rss_key' ) ) {
 			return true;
 		}
 

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -1328,11 +1328,11 @@ class Admin {
 					update_user_option( get_current_user_id(), 'friends_hide_from_friends_page', $hide_from_friends_page );
 			}
 
-			if ( $friend->set_retention_number_enabled( isset( $_POST['friends_enable_retention_number'] ) && intval( $_POST['friends_enable_retention_number'] ) ) && isset( $_POST['friends_retention_number'] ) ) {
-				$friend->set_retention_number( intval( $_POST['friends_retention_number'] ) );
+			if ( $friend->set_retention_number_enabled( filter_input( INPUT_POST, 'friends_enable_retention_number', FILTER_VALIDATE_BOOL ) ) && isset( $_POST['friends_retention_number'] ) ) {
+				$friend->set_retention_number( filter_input( INPUT_POST, 'friends_retention_number', FILTER_SANITIZE_NUMBER_INT ) );
 			}
-			if ( $friend->set_retention_days_enabled( isset( $_POST['friends_enable_retention_days'] ) && intval( $_POST['friends_enable_retention_days'] ) ) && isset( $_POST['friends_retention_days'] ) ) {
-				$friend->set_retention_days( intval( $_POST['friends_retention_days'] ) );
+			if ( $friend->set_retention_days_enabled( filter_input( INPUT_POST, 'friends_enable_retention_days', FILTER_VALIDATE_BOOL ) ) && isset( $_POST['friends_retention_days'] ) ) {
+				$friend->set_retention_days( filter_input( INPUT_POST, 'friends_retention_days', FILTER_SANITIZE_NUMBER_INT ) );
 			}
 
 			$hide_from_friends_page = get_user_option( 'friends_hide_from_friends_page' );

--- a/includes/class-automatic-status-list-table.php
+++ b/includes/class-automatic-status-list-table.php
@@ -106,7 +106,7 @@ class Automatic_Status_List_Table extends \WP_Posts_List_Table {
 			$counts[ $row->post_status ] = $row->count;
 		}
 		$counts = (object) $counts;
-		wp_cache_set( $cache_key, $counts, 'friends' );
+		wp_cache_set( $cache_key, $counts, 'friends', HOUR_IN_SECONDS );
 
 		return $counts;
 	}

--- a/includes/class-user.php
+++ b/includes/class-user.php
@@ -1168,7 +1168,7 @@ class User extends \WP_User {
 
 		$name = apply_filters( 'friend_user_role_name', false, $this );
 
-		if ( ! $name ) {
+		if ( empty( $name ) ) {
 			$name = _x( 'Unknown', 'User role', 'friends' );
 		}
 


### PR DESCRIPTION
This addresses a number of review comments by @apermo. Thank you!

We also discussed that `get_transient` should be enough for caching, and then I filed https://github.com/WordPress/WordPress-Coding-Standards/issues/2463. As long as that issue is open, I'll keep the doubling of `wp_cache_get` and `get_transient` introduced in #329.

We also ran into https://github.com/WordPress/WordPress-Coding-Standards/issues/2299, I preemptively left the `phpcs:ignore WordPress.Security.NonceVerification.Recommended` there.