### PR TITLE
Use Outbox of ActivityPub 5.3.0

### DIFF
--- a/feed-parsers/class-feed-parser-activitypub.php
+++ b/feed-parsers/class-feed-parser-activitypub.php
@@ -2301,7 +2301,7 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 	 * @param      id     $user_id  The user id.
 	 */
 	public function activitypub_announce( $url, $user_id ) {
-		ActivityPub\add_to_outbox( $url, 'Announce', $user_id, ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC );
+		\Activitypub\add_to_outbox( $url, 'Announce', $user_id, ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC );
 	}
 
 	/**
@@ -2311,11 +2311,11 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 	 * @param      id     $user_id  The user id.
 	 */
 	public function activitypub_unannounce( $url, $user_id ) {
-		ActivityPub\add_to_outbox(
-			array(
-				'type'   => 'Announce',
-				'object' => $url,
-			),
+		$transformer = \Activitypub\Transformer\Factory::get_transformer( 'https://alex.kirk.at/' )->to_object();
+		$activity_object = $transformer->to_object();
+
+		\Activitypub\add_to_outbox(
+			$activity_object,
 			'Undo',
 			$user_id,
 			ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC

--- a/feed-parsers/class-feed-parser-activitypub.php
+++ b/feed-parsers/class-feed-parser-activitypub.php
@@ -1923,7 +1923,7 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 	}
 
 	/**
-	 * Prepare to follow the user via a scheduled event.
+	 * Prepare to like the post via a scheduled event.
 	 *
 	 * @param      \WP_Post $post       The post.
 	 * @param      string   $author_url  The author url.
@@ -1935,12 +1935,31 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 		if ( ! $external_post_id ) {
 			$external_post_id = $post->guid;
 		}
+		$user_feed = User_Feed::get_by_url( $author_url );
+		if ( version_compare( ACTIVITYPUB_PLUGIN_VERSION, '5.3.0', '>=' ) ) {
+			$outbox_activity_id = \Activitypub\add_to_outbox( $external_post_id, 'Like', get_current_user_id(), ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC );
+			if ( ! $outbox_activity_id ) {
+				if ( $user_feed instanceof User_Feed ) {
+					$user_feed->update_last_log( __( 'Like failed.', 'friends' ) );
+				}
+				return false;
+			}
+			if ( $user_feed instanceof User_Feed ) {
+				$user_feed->update_last_log( __( 'Sent like.', 'friends' ) );
+			}
+			update_post_meta( $post->ID, 'ap_outbox_like_id', $outbox_activity_id );
+			return true;
+		}
 
 		$queued = $this->queue(
 			'friends_feed_parser_activitypub_like',
 			array( $author_url, $external_post_id, get_current_user_id() ),
 			'friends_feed_parser_activitypub_unlike'
 		);
+
+		if ( $queued && $user_feed instanceof User_Feed ) {
+			$user_feed->update_last_log( __( 'Queued like request.', 'friends' ) );
+		}
 
 		return $queued;
 	}
@@ -1967,8 +1986,14 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 		$activity->set_id( $actor . '#like-' . \preg_replace( '~^https?://~', '', $external_post_id ) );
 		$activity->set_published( \gmdate( 'Y-m-d\TH:i:s\Z', time() ) );
 
-		$inboxes = apply_filters( 'activitypub_send_to_inboxes', array(), $user_id, $activity );
-		$inboxes = array_unique( $inboxes );
+		$json = $activity->to_json();
+
+		if ( version_compare( ACTIVITYPUB_PLUGIN_VERSION, '5.2.0', '>=' ) ) {
+			$inboxes = \Activitypub\Followers::get_inboxes_for_activity( $json, $actor->get__id(), 500 );
+		} else {
+			$inboxes = apply_filters( 'activitypub_send_to_inboxes', array(), $user_id, $activity );
+			$inboxes = array_unique( $inboxes );
+		}
 
 		if ( empty( $inboxes ) ) {
 			$message = sprintf(
@@ -1985,8 +2010,6 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 			Logging::log( 'like-failed', $message, $details, self::SLUG, $user_id );
 			return;
 		}
-
-		$json = $activity->to_json();
 
 		$report = array();
 		foreach ( $inboxes as $inbox ) {
@@ -2049,18 +2072,29 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 		if ( ! $external_post_id ) {
 			$external_post_id = $post->guid;
 		}
-
+		$user_feed = User_Feed::get_by_url( $author_url );
+		if ( version_compare( ACTIVITYPUB_PLUGIN_VERSION, '5.3.0', '>=' ) ) {
+			$outbox_activity_id = get_post_meta( $post->ID, 'ap_outbox_like_id', true );
+			if ( ! $outbox_activity_id ) {
+				if ( $user_feed instanceof User_Feed ) {
+					$user_feed->update_last_log( __( 'Unlike failed.', 'friends' ) );
+				}
+				return false;
+			}
+			if ( $user_feed instanceof User_Feed ) {
+				$user_feed->update_last_log( __( 'Sent unlike request.', 'friends' ) );
+			}
+			\Activitypub\Outbox::undo( $outbox_activity_id );
+			return true;
+		}
 		$queued = $this->queue(
 			'friends_feed_parser_activitypub_unlike',
 			array( $author_url, $external_post_id, get_current_user_id() ),
 			'friends_feed_parser_activitypub_like'
 		);
 
-		if ( $queued ) {
-			$user_feed = User_Feed::get_by_url( $author_url );
-			if ( $user_feed instanceof User_Feed ) {
-				$user_feed->update_last_log( __( 'Queued unlike request.', 'friends' ) );
-			}
+		if ( $queued && $user_feed instanceof User_Feed ) {
+			$user_feed->update_last_log( __( 'Queued unlike request.', 'friends' ) );
 		}
 
 		return $queued;
@@ -2094,8 +2128,13 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 		);
 		$activity->set_id( $actor . '#unlike-' . \preg_replace( '~^https?://~', '', $external_post_id ) );
 
-		$inboxes = apply_filters( 'activitypub_send_to_inboxes', array(), $user_id, $activity );
-		$inboxes = array_unique( $inboxes );
+		$json = $activity->to_json();
+		if ( version_compare( ACTIVITYPUB_PLUGIN_VERSION, '5.2.0', '>=' ) ) {
+			$inboxes = \Activitypub\Followers::get_inboxes_for_activity( $json, $actor->get__id(), 500 );
+		} else {
+			$inboxes = apply_filters( 'activitypub_send_to_inboxes', array(), $user_id, $activity );
+			$inboxes = array_unique( $inboxes );
+		}
 
 		if ( empty( $inboxes ) ) {
 			$message = sprintf(
@@ -2112,8 +2151,6 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 			Logging::log( 'unlike-failed', $message, $details, self::SLUG, $user_id );
 			return;
 		}
-
-		$json = $activity->to_json();
 
 		$report = array();
 		foreach ( $inboxes as $inbox ) {
@@ -2244,11 +2281,11 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 	}
 
 	public function mastodon_api_reblog( $post_id ) {
-		$this->queue_announce( get_permalink( $post_id ) );
+		$this->queue_announce( get_post( $post_id ) );
 	}
 
 	public function mastodon_api_unreblog( $post_id ) {
-		$this->queue_unannounce( get_permalink( $post_id ) );
+		$this->queue_unannounce( get_post( $post_id ) );
 	}
 
 	/**
@@ -2274,7 +2311,7 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 			return $ret;
 		}
 		if ( User_Feed::get_parser_for_post_id( $post->ID ) === 'activitypub' ) {
-			$this->queue_announce( $post->guid );
+			$this->queue_announce( $post );
 			\update_post_meta( $post->ID, 'reblogged', 'activitypub' );
 			\update_post_meta( $post->ID, 'reblogged_by', get_current_user_id() );
 			return true;
@@ -2288,7 +2325,7 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 			return $ret;
 		}
 		if ( get_post_meta( $post->ID, 'reblogged', true ) === 'activitypub' ) {
-			$this->queue_unannounce( $post->guid );
+			$this->queue_unannounce( $post );
 			\delete_post_meta( $post->ID, 'reblogged', 'activitypub' );
 			\delete_post_meta( $post->ID, 'reblogged_by', get_current_user_id() );
 			return true;
@@ -2299,11 +2336,20 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 	/**
 	 * Prepare to announce the post via a scheduled event.
 	 *
-	 * @param      string $url  The url to announce.
+	 * @param      \WP_Post $post  The post.
 	 *
 	 * @return     bool|WP_Error              Whether the event was queued.
 	 */
-	public function queue_announce( $url ) {
+	public function queue_announce( \WP_Post $post ) {
+		$url = get_permalink( $post );
+		if ( version_compare( ACTIVITYPUB_PLUGIN_VERSION, '5.3.0', '>=' ) ) {
+			$outbox_activity_id = \Activitypub\add_to_outbox( $url, 'Announce', get_current_user_id(), ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC );
+			if ( ! $outbox_activity_id ) {
+				return false;
+			}
+			update_post_meta( $post->ID, 'ap_outbox_announce_id', $outbox_activity_id );
+			return true;
+		}
 		$queued = $this->queue(
 			'friends_feed_parser_activitypub_announce',
 			array( $url, get_current_user_id() ),
@@ -2331,8 +2377,13 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 		$activity->set_to( array( 'https://www.w3.org/ns/activitystreams#Public' ) );
 		$activity->set_published( \gmdate( 'Y-m-d\TH:i:s\Z', time() ) );
 
-		$inboxes = apply_filters( 'activitypub_send_to_inboxes', array(), $user_id, $activity );
-		$inboxes = array_unique( $inboxes );
+		$json = $activity->to_json();
+		if ( version_compare( ACTIVITYPUB_PLUGIN_VERSION, '5.2.0', '>=' ) ) {
+			$inboxes = \Activitypub\Followers::get_inboxes_for_activity( $json, $actor->get__id(), 500 );
+		} else {
+			$inboxes = apply_filters( 'activitypub_send_to_inboxes', array(), $user_id, $activity );
+			$inboxes = array_unique( $inboxes );
+		}
 
 		if ( empty( $inboxes ) ) {
 			$message = sprintf(
@@ -2350,7 +2401,6 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 			return;
 		}
 
-		$json = $activity->to_json();
 		$report = array();
 		foreach ( $inboxes as $inbox ) {
 			$response = \Activitypub\safe_remote_post( $inbox, $json, $user_id );
@@ -2374,11 +2424,20 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 	/**
 	 * Prepare to announce the post via a scheduled event.
 	 *
-	 * @param      string $url  The url to announce.
+	 * @param      \WP_Post $post  The post.
 	 *
 	 * @return     bool|WP_Error              Whether the event was queued.
 	 */
-	public function queue_unannounce( $url ) {
+	public function queue_unannounce( \WP_Post $post ) {
+		$url = get_permalink( $post );
+		if ( version_compare( ACTIVITYPUB_PLUGIN_VERSION, '5.3.0', '>=' ) ) {
+			$outbox_activity_id = get_post_meta( $post->ID, 'ap_outbox_announce_id', true );
+			if ( ! $outbox_activity_id ) {
+				return false;
+			}
+			\Activitypub\Outbox::undo( $outbox_activity_id );
+			return true;
+		}
 		$queued = $this->queue(
 			'friends_feed_parser_activitypub_unannounce',
 			array( $url, get_current_user_id() ),
@@ -2414,8 +2473,13 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 		);
 		$activity->set_published( \gmdate( 'Y-m-d\TH:i:s\Z', time() ) );
 
-		$inboxes = apply_filters( 'activitypub_send_to_inboxes', array(), $user_id, $activity );
-		$inboxes = array_unique( $inboxes );
+		$json = $activity->to_json();
+		if ( version_compare( ACTIVITYPUB_PLUGIN_VERSION, '5.2.0', '>=' ) ) {
+			$inboxes = \Activitypub\Followers::get_inboxes_for_activity( $json, $actor->get__id(), 500 );
+		} else {
+			$inboxes = apply_filters( 'activitypub_send_to_inboxes', array(), $user_id, $activity );
+			$inboxes = array_unique( $inboxes );
+		}
 
 		if ( empty( $inboxes ) ) {
 			$message = sprintf(
@@ -2432,8 +2496,6 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 			Logging::log( 'unannounce-failed', $message, $details, self::SLUG, $user_id );
 			return;
 		}
-
-		$json = $activity->to_json();
 
 		$report = array();
 		foreach ( $inboxes as $inbox ) {

--- a/feed-parsers/class-feed-parser-activitypub.php
+++ b/feed-parsers/class-feed-parser-activitypub.php
@@ -1989,7 +1989,7 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 		$json = $activity->to_json();
 
 		if ( version_compare( ACTIVITYPUB_PLUGIN_VERSION, '5.2.0', '>=' ) ) {
-			$inboxes = \Activitypub\Followers::get_inboxes_for_activity( $json, $actor->get__id(), 500 );
+			$inboxes = \Activitypub\Collection\Followers::get_inboxes_for_activity( $json, $actor->get__id(), 500 );
 		} else {
 			$inboxes = apply_filters( 'activitypub_send_to_inboxes', array(), $user_id, $activity );
 			$inboxes = array_unique( $inboxes );
@@ -2130,7 +2130,7 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 
 		$json = $activity->to_json();
 		if ( version_compare( ACTIVITYPUB_PLUGIN_VERSION, '5.2.0', '>=' ) ) {
-			$inboxes = \Activitypub\Followers::get_inboxes_for_activity( $json, $actor->get__id(), 500 );
+			$inboxes = \Activitypub\Collection\Followers::get_inboxes_for_activity( $json, $actor->get__id(), 500 );
 		} else {
 			$inboxes = apply_filters( 'activitypub_send_to_inboxes', array(), $user_id, $activity );
 			$inboxes = array_unique( $inboxes );
@@ -2379,7 +2379,7 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 
 		$json = $activity->to_json();
 		if ( version_compare( ACTIVITYPUB_PLUGIN_VERSION, '5.2.0', '>=' ) ) {
-			$inboxes = \Activitypub\Followers::get_inboxes_for_activity( $json, $actor->get__id(), 500 );
+			$inboxes = \Activitypub\Collection\Followers::get_inboxes_for_activity( $json, $actor->get__id(), 500 );
 		} else {
 			$inboxes = apply_filters( 'activitypub_send_to_inboxes', array(), $user_id, $activity );
 			$inboxes = array_unique( $inboxes );
@@ -2475,7 +2475,7 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 
 		$json = $activity->to_json();
 		if ( version_compare( ACTIVITYPUB_PLUGIN_VERSION, '5.2.0', '>=' ) ) {
-			$inboxes = \Activitypub\Followers::get_inboxes_for_activity( $json, $actor->get__id(), 500 );
+			$inboxes = \Activitypub\Collection\Followers::get_inboxes_for_activity( $json, $actor->get__id(), 500 );
 		} else {
 			$inboxes = apply_filters( 'activitypub_send_to_inboxes', array(), $user_id, $activity );
 			$inboxes = array_unique( $inboxes );

--- a/feed-parsers/class-feed-parser-activitypub.php
+++ b/feed-parsers/class-feed-parser-activitypub.php
@@ -58,8 +58,6 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 		\add_action( 'friends_feed_parser_activitypub_unfollow', array( $this, 'activitypub_unfollow_user' ), 10, 2 );
 		\add_action( 'friends_feed_parser_activitypub_like', array( $this, 'activitypub_like_post' ), 10, 3 );
 		\add_action( 'friends_feed_parser_activitypub_unlike', array( $this, 'activitypub_unlike_post' ), 10, 3 );
-		\add_action( 'friends_feed_parser_activitypub_announce', array( $this, 'activitypub_announce' ), 10, 2 );
-		\add_action( 'friends_feed_parser_activitypub_unannounce', array( $this, 'activitypub_unannounce' ), 10, 2 );
 		\add_filter( 'friends_rewrite_incoming_url', array( get_called_class(), 'friends_webfinger_resolve' ), 10, 2 );
 
 		\add_filter( 'friends_edit_feeds_table_end', array( $this, 'activitypub_settings' ), 10 );
@@ -2244,11 +2242,11 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 	}
 
 	public function mastodon_api_reblog( $post_id ) {
-		$this->queue_announce( get_permalink( $post_id ) );
+		return $this->activitypub_announce( get_permalink( $post_id ), get_current_user_id() );
 	}
 
 	public function mastodon_api_unreblog( $post_id ) {
-		$this->queue_unannounce( get_permalink( $post_id ) );
+		return $this->activitypub_unannounce( get_permalink( $post_id ), get_current_user_id() );
 	}
 
 	/**
@@ -2274,7 +2272,7 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 			return $ret;
 		}
 		if ( User_Feed::get_parser_for_post_id( $post->ID ) === 'activitypub' ) {
-			$this->queue_announce( $post->guid );
+			$this->activitypub_announce( $post->guid );
 			\update_post_meta( $post->ID, 'reblogged', 'activitypub' );
 			\update_post_meta( $post->ID, 'reblogged_by', get_current_user_id() );
 			return true;
@@ -2288,29 +2286,12 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 			return $ret;
 		}
 		if ( get_post_meta( $post->ID, 'reblogged', true ) === 'activitypub' ) {
-			$this->queue_unannounce( $post->guid );
+			$this->activitypub_unannounce( $post->guid );
 			\delete_post_meta( $post->ID, 'reblogged', 'activitypub' );
 			\delete_post_meta( $post->ID, 'reblogged_by', get_current_user_id() );
 			return true;
 		}
 		return $ret;
-	}
-
-	/**
-	 * Prepare to announce the post via a scheduled event.
-	 *
-	 * @param      string $url  The url to announce.
-	 *
-	 * @return     bool|WP_Error              Whether the event was queued.
-	 */
-	public function queue_announce( $url ) {
-		$queued = $this->queue(
-			'friends_feed_parser_activitypub_announce',
-			array( $url, get_current_user_id() ),
-			'friends_feed_parser_activitypub_unannounce'
-		);
-
-		return $queued;
 	}
 
 	/**
@@ -2320,72 +2301,7 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 	 * @param      id     $user_id  The user id.
 	 */
 	public function activitypub_announce( $url, $user_id ) {
-		$user_id = $this->get_activitypub_actor_id( $user_id );
-		$actor = $this->get_activitypub_actor( $user_id );
-
-		$activity = new \Activitypub\Activity\Activity();
-		$activity->set_type( 'Announce' );
-		$activity->set_actor( $actor );
-		$activity->set_object( $url );
-		$activity->set_id( $actor . '#activitypub_announce-' . \preg_replace( '~^https?://~', '', $url ) );
-		$activity->set_to( array( 'https://www.w3.org/ns/activitystreams#Public' ) );
-		$activity->set_published( \gmdate( 'Y-m-d\TH:i:s\Z', time() ) );
-
-		$inboxes = apply_filters( 'activitypub_send_to_inboxes', array(), $user_id, $activity );
-		$inboxes = array_unique( $inboxes );
-
-		if ( empty( $inboxes ) ) {
-			$message = sprintf(
-				// translators: %s is the URL of the post.
-				__( 'Announce failed for %s', 'friends' ),
-				'<a href="' . esc_url( $url ) . '">' . $url . '</a>'
-			);
-
-			$details = array(
-				'url'   => $url,
-				'error' => __( 'No inboxes to send to.', 'friends' ),
-			);
-
-			Logging::log( 'announce-failed', $message, $details, self::SLUG, $user_id );
-			return;
-		}
-
-		$json = $activity->to_json();
-		$report = array();
-		foreach ( $inboxes as $inbox ) {
-			$response = \Activitypub\safe_remote_post( $inbox, $json, $user_id );
-			$report[ $inbox ] = wp_remote_retrieve_response_message( $response );
-		}
-
-		$message = sprintf(
-			// translators: %s is the URL of the post.
-			__( 'Announced %s', 'friends' ),
-			'<a href="' . esc_url( $url ) . '">' . $url . '</a>'
-		);
-
-		$details = array(
-			'url'     => $url,
-			'inboxes' => $report,
-		);
-
-		Logging::log( 'announce', $message, $details, self::SLUG, $user_id );
-	}
-
-	/**
-	 * Prepare to announce the post via a scheduled event.
-	 *
-	 * @param      string $url  The url to announce.
-	 *
-	 * @return     bool|WP_Error              Whether the event was queued.
-	 */
-	public function queue_unannounce( $url ) {
-		$queued = $this->queue(
-			'friends_feed_parser_activitypub_unannounce',
-			array( $url, get_current_user_id() ),
-			'friends_feed_parser_activitypub_announce'
-		);
-
-		return $queued;
+		ActivityPub\add_to_outbox( $url, 'Announce', $user_id, ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC );
 	}
 
 	/**
@@ -2395,64 +2311,15 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 	 * @param      id     $user_id  The user id.
 	 */
 	public function activitypub_unannounce( $url, $user_id ) {
-		$user_id = $this->get_activitypub_actor_id( $user_id );
-		$actor = $this->get_activitypub_actor( $user_id );
-
-		$activity = new \Activitypub\Activity\Activity();
-		$activity->set_type( 'Undo' );
-		$activity->set_to( null );
-		$activity->set_cc( null );
-		$activity->set_actor( $actor );
-		$activity->set_id( $actor . '#activitypub_unannounce-' . \preg_replace( '~^https?://~', '', $url ) );
-		$activity->set_object(
+		ActivityPub\add_to_outbox(
 			array(
 				'type'   => 'Announce',
-				'actor'  => $actor,
 				'object' => $url,
-				'id'     => $actor . '#activitypub_announce-' . \preg_replace( '~^https?://~', '', $url ),
-			)
+			),
+			'Undo',
+			$user_id,
+			ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC
 		);
-		$activity->set_published( \gmdate( 'Y-m-d\TH:i:s\Z', time() ) );
-
-		$inboxes = apply_filters( 'activitypub_send_to_inboxes', array(), $user_id, $activity );
-		$inboxes = array_unique( $inboxes );
-
-		if ( empty( $inboxes ) ) {
-			$message = sprintf(
-				// translators: %s is the URL of the post.
-				__( 'Unannounce failed for %s', 'friends' ),
-				'<a href="' . esc_url( $url ) . '">' . $url . '</a>'
-			);
-
-			$details = array(
-				'url'   => $url,
-				'error' => __( 'No inboxes to send to.', 'friends' ),
-			);
-
-			Logging::log( 'unannounce-failed', $message, $details, self::SLUG, $user_id );
-			return;
-		}
-
-		$json = $activity->to_json();
-
-		$report = array();
-		foreach ( $inboxes as $inbox ) {
-			$response = \Activitypub\safe_remote_post( $inbox, $json, $user_id );
-			$report[ $inbox ] = wp_remote_retrieve_response_message( $response );
-		}
-
-		$message = sprintf(
-			// translators: %s is the URL of the post.
-			__( 'Unannounced %s', 'friends' ),
-			'<a href="' . esc_url( $url ) . '">' . $url . '</a>'
-		);
-
-		$details = array(
-			'url'     => $url,
-			'inboxes' => $report,
-		);
-
-		Logging::log( 'unannounce', $message, $details, self::SLUG, $user_id );
 	}
 
 	/**


### PR DESCRIPTION
We'll be able to use the outbox in ActivityPub 5.3.0 (yet unreleased) since https://github.com/Automattic/wordpress-activitypub/pull/1292 was merged.

This also adds a workaround for the bug in Activitypub 5.2.0 where the `activitypub_send_to_inboxes` would no longer return the follower inboxes. See https://wordpress.org/support/topic/no-boosts-and-likes-possible/

