### PR TITLE
Fix boosting

### DIFF
--- a/friends.js
+++ b/friends.js
@@ -442,13 +442,14 @@
 					post_id: $this.data( 'id' ),
 				},
 				success( result ) {
-					if ( 'boosted' === result.status ) {
+					if ( 'boosted' === result ) {
 						$this
 							.find( 'i.friends-boost-status' )
 							.addClass( 'dashicons dashicons-saved' );
 					} else {
 						$this
 							.find( 'i.friends-boost-status' )
+							.addClass( 'dashicons dashicons-warning' )
 							.removeClass( 'dashicons-saved' );
 					}
 				},

--- a/templates/frontend/parts/activitypub/boost-button.php
+++ b/templates/frontend/parts/activitypub/boost-button.php
@@ -10,11 +10,11 @@ if ( \Friends\User::get_post_author( get_post() )->ID === get_current_user_id() 
 	return;
 }
 ?>
-<a tabindex="0" href="#" data-id="<?php echo esc_attr( get_the_ID() ); ?>" data-nonce="<?php echo esc_attr( wp_create_nonce( 'friends-activitypub-boost' ) ); ?>"  class="btn ml-1 friends-activitypub-boost has-icon-right">
+<a tabindex="0" href="#" data-id="<?php echo esc_attr( get_the_ID() ); ?>" data-nonce="<?php echo esc_attr( wp_create_nonce( 'friends-boost' ) ); ?>"  class="btn ml-1 friends-boost has-icon-right">
 	<i class="dashicons dashicons-controls-repeat"></i> <?php echo esc_html_x( 'Boost', 'button', 'friends' ); ?>
 	<?php if ( get_post_meta( get_the_ID(), 'boosted', true ) ) : ?>
-		<i class="friends-activitypub-boost-status dashicons dashicons-saved"></i>
+		<i class="friends-boost-status dashicons dashicons-saved"></i>
 	<?php else : ?>
-		<i class="friends-activitypub-boost-status"></i>
+		<i class="friends-boost-status"></i>
 	<?php endif; ?>
 </a>


### PR DESCRIPTION
Boosting was broken as @lordmatt reported (thanks!)

This fixes this which was overall mostly misnamed CSS classes.

When a boost was successful you'll see a checkmark:
![Screenshot 2024-09-20 at 13 34 44](https://github.com/user-attachments/assets/b562cfba-a982-440c-9590-2ad2a05bf60e)
