### PR TITLE
DMs: Preview lastest message

### DIFF
--- a/includes/class-messages.php
+++ b/includes/class-messages.php
@@ -493,13 +493,21 @@ class Messages {
 			}
 			$args['accounts'] = apply_filters( 'friends_message_form_accounts', array(), $args['friend_user'] );
 
+			add_filter( 'excerpt_length', array( $this, 'friends_message_excerpt_length' ) );
+
 			Friends::template_loader()->get_template_part(
 				'frontend/messages/friend',
 				null,
 				$args
 			);
 
+			remove_filter( 'excerpt_length', array( $this, 'friends_message_excerpt_length' ) );
+
 		}
+	}
+
+	public function friends_message_excerpt_length() {
+		return 10;
 	}
 
 	/**

--- a/templates/frontend/messages/friend.php
+++ b/templates/frontend/messages/friend.php
@@ -16,11 +16,6 @@ if ( false === strpos( $time_format, ':s' ) ) {
 	<strong><?php esc_html_e( 'Messages', 'friends' ); ?></strong>
 	<?php
 	foreach ( $args['existing_messages']->get_posts() as $_post ) {
-		$subject = get_the_title( $_post );
-		if ( ! $subject ) {
-			$subject = get_the_excerpt( $_post );
-		}
-
 		$messages = get_posts(
 			array(
 				'post_parent' => $_post->ID,
@@ -32,20 +27,26 @@ if ( false === strpos( $time_format, ':s' ) ) {
 		);
 		array_unshift( $messages, $_post );
 
-		$class = '';
+		$classes = array( 'display-message' => true );
+		$subject = false;
 		$last_message_time = false;
 		foreach ( $messages as $message ) {
 			if ( get_post_status( $message ) === 'friends_unread' ) {
-				$class .= ' unread';
+				$classes['unread'] = true;
 			}
 			$post_time = get_post_modified_time( 'U', true, $message );
 			if ( ! $last_message_time || $post_time > $last_message_time ) {
 				$last_message_time = $post_time;
+
+				$subject = get_the_title( $message );
+				if ( ! $subject ) {
+					$subject = get_the_excerpt( $message );
+				}
 			}
 		}
 		?>
 		<div class="friend-message" id="message-<?php echo esc_attr( $_post->ID ); ?>" data-id="<?php echo esc_attr( $_post->ID ); ?>" data-nonce="<?php echo esc_attr( wp_create_nonce( 'friends-mark-read' ) ); ?>">
-		<a href="" class="display-message<?php echo esc_attr( $class ); ?>" title="<?php echo esc_attr( date_i18n( $time_format, $last_message_time ) ); ?>">
+		<a href="" class="<?php echo esc_attr( implode( ' ', array_keys( $classes ) ) ); ?>" title="<?php echo esc_attr( date_i18n( $time_format, $last_message_time ) ); ?>">
 			<?php
 			// translators: %s is a time span.
 			echo esc_html( sprintf( __( '%s ago' ), human_time_diff( $last_message_time ) ) ); // phpcs:ignore WordPress.WP.I18n.MissingArgDomain


### PR DESCRIPTION
Before this, the first message was shown for the preview.
![Screenshot 2025-03-18 at 14 59 35](https://github.com/user-attachments/assets/828746eb-0588-4027-8830-0fe8c6600f6f)

Now, the last message:
![Screenshot 2025-03-18 at 14 58 08](https://github.com/user-attachments/assets/347272ae-5349-4d5d-9479-8c29d1972cf1)
