### PR TITLE
Add support for ActivityPub Move activity

### DIFF
--- a/includes/class-user.php
+++ b/includes/class-user.php
@@ -388,7 +388,7 @@ class User extends \WP_User {
 	/**
 	 * Save multiple feeds for a user.
 	 *
-	 * @param      string $feeds  The feed URLs to subscribe to.
+	 * @param      array $feeds  The feed URLs to subscribe to.
 	 *
 	 * @return     array(\WP_Term)|\WP_error  $user The new associated user or an error object.
 	 */

--- a/tests/test-activitypub.php
+++ b/tests/test-activitypub.php
@@ -463,4 +463,31 @@ class ActivityPubTest extends Friends_TestCase_Cache_HTTP {
 
 		return $actors;
 	}
+
+	public function test_incoming_move() {
+		$new_url = 'https://example.com/new_url';
+
+		$request = new \WP_REST_Request( 'POST', '/activitypub/1.0/users/' . get_current_user_id() . '/inbox' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'type'   => 'Move',
+					'id'     => $this->actor . '/move',
+					'actor'  => $this->actor,
+					'object'  => $this->actor,
+					'target' => $new_url,
+				)
+			)
+		);
+		$request->set_header( 'Content-type', 'application/json' );
+
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 202, $response->get_status() );
+
+		$old_user_feed = User_Feed::get_by_url( $this->actor );
+		$this->assertTrue( is_wp_error( $old_user_feed ) );
+
+		$new_user_feed = User_Feed::get_by_url( $new_url );
+		$this->assertInstanceof( 'Friends\User_Feed', $new_user_feed );
+	}
 }


### PR DESCRIPTION
When we receive a Move for an existing feed, we'll update their feed URL.