### PR TITLE
Fix broken DMs when using the blog user in Activitypub

### DIFF
--- a/feed-parsers/class-feed-parser-activitypub.php
+++ b/feed-parsers/class-feed-parser-activitypub.php
@@ -464,7 +464,12 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 
 		require_once __DIR__ . '/activitypub/class-activitypub-transformer-message.php';
 
-		$actor = \Activitypub\Model\User::from_wp_user( get_current_user_id() );
+		$user_id = $this->get_activitypub_actor_id( $user_id );
+		$actor = $this->get_activitypub_actor( $user_id );
+		if ( ! $actor ) {
+			return $post_id;
+		}
+
 		$transformer = new ActivityPub_Transformer_Message( get_post( $post_id ) );
 		if ( is_wp_error( $transformer ) ) {
 			return $transformer;


### PR DESCRIPTION
Reported here: https://wordpress.org/support/topic/direct-messages-via-activitypub/#post-18365636