### PR TITLE
Allow an extra redirect when discovering feeds

### DIFF
--- a/includes/class-feed.php
+++ b/includes/class-feed.php
@@ -843,7 +843,7 @@ class Feed {
 			$url,
 			array(
 				'timeout'     => apply_filters( 'friends_http_timeout', 20 ),
-				'redirection' => 1,
+				'redirection' => 2,
 			)
 		);
 


### PR DESCRIPTION
This is necessary for brid.gy, see https://github.com/snarfed/bridgy-fed/issues/1493 and https://wordpress.org/support/topic/attempting-to-follow-bridgyfed-the-fediverse-bluesky-bridge-fails/

cc @solarbirdy
