### PR TITLE
Log Activitypub actions and add the publish date to Announcements

### DIFF
--- a/feed-parsers/class-feed-parser-activitypub.php
+++ b/feed-parsers/class-feed-parser-activitypub.php
@@ -1823,6 +1823,18 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 				)
 			);
 		}
+		$type = 'like';
+		$message = sprintf(
+			// translators: %s is the URL of the post.
+			__( 'Liked %s', 'friends' ),
+			'<a href="' . esc_url( $external_post_id ) . '">' . $external_post_id . '</a>'
+		);
+		$details = array(
+			'actor'  => $actor,
+			'object' => $external_post_id,
+		);
+
+		Logging::log( 'like', $message, $details, self::SLUG, $user_id );
 	}
 
 	/**
@@ -2108,6 +2120,19 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 		foreach ( $inboxes as $inbox ) {
 			\Activitypub\safe_remote_post( $inbox, $json, $user_id );
 		}
+
+		$message = sprintf(
+			// translators: %s is the URL of the post.
+			__( 'Announced %s', 'friends' ),
+			'<a href="' . esc_url( $url ) . '">' . $url . '</a>'
+		);
+
+		$details = array(
+			'url'     => $url,
+			'inboxes' => count( $inboxes ),
+		);
+
+		Logging::log( 'announce', $message, $details, self::SLUG, $user_id );
 	}
 
 	/**

--- a/feed-parsers/class-feed-parser-activitypub.php
+++ b/feed-parsers/class-feed-parser-activitypub.php
@@ -1797,10 +1797,6 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 	 */
 	public function activitypub_like_post( $url, $external_post_id, $user_id ) {
 		$type = 'Like';
-		$inbox = self::get_inbox_by_actor( $url, $type );
-		if ( is_wp_error( $inbox ) ) {
-			return $inbox;
-		}
 		$actor = \get_author_posts_url( $user_id );
 
 		$activity = new \Activitypub\Activity\Activity();
@@ -1810,8 +1806,34 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 		$activity->set_actor( $actor );
 		$activity->set_object( $external_post_id );
 		$activity->set_id( $actor . '#like-' . \preg_replace( '~^https?://~', '', $external_post_id ) );
-		$activity = $activity->to_json();
-		$response = \Activitypub\safe_remote_post( $inbox, $activity, $user_id );
+		$activity->set_published( \gmdate( 'Y-m-d\TH:i:s\Z', time() ) );
+
+		$inboxes = apply_filters( 'activitypub_send_to_inboxes', array(), $user_id, $activity );
+		$inboxes = array_unique( $inboxes );
+
+		if ( empty( $inboxes ) ) {
+			$message = sprintf(
+				// translators: %s is the URL of the post.
+				__( 'Like failed for %s', 'friends' ),
+				'<a href="' . esc_url( $url ) . '">' . $url . '</a>'
+			);
+
+			$details = array(
+				'url'   => $url,
+				'error' => __( 'No inboxes to send to.', 'friends' ),
+			);
+
+			Logging::log( 'like-failed', $message, $details, self::SLUG, $user_id );
+			return;
+		}
+
+		$json = $activity->to_json();
+
+		$report = array();
+		foreach ( $inboxes as $inbox ) {
+			$response = \Activitypub\safe_remote_post( $inbox, $json, $user_id );
+			$report[ $inbox ] = wp_remote_retrieve_response_message( $response );
+		}
 
 		$user_feed = User_Feed::get_by_url( $url );
 		if ( $user_feed instanceof User_Feed ) {
@@ -1830,8 +1852,9 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 			'<a href="' . esc_url( $external_post_id ) . '">' . $external_post_id . '</a>'
 		);
 		$details = array(
-			'actor'  => $actor,
-			'object' => $external_post_id,
+			'actor'   => $actor,
+			'url'     => $external_post_id,
+			'inboxes' => $report,
 		);
 
 		Logging::log( 'like', $message, $details, self::SLUG, $user_id );
@@ -1894,10 +1917,6 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 	 */
 	public function activitypub_unlike_post( $url, $external_post_id, $user_id ) {
 		$type = 'Like';
-		$inbox = self::get_inbox_by_actor( $url, $type );
-		if ( is_wp_error( $inbox ) ) {
-			return $inbox;
-		}
 		$actor = \get_author_posts_url( $user_id );
 
 		$activity = new \Activitypub\Activity\Activity();
@@ -1914,8 +1933,33 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 			)
 		);
 		$activity->set_id( $actor . '#unlike-' . \preg_replace( '~^https?://~', '', $external_post_id ) );
