### PR TITLE
Friends 4.0

### DIFF
--- a/friends.php
+++ b/friends.php
@@ -3,7 +3,7 @@
  * Plugin name: Friends
  * Plugin author: Alex Kirk
  * Plugin URI: https://github.com/akirk/friends
- * Version: 3.4.8
+ * Version: 4.0.0-alpha1
  * Requires PHP: 5.6
 
  * Description: A social network between WordPresses. Privacy focused, by itself a self-hosted RSS++ reader with notifications.
@@ -25,7 +25,7 @@ defined( 'ABSPATH' ) || exit;
 define( 'FRIENDS_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'FRIENDS_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
 define( 'FRIENDS_PLUGIN_FILE', plugin_dir_path( __FILE__ ) . '/' . basename( __FILE__ ) );
-define( 'FRIENDS_VERSION', '3.4.8' );
+define( 'FRIENDS_VERSION', '4.0.0-alpha1' );
 
 require_once __DIR__ . '/libs/Mf2/Parser.php';
 


### PR DESCRIPTION
This is the PR leading up to Friends 4.0. This will include:

- Removal of the WordPress to WordPress "Friendship" functionality #515 
	- The idea was received well but never widely used and caused code complexity and never fixed issues due to low usage.
	- Instead we will focus on RSS+ActivityPub subscriptions, private posting functionality might come back through ActivityPub.
- Move the "Add Friend" and "Friend List" functionality to the frontend
	- Offer to subscribe to RSS, ActivityPub and Bluesky, only prompt afterwards if a plugin is needed and remember the user to be added.
	- Prefer ActivityPub over RSS.
	- Include OPML import.
- Block Theme for the friends page #362