### PR TITLE
Fix Warning:  Undefined variable $account

### DIFF
--- a/feed-parsers/class-feed-parser-activitypub.php
+++ b/feed-parsers/class-feed-parser-activitypub.php
@@ -267,6 +267,7 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 			return $status;
 		}
 
+		$account = false;
 		$meta = get_post_meta( $post_id, self::SLUG, true );
 		if ( isset( $meta['attributedTo']['id'] ) && $meta['attributedTo']['id'] ) {
 			if ( isset( $meta['reblog'] ) && $meta['reblog'] ) {


### PR DESCRIPTION
Fixes warning reported in https://wordpress.org/support/topic/accounts-is-undefined/

```PHP message: PHP Warning:  Undefined variable $account in /mnt/wordpress/wp-content/plugins/friends/feed-parsers/class-feed-parser-activitypub.php on line 314; PHP message: PHP Warning:  Undefined variable $account in /mnt/wordpress/wp-content/plugins/friends/feed-parsers/class-feed-parser-activitypub.php on line 314
```

props [teledyn](https://radio.teledyn.com/blog/)