-		$activity = $activity->to_json();
-		$response = \Activitypub\safe_remote_post( $inbox, $activity, $user_id );
+
+		$inboxes = apply_filters( 'activitypub_send_to_inboxes', array(), $user_id, $activity );
+		$inboxes = array_unique( $inboxes );
+
+		if ( empty( $inboxes ) ) {
+			$message = sprintf(
+				// translators: %s is the URL of the post.
+				__( 'Unlike failed for %s', 'friends' ),
+				'<a href="' . esc_url( $url ) . '">' . $url . '</a>'
+			);
+
+			$details = array(
+				'url'   => $url,
+				'error' => __( 'No inboxes to send to.', 'friends' ),
+			);
+
+			Logging::log( 'unlike-failed', $message, $details, self::SLUG, $user_id );
+			return;
+		}
+
+		$json = $activity->to_json();
+
+		$report = array();
+		foreach ( $inboxes as $inbox ) {
+			$response = \Activitypub\safe_remote_post( $inbox, $json, $user_id );
+			$report[ $inbox ] = wp_remote_retrieve_response_message( $response );
+		}
 
 		$user_feed = User_Feed::get_by_url( $url );
 		if ( $user_feed instanceof User_Feed ) {
@@ -1927,6 +1971,19 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 				)
 			);
 		}
