### PR TITLE
Prepare for the next Enable Mastodon Update

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        php: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
+        php: ["7.2", "7.3", "7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]
 
     name: "Lint: PHP ${{ matrix.php }}"
 
@@ -35,8 +35,8 @@ jobs:
           ini-values: zend.assertions=1, error_reporting=-1, display_errors=On
           coverage: none
 
-      - name: 'Composer: remove PHPUnit (not needed for lint)'
-        run: composer remove phpunit/phpunit --no-update --no-interaction
+      - name: "Composer: remove PHPUnit (not needed for lint)"
+        run: composer remove phpunit/phpunit --dev --no-update --no-interaction
 
       - name: Install Composer dependencies - normal
         uses: "ramsey/composer-install@v2"

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
 		"wp-coding-standards/wpcs": "*",
 		"yoast/phpunit-polyfills": "*",
 		"php-parallel-lint/php-parallel-lint": "^1.3",
-		"phpunit/phpunit": "*",
+		"phpunit/phpunit": "9.*",
 		"akirk/extract-wp-hooks": "*"
 	},
 	"config": {

--- a/feed-parsers/class-feed-parser-activitypub.php
+++ b/feed-parsers/class-feed-parser-activitypub.php
@@ -1067,7 +1067,12 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 				if ( strpos( $attachment['mediaType'], 'image/' ) === 0 ) {
 					$data['content'] .= PHP_EOL;
 					$data['content'] .= '<!-- wp:image -->';
-					$data['content'] .= '<p><img src="' . esc_url( $attachment['url'] ) . '" width="' . esc_attr( $attachment['width'] ) . '"  height="' . esc_attr( $attachment['height'] ) . '" class="size-full" /></p>';
+					$data['content'] .= '<p><img src="' . esc_url( $attachment['url'] ) . '"';
+					if ( isset( $attachment['width'] ) && $attachment['height'] ) {
+						$data['content'] .= ' width="' . esc_attr( $attachment['width'] ) . '"';
+						$data['content'] .= ' height="' . esc_attr( $attachment['height'] ) . '"';
+					}
+					$data['content'] .= ' class="size-full" /></p>';
 					$data['content'] .= '<!-- /wp:image -->';
 				} elseif ( strpos( $attachment['mediaType'], 'video/' ) === 0 ) {
 					$data['content'] .= PHP_EOL;

--- a/includes/class-access-control.php
+++ b/includes/class-access-control.php
@@ -121,7 +121,7 @@ class Access_Control {
 			}
 		}
 
-		if ( ! password_verify( $until . get_user_option( 'friends_out_token', $user_id ), $auth ) ) {
+		if ( ! $auth || ! password_verify( $until . get_user_option( 'friends_out_token', $user_id ), $auth ) ) {
 			return false;
 		}
 

--- a/integrations/class-enable-mastodon-apps.php
+++ b/integrations/class-enable-mastodon-apps.php
@@ -17,12 +17,17 @@ class Enable_Mastodon_Apps {
 		add_filter( 'mastodon_api_get_posts_query_args', array( 'Friends\User', 'mastodon_api_get_posts_query_args' ) );
 		add_filter( 'mastodon_entity_relationship', array( 'Friends\User', 'mastodon_entity_relationship' ), 10, 2 );
 		add_action( 'mastodon_api_account_follow', array( get_called_class(), 'mastodon_api_account_follow' ), 10, 1 );
-		add_filter( 'mastodon_api_timelines_args', array( get_called_class(), 'mastodon_api_view_post_types' ) );
+		add_filter( 'mastodon_api_timelines_args', array( get_called_class(), 'mastodon_api_timelines_args' ) );
 		add_filter( 'mastodon_api_view_post_types', array( get_called_class(), 'mastodon_api_view_post_types' ) );
 	}
 
 	public static function mastodon_api_account_follow( $user_id ) {
 		return apply_filters( 'friends_create_and_follow', null, $user_id );
+	}
+
+	public static function mastodon_api_timelines_args( $args ) {
+		$args['post_type'][] = Friends::CPT;
+		return $args;
 	}
 
 	public static function mastodon_api_view_post_types( $view_post_types ) {

--- a/integrations/class-enable-mastodon-apps.php
+++ b/integrations/class-enable-mastodon-apps.php
@@ -18,6 +18,7 @@ class Enable_Mastodon_Apps {
 		add_filter( 'mastodon_entity_relationship', array( 'Friends\User', 'mastodon_entity_relationship' ), 10, 2 );
 		add_action( 'mastodon_api_account_follow', array( get_called_class(), 'mastodon_api_account_follow' ), 10, 1 );
 		add_filter( 'mastodon_api_timelines_args', array( get_called_class(), 'mastodon_api_timelines_args' ) );
+		add_filter( 'mastodon_api_account_statuses_args', array( get_called_class(), 'mastodon_api_timelines_args' ) );
 		add_filter( 'mastodon_api_view_post_types', array( get_called_class(), 'mastodon_api_view_post_types' ) );
 	}
 

--- a/integrations/class-enable-mastodon-apps.php
+++ b/integrations/class-enable-mastodon-apps.php
@@ -17,15 +17,16 @@ class Enable_Mastodon_Apps {
 		add_filter( 'mastodon_api_get_posts_query_args', array( 'Friends\User', 'mastodon_api_get_posts_query_args' ) );
 		add_filter( 'mastodon_entity_relationship', array( 'Friends\User', 'mastodon_entity_relationship' ), 10, 2 );
 		add_action( 'mastodon_api_account_follow', array( get_called_class(), 'mastodon_api_account_follow' ), 10, 1 );
-		add_filter( 'mastodon_api_timelines_args', array( get_called_class(), 'mastodon_api_timelines_args' ) );
+		add_filter( 'mastodon_api_timelines_args', array( get_called_class(), 'mastodon_api_view_post_types' ) );
+		add_filter( 'mastodon_api_view_post_types', array( get_called_class(), 'mastodon_api_view_post_types' ) );
 	}
 
 	public static function mastodon_api_account_follow( $user_id ) {
 		return apply_filters( 'friends_create_and_follow', null, $user_id );
 	}
 
-	public static function mastodon_api_timelines_args( $args ) {
-		$args['post_type'][] = Friends::CPT;
-		return $args;
+	public static function mastodon_api_view_post_types( $view_post_types ) {
+		$view_post_types[] = Friends::CPT;
+		return $view_post_types;
 	}
 }


### PR DESCRIPTION
Main Change: The (view) post type is not injected upon each query but set per app at creation, thus `mastodon_api_timelines_args` will no longer be used and `mastodon_api_view_post_types` instead at app creation.