### PR TITLE
At A Glance messaging: ensure numbers are correctly displayed

### DIFF
--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -3444,7 +3444,7 @@ class Admin {
 
 		if ( $friend_post_count ) {
 			// translators: %s is the number of friend posts.
-			$items[] = '<a class="friend-posts" href="' . home_url( '/friends/' ) . '">' . sprintf( _n( '%s Post by Friends', '%s Posts by Friends', $friend_post_count, 'friends' ), $friend_post_count ) . '</a>';
+			$items[] = '<a class="friend-posts" href="' . home_url( '/friends/' ) . '">' . sprintf( _n( '%s Post by Friends', '%s Posts by Friends', $friend_post_count, 'friends' ), number_format_i18n( $friend_post_count ) ) . '</a>';
 		}
 		return $items;
 	}


### PR DESCRIPTION
Since the number of posts by friends can become quite high, it's important that such a high number be properly displayed for each locale.