+		$type = 'unlike';
+		$message = sprintf(
+			// translators: %s is the URL of the post.
+			__( 'Unliked %s', 'friends' ),
+			'<a href="' . esc_url( $external_post_id ) . '">' . $external_post_id . '</a>'
+		);
+		$details = array(
+			'actor'   => $actor,
+			'url'     => $external_post_id,
+			'inboxes' => $report,
+		);
+
+		Logging::log( 'unlike', $message, $details, self::SLUG, $user_id );
 	}
 
 	public function boost_button() {
@@ -2115,7 +2172,6 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 		$inboxes = array_unique( $inboxes );
 
 		if ( empty( $inboxes ) ) {
-
 			$message = sprintf(
 				// translators: %s is the URL of the post.
 				__( 'Announce failed for %s', 'friends' ),
@@ -2137,7 +2193,6 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 		foreach ( $inboxes as $inbox ) {
 			$response = \Activitypub\safe_remote_post( $inbox, $json, $user_id );
 			$report[ $inbox ] = wp_remote_retrieve_response_message( $response );
-
 		}
 
 		$message = sprintf(
@@ -2194,18 +2249,47 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 				'id'     => $actor . '#activitypub_announce-' . \preg_replace( '~^https?://~', '', $url ),
 			)
 		);
+		$activity->set_published( \gmdate( 'Y-m-d\TH:i:s\Z', time() ) );
 
-		$follower_inboxes  = \Activitypub\Collection\Followers::get_inboxes( $user_id );
-		$mentioned_inboxes = \Activitypub\Mention::get_inboxes( $activity->get_cc() );
-
-		$inboxes = array_merge( $follower_inboxes, $mentioned_inboxes );
+		$inboxes = apply_filters( 'activitypub_send_to_inboxes', array(), $user_id, $activity );
 		$inboxes = array_unique( $inboxes );
+
+		if ( empty( $inboxes ) ) {
+			$message = sprintf(
+				// translators: %s is the URL of the post.
+				__( 'Unannounce failed for %s', 'friends' ),
+				'<a href="' . esc_url( $url ) . '">' . $url . '</a>'
+			);
+
+			$details = array(
+				'url'   => $url,
+				'error' => __( 'No inboxes to send to.', 'friends' ),
+			);
+
+			Logging::log( 'unannounce-failed', $message, $details, self::SLUG, $user_id );
+			return;
+		}
 
 		$json = $activity->to_json();
 
+		$report = array();
 		foreach ( $inboxes as $inbox ) {
-			\Activitypub\safe_remote_post( $inbox, $json, $user_id );
+			$response = \Activitypub\safe_remote_post( $inbox, $json, $user_id );
+			$report[ $inbox ] = wp_remote_retrieve_response_message( $response );
 		}
+
+		$message = sprintf(
+			// translators: %s is the URL of the post.
+			__( 'Unannounced %s', 'friends' ),
+			'<a href="' . esc_url( $url ) . '">' . $url . '</a>'
+		);
+
+		$details = array(
+			'url'     => $url,
+			'inboxes' => $report,
+		);
+
+		Logging::log( 'unannounce', $message, $details, self::SLUG, $user_id );
 	}
 
 	/**

--- a/feed-parsers/class-feed-parser-activitypub.php
+++ b/feed-parsers/class-feed-parser-activitypub.php
@@ -2117,8 +2117,11 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 
 		$json = $activity->to_json();
 
+		$report = array();
 		foreach ( $inboxes as $inbox ) {
-			\Activitypub\safe_remote_post( $inbox, $json, $user_id );
+			$response = \Activitypub\safe_remote_post( $inbox, $json, $user_id );
+			$report[ $inbox ] = wp_remote_retrieve_response_message( $response );
+
 		}
 
 		$message = sprintf(
@@ -2129,7 +2132,7 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 
 		$details = array(
 			'url'     => $url,
-			'inboxes' => count( $inboxes ),
+			'inboxes' => $report,
 		);
 
 		Logging::log( 'announce', $message, $details, self::SLUG, $user_id );

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -178,6 +178,15 @@ class Admin {
 			add_action( 'load-' . $page_type . '_page_edit-friend-rules', array( $this, 'process_admin_edit_friend_rules' ) );
 		}
 
+		if ( isset( $_GET['page'] ) && 'friends-log' === $_GET['page'] ) {
+			$user = new User( intval( $_GET['user'] ) );
+			if ( $user ) {
+				// translators: as in log file.
+				$title = __( 'Log', 'friends' );
+				add_submenu_page( 'friends', $title, $title, $required_role, 'friends-log', array( $this, 'render_friends_log' ) );
+			}
+		}
+
 		if ( isset( $_GET['page'] ) && 'unfriend' === $_GET['page'] ) {
 			$user = new User( intval( $_GET['user'] ) );
 			if ( $user ) {
@@ -2489,6 +2498,32 @@ class Admin {
 	}
 
 	public function process_admin_import_export() {
+	}
+
+	public function render_friends_log() {
+		Friends::template_loader()->get_template_part(
+			'admin/settings-header',
+			null,
+			array(
+				'active' => 'friends-log',
+				'title'  => __( 'Friends', 'friends' ),
+			)
+		);
+		$this->check_admin_settings();
+
+		?>
+		<h1><?php esc_html_e( 'Friends Log', 'friends' ); ?></h1>
+		<?php
+
+		Friends::template_loader()->get_template_part(
+			'admin/logs',
+			null,
+			array(
+				'logs' => Logging::get_logs(),
+			)
+		);
+
+		Friends::template_loader()->get_template_part( 'admin/settings-footer' );
 	}
 
 	/**

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -178,13 +178,10 @@ class Admin {
 			add_action( 'load-' . $page_type . '_page_edit-friend-rules', array( $this, 'process_admin_edit_friend_rules' ) );
 		}
 
-		if ( isset( $_GET['page'] ) && 'friends-log' === $_GET['page'] ) {
-			$user = new User( intval( $_GET['user'] ) );
-			if ( $user ) {
-				// translators: as in log file.
-				$title = __( 'Log', 'friends' );
-				add_submenu_page( 'friends', $title, $title, $required_role, 'friends-log', array( $this, 'render_friends_log' ) );
-			}
+		if ( isset( $_GET['page'] ) && 'friends-logs' === $_GET['page'] ) {
+			// translators: as in log file.
+			$title = __( 'Log', 'friends' );
+			add_submenu_page( 'friends', $title, $title, $required_role, 'friends-logs', array( $this, 'render_friends_logs' ) );
 		}
 
 		if ( isset( $_GET['page'] ) && 'unfriend' === $_GET['page'] ) {
@@ -2500,19 +2497,19 @@ class Admin {
 	public function process_admin_import_export() {
 	}
 
-	public function render_friends_log() {
+	public function render_friends_logs() {
 		Friends::template_loader()->get_template_part(
 			'admin/settings-header',
 			null,
 			array(
-				'active' => 'friends-log',
+				'active' => 'friends-logs',
 				'title'  => __( 'Friends', 'friends' ),
 			)
 		);
 		$this->check_admin_settings();
 
 		?>
-		<h1><?php esc_html_e( 'Friends Log', 'friends' ); ?></h1>
+		<h1><?php esc_html_e( 'Logs', 'friends' ); ?></h1>
 		<?php
 
 		Friends::template_loader()->get_template_part(

--- a/includes/class-logging.php
+++ b/includes/class-logging.php
@@ -43,9 +43,19 @@ class Logging {
 	}
 
 	/**
+	 * Register the WordPress hooks
+	 */
+	private function register_hooks() {
+		add_action( 'init', array( $this, 'register_post_type' ) );
+		add_action( 'friends_retrieved_new_posts', array( $this, 'log_feed_successfully_fetched' ), 10, 3 );
+		add_action( 'friends_retrieve_friends_error', array( $this, 'log_feed_error' ), 10, 2 );
+		add_action( 'friends_log', array( $this, 'log_entry' ), 10, 2 );
+	}
+
+	/**
 	 * Register the custom post type for logging.
 	 */
-	private function register_post_type() {
+	public function register_post_type() {
 		$args = array(
 			'labels'       => array(
 				'name'          => __( 'Friends Logs', 'friends' ),
@@ -74,16 +84,6 @@ class Logging {
 				'single' => true,
 			)
 		);
-	}
-
-	/**
-	 * Register the WordPress hooks
-	 */
-	private function register_hooks() {
-		add_action( 'init', array( $this, 'register_post_type' ) );
-		add_action( 'friends_retrieved_new_posts', array( $this, 'log_feed_successfully_fetched' ), 10, 3 );
-		add_action( 'friends_retrieve_friends_error', array( $this, 'log_feed_error' ), 10, 2 );
-		add_action( 'friends_log', array( $this, 'log_entry' ), 10, 2 );
 	}
 
 	/**

--- a/includes/class-logging.php
+++ b/includes/class-logging.php
@@ -131,7 +131,7 @@ class Logging {
 			array(
 				'post_type'    => self::CPT,
 				'post_title'   => $message,
-				'post_content' => wp_json_encode( $details ),
+				'post_content' => wp_json_encode( $details, JSON_PRETTY_PRINT ),
 				'post_author'  => $user_id,
 				'post_status'  => 'publish',
 			)

--- a/includes/class-logging.php
+++ b/includes/class-logging.php
@@ -121,7 +121,7 @@ class Logging {
 	 *
 	 * @param     string $type    The type of log message.
 	 * @param     string $message The message.
-	 * @param     string $details The details of the log message.
+	 * @param     array  $details The details of the log message.
 	 * @param     string $module  The module that generated the log message.
 	 * @param     int    $user_id The ID of the user that generated the log message.
 	 * @return    int    The ID of the log post.
@@ -131,7 +131,7 @@ class Logging {
 			array(
 				'post_type'    => self::CPT,
 				'post_title'   => $message,
-				'post_content' => $details,
+				'post_content' => wp_json_encode( $details ),
 				'post_author'  => $user_id,
 				'post_status'  => 'publish',
 			)

--- a/templates/admin/logs.php
+++ b/templates/admin/logs.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * This template displays the Friends Log.
+ *
+ * @package Friends
+ */
+
+?>
+<table class="widefat">
+	<thead>
+		<tr>
+			<th><?php esc_html_e( 'Date', 'friends' ); ?></th>
+			<th><?php esc_html_e( 'Message', 'friends' ); ?></th>
+			<th><?php esc_html_e( 'User', 'friends' ); ?></th>
+		</tr>
+	</thead>
+	<tbody>
+		<?php
+		foreach ( $args['logs'] as $log ) :
+			?>
+			<tr>
+				<td><?php echo esc_html( $log->post_date ); ?></td>
+				<td><?php echo wp_kses_post( $log->post_title ); ?></td>
+				<td><?php echo esc_html( get_the_author_meta( 'display_name', $log->post_author ) ); ?></td>
+			</tr>
+		<?php endforeach; ?>
+	</tbody>

--- a/templates/admin/logs.php
+++ b/templates/admin/logs.php
@@ -20,8 +20,14 @@
 			?>
 			<tr>
 				<td><?php echo esc_html( $log->post_date ); ?></td>
-				<td><?php echo wp_kses_post( $log->post_title ); ?></td>
+				<td>
+					<details>
+						<summary><?php echo wp_kses_post( $log->post_title ); ?></summary>
+						<pre><?php echo wp_kses_post( $log->post_content ); ?></pre>
+					</details>
+				</td>
 				<td><?php echo esc_html( get_the_author_meta( 'display_name', $log->post_author ) ); ?></td>
 			</tr>
 		<?php endforeach; ?>
 	</tbody>
+</table>


### PR DESCRIPTION
This adds logging capabilities, and specifically for ActivityPub actions so that you can know whether they worked.
- Like
- Announce

The log is not exposed (yet), you can access it at `/wp-admin/admin.php?page=friends-logs`

![Screenshot 2024-10-15 at 08 13 12](https://github.com/user-attachments/assets/7791ccea-6dab-4d9a-a10f-7906977bc468)


![Screenshot 2024-10-15 at 08 03 28](https://github.com/user-attachments/assets/991c7fe1-9d8f-41f6-8a72-f14bfc0be04e)
