### PR TITLE
Fix next page articles attached in the wrong place

### DIFF
--- a/friends.js
+++ b/friends.js
@@ -438,9 +438,7 @@
 					'section.posts .posts-navigation .nav-previous'
 				).removeClass( 'loading' );
 				if ( newPosts ) {
-					$( 'section.posts' )
-						.find( 'article:last-of-type' )
-						.after( newPosts );
+					$( 'section.posts > article' ).last().after( newPosts );
 					if (
 						++friends.current_page < friends.max_page &&
 						/<article/.test( newPosts )


### PR DESCRIPTION
When a post on the current page contains an `<article>` itself, the lazy-loaded next articles were attached in the wrong place.
