### PR TITLE
Incoming Feed Items: Fix in-article hash links

### DIFF
--- a/feed-parsers/class-feed-parser-simplepie.php
+++ b/feed-parsers/class-feed-parser-simplepie.php
@@ -293,7 +293,7 @@ class Feed_Parser_SimplePie extends Feed_Parser_V2 {
 				array(
 					'permalink' => $item->get_permalink(),
 					'title'     => $title,
-					'content'   => $this->convert_relative_urls_to_absolute_urls( $item->get_content(), $url, $item->get_permalink() ),
+					'content'   => $this->convert_relative_urls_to_absolute_urls( $item->get_content(), $item->get_permalink() ),
 				)
 			);
 

--- a/feed-parsers/class-feed-parser-simplepie.php
+++ b/feed-parsers/class-feed-parser-simplepie.php
@@ -347,7 +347,10 @@ class Feed_Parser_SimplePie extends Feed_Parser_V2 {
 			}
 
 			if ( is_object( $item->get_author() ) ) {
-				$feed_item->author = \wp_strip_all_tags( $item->get_author()->name );
+				$feed_item->author = $item->get_author()->name;
+				// Strip HTML tags, even if they are escaped.
+				$feed_item->author = htmlspecialchars_decode( $feed_item->author, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 );
+				$feed_item->author = \wp_strip_all_tags( $feed_item->author );
 			}
 
 			$feed_item->date         = $item->get_gmdate( 'U' );

--- a/feed-parsers/class-feed-parser-simplepie.php
+++ b/feed-parsers/class-feed-parser-simplepie.php
@@ -293,7 +293,7 @@ class Feed_Parser_SimplePie extends Feed_Parser_V2 {
 				array(
 					'permalink' => $item->get_permalink(),
 					'title'     => $title,
-					'content'   => $this->convert_relative_urls_to_absolute_urls( $item->get_content(), $url ),
+					'content'   => $this->convert_relative_urls_to_absolute_urls( $item->get_content(), $url, $item->get_permalink() ),
 				)
 			);
 

--- a/feed-parsers/class-feed-parser.php
+++ b/feed-parsers/class-feed-parser.php
@@ -79,17 +79,29 @@ abstract class Feed_Parser {
 	 *
 	 * @param      string $html   The html.
 	 * @param      string $url    The url of the feed.
+	 * @param      string $permalink  The permalink of the feed.
 	 *
 	 * @return     string  The HTML with URLs replaced to their absolute represenation.
 	 */
-	public function convert_relative_urls_to_absolute_urls( $html, $url ) {
+	public function convert_relative_urls_to_absolute_urls( $html, $url, $permalink ) {
 		if ( ! $html ) {
 			$html = '';
 		}
+		$permalink = strtok( $permalink, '#' );
 		// For now this only converts links and image srcs.
 		return preg_replace_callback(
 			'~(src|href)=(?:"([^"]+)|\'([^\']+))~i',
-			function ( $m ) use ( $url ) {
+			function ( $m ) use ( $url, $permalink ) {
+				if ( str_starts_with( $m[2], '#' ) ) {
+					// Don't update hash-only links.
+					return $m[0];
+				}
+
+				if ( str_starts_with( $m[2], $permalink . '#' ) ) {
+					// Remove absolute URL from hashes.
+					return str_replace( $permalink, '', $m[0] );
+				}
+
 				return str_replace( $m[2], Mf2\resolveUrl( $url, $m[2] ), $m[0] );
 			},
 			$html

--- a/feed-parsers/class-feed-parser.php
+++ b/feed-parsers/class-feed-parser.php
@@ -78,20 +78,22 @@ abstract class Feed_Parser {
 	 * Convert relative URLs to absolute ones in incoming content.
 	 *
 	 * @param      string $html   The html.
-	 * @param      string $url    The url of the feed.
 	 * @param      string $permalink  The permalink of the feed.
 	 *
 	 * @return     string  The HTML with URLs replaced to their absolute represenation.
 	 */
-	public function convert_relative_urls_to_absolute_urls( $html, $url, $permalink ) {
+	public function convert_relative_urls_to_absolute_urls( $html, $permalink ) {
 		if ( ! $html ) {
 			$html = '';
 		}
+
+		// Strip off the hash.
 		$permalink = strtok( $permalink, '#' );
+
 		// For now this only converts links and image srcs.
 		return preg_replace_callback(
 			'~(src|href)=(?:"([^"]+)|\'([^\']+))~i',
-			function ( $m ) use ( $url, $permalink ) {
+			function ( $m ) use ( $permalink ) {
 				if ( str_starts_with( $m[2], '#' ) ) {
 					// Don't update hash-only links.
 					return $m[0];
@@ -102,7 +104,8 @@ abstract class Feed_Parser {
 					return str_replace( $permalink, '', $m[0] );
 				}
 
-				return str_replace( $m[2], Mf2\resolveUrl( $url, $m[2] ), $m[0] );
+				// Convert relative URLs to absolute ones.
+				return str_replace( $m[2], Mf2\resolveUrl( $permalink, $m[2] ), $m[0] );
 			},
 			$html
 		);


### PR DESCRIPTION
When an article contains an absolute hashed link to the current article, this link would be wrong inside the friends page or notification e-mails, so we'll make it relative again.