### PR TITLE
Don't double fetch URL for boosting

### DIFF
--- a/feed-parsers/class-feed-parser-activitypub.php
+++ b/feed-parsers/class-feed-parser-activitypub.php
@@ -1676,7 +1676,6 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 			);
 			return;
 		}
-		$post_id = $this->cache_url( $url );
 
 		$user = User::get_post_author( get_post( $post_id ) );
 		wp_safe_redirect( $user->get_local_friends_page_url( $post_id ) . $append_to_redirect );


### PR DESCRIPTION
Fixes #460.

No idea why I had the cache_url twice. But because the result of `url_to_postid` is cached, if we try to retrieve it twice inside the same request it will fail.