### PR TITLE
Make tagged Friend Posts accessible

### DIFF
--- a/feed-parsers/class-feed-parser-activitypub.php
+++ b/feed-parsers/class-feed-parser-activitypub.php
@@ -1583,15 +1583,17 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 			if ( ! $processor->get_attribute( 'href' ) ) {
 				continue;
 			}
-			if ( ! $processor->get_attribute( 'class' ) || false === strpos( $processor->get_attribute( 'class' ), 'hashtag' ) ) {
+			if ( ! $processor->get_attribute( 'class' ) || false === strpos( $processor->get_attribute( 'class' ), 'tag' ) ) {
 				// Also consider URLs that contain the word hashtag like https://twitter.com/hashtag/WordPress.
 				if ( false === strpos( $processor->get_attribute( 'href' ), '/hashtag/' ) ) {
 					continue;
 				}
 			}
-			$path_parts = explode( '/', wp_parse_url( $processor->get_attribute( 'href' ), PHP_URL_PATH ) );
+			$href = $processor->get_attribute( 'href' );
+			$path_parts = explode( '/', rtrim( wp_parse_url( $href, PHP_URL_PATH ), '/' ) );
 			$tag = array_pop( $path_parts );
 			$processor->set_attribute( 'href', '/friends/tag/' . sanitize_title_with_dashes( $tag ) . '/' );
+			$processor->set_attribute( 'original-href', $href );
 		}
 
 		$the_content = $processor->get_updated_html();

--- a/feed-parsers/class-feed-parser-activitypub.php
+++ b/feed-parsers/class-feed-parser-activitypub.php
@@ -1577,6 +1577,25 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 
 		$the_content = str_replace( array_keys( $protected_tags ), array_values( $protected_tags ), $the_content );
 
+		// replace all links in <a href="mention hashtag"> with /friends/tag/tagname using the WP_HTML_Tag_Processor.
+		$processor = new \WP_HTML_Tag_Processor( $the_content );
+		while ( $processor->next_tag( array( 'tag_name' => 'a' ) ) ) {
+			if ( ! $processor->get_attribute( 'href' ) ) {
+				continue;
+			}
+			if ( ! $processor->get_attribute( 'class' ) || false === strpos( $processor->get_attribute( 'class' ), 'hashtag' ) ) {
+				// Also consider URLs that contain the word hashtag like https://twitter.com/hashtag/WordPress.
+				if ( false === strpos( $processor->get_attribute( 'href' ), '/hashtag/' ) ) {
+					continue;
+				}
+			}
+			$path_parts = explode( '/', wp_parse_url( $processor->get_attribute( 'href' ), PHP_URL_PATH ) );
+			$tag = array_pop( $path_parts );
+			$processor->set_attribute( 'href', '/friends/tag/' . sanitize_title_with_dashes( $tag ) . '/' );
+		}
+
+		$the_content = $processor->get_updated_html();
+
 		return $the_content;
 	}
 

--- a/includes/class-friends.php
+++ b/includes/class-friends.php
@@ -1175,6 +1175,35 @@ class Friends {
 		return $tax_query;
 	}
 
