### PR TITLE
Friends Page: ensure friends posts can be collapsed / uncollapsed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Unreleased
+- Friends Page: ensure Friends posts can be collapsed and uncollapsed.
+
 ### 3.4.3
 - Rerelease of 3.4.2, which got stuck somewhere on WordPress.org
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,3 @@
-### Unreleased
-- Friends Page: ensure Friends posts can be collapsed and uncollapsed.
-
 ### 3.4.3
 - Rerelease of 3.4.2, which got stuck somewhere on WordPress.org
 

--- a/friends.js
+++ b/friends.js
@@ -338,7 +338,7 @@
 	} );
 
 	$document.on( 'click', 'a.collapse-post, .collapsed.card, .all-collapsed .card:not(.uncollapsed)', function ( e ) {
-		if ( e.target.closest( '.friends-dropdown' ) || e.target.is( 'a' ) ) {
+		if ( e.target.closest( '.friends-dropdown' ) || $ (this ).is( 'a' ) ) {
 			return true;
 		}
 

--- a/friends.js
+++ b/friends.js
@@ -338,7 +338,7 @@
 	} );
 
 	$document.on( 'click', 'a.collapse-post, .collapsed.card, .all-collapsed .card:not(.uncollapsed)', function ( e ) {
-		if ( e.target.closest( '.friends-dropdown' ) || $ ( this ).is( 'a' ) ) {
+		if ( e.target.closest( '.friends-dropdown' ) || $( this ).is( 'a' ) ) {
 			return true;
 		}
 

--- a/friends.js
+++ b/friends.js
@@ -338,7 +338,7 @@
 	} );
 
 	$document.on( 'click', 'a.collapse-post, .collapsed.card, .all-collapsed .card:not(.uncollapsed)', function ( e ) {
-		if ( e.target.closest( '.friends-dropdown' ) || $ (this ).is( 'a' ) ) {
+		if ( e.target.closest( '.friends-dropdown' ) || $ ( this ).is( 'a' ) ) {
 			return true;
 		}
 


### PR DESCRIPTION
Fixes #495

### Testing instructions

1. Go to your Friends page 
2. Click on a friends post
3. Ensure it can be uncollapsed with no errors.