### PR TITLE
Add mark tag CSS to emails to ensure highlighting

### DIFF
--- a/templates/email/header.php
+++ b/templates/email/header.php
@@ -97,6 +97,11 @@
 			overflow-wrap: break-word;
 		}
 
+		mark {
+			background-color: #ff0;
+			color: #000;
+		}
+
 		hr {
 			border: 0;
 			margin-top: 1.5em;


### PR DESCRIPTION
Some e-mail client's don't highlight `<mark>` tags by default which we use for highlighting notification keywords:

![Screenshot 2024-10-11 at 10 00 41](https://github.com/user-attachments/assets/fa45ec78-5802-43a7-93d3-6c0833d79237)