+	public function wp_query_get_post_tag_tax_query( $tax_query, $filter_by_post_tag ) {
+		if ( empty( $filter_by_post_tag ) ) {
+			return $tax_query;
+		}
+
+		if ( ! is_array( $filter_by_post_tag ) ) {
+			$filter_by_post_tag = array( $filter_by_post_tag );
+		}
+
+		if ( ! empty( $tax_query ) ) {
+			$tax_query['relation'] = 'AND';
+		}
+		$post_tag_query = array(
+			'taxonomy' => 'post_tag',
+			'field'    => 'slug',
+			'operator' => 'IN',
+			'terms'    => $filter_by_post_tag,
+		);
+
+		if ( ! empty( $tax_query ) ) {
+			$tax_query[] = $post_tag_query;
+		} else {
+			$tax_query = array( $post_tag_query );
+		}
+
+		return $tax_query;
+	}
+
+
 	/**
 	 * Plural texts for post formats.
 	 *

--- a/includes/class-frontend.php
+++ b/includes/class-frontend.php
@@ -125,6 +125,7 @@ class Frontend {
 		add_action( 'the_post', array( $this, 'the_post' ), 10, 2 );
 		add_action( 'parse_query', array( $this, 'parse_query' ) );
 		add_filter( 'body_class', array( $this, 'add_body_class' ) );
+		add_filter( 'tag_row_actions', array( $this, 'tag_row_actions' ), 10, 2 );
 
 		add_filter( 'friends_override_author_name', array( $this, 'override_author_name' ), 10, 3 );
 		add_filter( 'friends_friend_posts_query_viewable', array( $this, 'expose_opml' ), 10, 2 );
@@ -365,6 +366,16 @@ class Frontend {
 
 		return $classes;
 	}
+
+	public function tag_row_actions( $actions, $tag ) {
+		$actions['view-friends'] = sprintf(
+			'<a href="%s">%s</a>',
+			esc_url( home_url( '/friends/tag/' . $tag->name ) ),
+			__( 'View on your Friends page', 'friends' )
+		);
+		return $actions;
+	}
+
 
 	/**
 	 * Gets the minimal query variables.

--- a/includes/class-frontend.php
+++ b/includes/class-frontend.php
@@ -1409,6 +1409,11 @@ class Frontend {
 					}
 					break;
 
+				case 'tag':
+					$post_tag = array_shift( $pagename_parts );
+					$tax_query = $this->friends->wp_query_get_post_tag_tax_query( $tax_query, $post_tag );
+					break;
+
 				default: // Maybe an author.
 					$author = User::get_by_username( $current_part );
 					if ( false === $author || is_wp_error( $author ) ) {

--- a/includes/class-frontend.php
+++ b/includes/class-frontend.php
@@ -40,6 +40,13 @@ class Frontend {
 	public $author = false;
 
 	/**
+	 * Whether an tag is being displayed
+	 *
+	 * @var object|false
+	 */
+	public $tag = false;
+
+	/**
 	 * Whether a post-format is being displayed
 	 *
 	 * @var string|false
@@ -1410,8 +1417,14 @@ class Frontend {
 					break;
 
 				case 'tag':
-					$post_tag = array_shift( $pagename_parts );
-					$tax_query = $this->friends->wp_query_get_post_tag_tax_query( $tax_query, $post_tag );
+					if ( empty( $pagename_parts ) && $page_id ) {
+						// Support numeric tags.
+						$this->tag = strval( $page_id );
+						$page_id = false;
+					} else {
+						$this->tag = array_shift( $pagename_parts );
+					}
+					$tax_query = $this->friends->wp_query_get_post_tag_tax_query( $tax_query, $this->tag );
 					break;
 
 				default: // Maybe an author.
@@ -1476,9 +1489,12 @@ class Frontend {
 			$query->set( 'page_id', $page_id );
 			if ( ! $this->author ) {
 				$post = get_post( $page_id );
-				$author = User::get_post_author( $post );
-				if ( false !== $author ) {
-					$this->author = $author;
+
+				if ( $post ) {
+					$author = User::get_post_author( $post );
+					if ( false !== $author ) {
+						$this->author = $author;
+					}
 				}
 			}
 			$query->is_single = true;

--- a/templates/frontend/main-feed-header.php
+++ b/templates/frontend/main-feed-header.php
@@ -63,6 +63,15 @@ if ( $args['friends']->frontend->reaction ) {
 			$_title
 		)
 	);
+} elseif ( $args['friends']->frontend->tag ) {
+	echo esc_html(
+		sprintf(
+		// translators: %1$s is a hash tag, %2$s is a type of feed, e.g. "Main Feed".
+			_x( '#%1$s on %2$s', '#tag on feed', 'friends' ),
+			$args['friends']->frontend->tag,
+			$_title
+		)
+	);
 } else {
 	echo esc_html( $_title );
 }


### PR DESCRIPTION
Fixes #418. You can now view tags on the frontend with URLs like `/friends/tag/<tagname>`:

![Screenshot 2024-12-20 at 10 00 59](https://github.com/user-attachments/assets/2316deef-58ec-4a27-be6b-0f097612307b)

Links in Friend posts on the front end are rewritten (intended mainly for Mastodon and Twitter links but it also works for WordPress links with the class `tag`):
![Screenshot 2024-12-20 at 10 05 49](https://github.com/user-attachments/assets/5b20bc4d-6dc9-49fc-84e3-04ab67a514b6)

![Screenshot 2024-12-20 at 10 01 25](https://github.com/user-attachments/assets/b8d672a2-3853-42e2-b313-093657e854bd)

