### PR TITLE
Fix support for threads.net

### DIFF
--- a/includes/class-feed.php
+++ b/includes/class-feed.php
@@ -861,20 +861,18 @@ class Feed {
 			$content_type = strtok( $headers['content-type'], ';' );
 		}
 
-		if ( $content ) {
-			foreach ( $this->parsers as $slug => $parser ) {
-				foreach ( $parser->discover_available_feeds( $content, $url ) as $link_url => $feed ) {
-					if ( isset( $available_feeds[ $link_url ] ) ) {
-						// If this parser tells us it can parse it right away, allow it to override.
-						if ( isset( $available_feeds[ $link_url ]['parser'] ) || ! isset( $feed['parser'] ) ) {
-							continue;
-						}
-					} else {
-						$available_feeds[ $link_url ] = array();
+		foreach ( $this->parsers as $slug => $parser ) {
+			foreach ( $parser->discover_available_feeds( $content, $url ) as $link_url => $feed ) {
+				if ( isset( $available_feeds[ $link_url ] ) ) {
+					// If this parser tells us it can parse it right away, allow it to override.
+					if ( isset( $available_feeds[ $link_url ]['parser'] ) || ! isset( $feed['parser'] ) ) {
+						continue;
 					}
-					$available_feeds[ $link_url ] = array_merge( $available_feeds[ $link_url ], $feed );
-					$available_feeds[ $link_url ]['url'] = $link_url;
+				} else {
+					$available_feeds[ $link_url ] = array();
 				}
+				$available_feeds[ $link_url ] = array_merge( $available_feeds[ $link_url ], $feed );
+				$available_feeds[ $link_url ]['url'] = $link_url;
 			}
 		}
 


### PR DESCRIPTION
Fixes #376.

The problem was that we first try to request the "feed url" without an `Accept: application/activity+json` header. Following action was dependent on this request working. We now try ActivityPub even if that fails.

![Screenshot 2024-10-18 at 14 39 44](https://github.com/user-attachments/assets/1af2abc9-c9f9-494c-bf73-77d5a5c50cdc)
