### PR TITLE
Add a Friend on the Frontend

### DIFF
--- a/friends-blocks.css
+++ b/friends-blocks.css
@@ -2,3 +2,237 @@ ul.friend-posts img.avatar {
 	vertical-align: middle;
 	margin-right: .3em;
 }
+
+.friends-page .wp-block-friends-add-friend-form {
+	max-width: min(100%, 860px);
+}
+
+.friends-page .wp-block-friends-add-friend-form .hidden {
+	display: none;
+}
+
+.friends-page .wp-block-friends-add-friend-form .add-friend-subscriptions {
+	display: grid;
+	gap: var(--wp--preset--spacing--40, 1.25rem);
+}
+
+.friends-page .wp-block-friends-add-friend-form .card {
+	background: color-mix(in srgb, currentColor 3%, transparent);
+	border-radius: 6px;
+	margin: 0;
+}
+
+.friends-page .wp-block-friends-add-friend-form .card-body {
+	padding: clamp(1rem, 2vw, 1.5rem);
+}
+
+.friends-page .wp-block-friends-add-friend-form .add-subscription-input {
+	display: flex;
+	align-items: flex-start;
+	gap: .75rem;
+}
+
+.friends-page .wp-block-friends-add-friend-form .form-input,
+.friends-page .wp-block-friends-add-friend-form .form-select {
+	background: var(--wp--preset--color--base, Canvas);
+	border: 1px solid color-mix(in srgb, currentColor 18%, transparent);
+	border-radius: 4px;
+	box-sizing: border-box;
+	color: inherit;
+	font: inherit;
+	padding: .55rem .7rem;
+	width: 100%;
+}
+
+.friends-page .wp-block-friends-add-friend-form textarea.form-input {
+	min-height: 6rem;
+	resize: vertical;
+}
+
+.friends-page .wp-block-friends-add-friend-form .btn {
+	background: color-mix(in srgb, currentColor 8%, transparent);
+	border: 0;
+	border-radius: 4px;
+	color: inherit;
+	cursor: pointer;
+	font: inherit;
+	line-height: 1.3;
+	padding: .55rem .85rem;
+	text-decoration: none;
+	white-space: nowrap;
+}
+
+.friends-page .wp-block-friends-add-friend-form .btn-primary {
+	background: var(--wp--preset--color--contrast, currentColor);
+	color: var(--wp--preset--color--base, Canvas);
+}
+
+.friends-page .wp-block-friends-add-friend-form .btn-link {
+	background: transparent;
+	color: inherit;
+	opacity: .78;
+}
+
+.friends-page .wp-block-friends-add-friend-form .opml-file-hint,
+.friends-page .wp-block-friends-add-friend-form .subscription-preview-description,
+.friends-page .wp-block-friends-add-friend-form .subscription-feed-details,
+.friends-page .wp-block-friends-add-friend-form .subscription-preview-status,
+.friends-page .wp-block-friends-add-friend-form .bulk-feed-status {
+	color: color-mix(in srgb, currentColor 68%, transparent);
+	font-size: .9rem;
+}
+
+.friends-page .wp-block-friends-add-friend-form #preview-subscription:not(:empty) {
+	margin-top: 1rem;
+}
+
+.friends-page .wp-block-friends-add-friend-form .subscription-preview-results,
+.friends-page .wp-block-friends-add-friend-form .bulk-feed-list,
+.friends-page .wp-block-friends-add-friend-form .subscription-feed-list {
+	display: grid;
+	gap: .75rem;
+	list-style: none;
+	margin: 1rem 0 0;
+	padding: 0;
+}
+
+.friends-page .wp-block-friends-add-friend-form .subscription-feed-list.hidden {
+	display: none;
+}
+
+.friends-page .wp-block-friends-add-friend-form .bulk-controls,
+.friends-page .wp-block-friends-add-friend-form .subscription-feed-actions,
+.friends-page .wp-block-friends-add-friend-form .subscription-preview-actions {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: .5rem;
+	margin-top: 1rem;
+}
+
+.friends-page .wp-block-friends-add-friend-form .bulk-feed-row,
+.friends-page .wp-block-friends-add-friend-form .subscription-feed-option {
+	background: color-mix(in srgb, currentColor 5%, transparent);
+	border-radius: 6px;
+	padding: .75rem;
+}
+
+.friends-page .wp-block-friends-add-friend-form .bulk-feed-row > label,
+.friends-page .wp-block-friends-add-friend-form .subscription-feed-option > label {
+	display: block;
+	font-weight: 600;
+	overflow-wrap: anywhere;
+}
+
+.friends-page .wp-block-friends-add-friend-form .bulk-feed-row.is-reviewing > .label-for-bulkfeed,
+.friends-page .wp-block-friends-add-friend-form .bulk-feed-row.is-reviewing > .bulk-feed-status {
+	display: none;
+}
+
+.friends-page .wp-block-friends-add-friend-form .bulk-feed-review {
+	margin-top: .75rem;
+}
+
+.friends-page .wp-block-friends-add-friend-form .feed-preview {
+	background: color-mix(in srgb, currentColor 4%, transparent);
+	border-radius: 6px;
+	box-shadow: inset 3px 0 0 color-mix(in srgb, currentColor 22%, transparent);
+	margin-top: 1rem;
+	padding: 1rem;
+}
+
+.friends-page .wp-block-friends-add-friend-form .bulk-feed-review .feed-preview {
+	background: transparent;
+	border-radius: 0;
+	box-shadow: none;
+	margin-top: 0;
+	padding: 0;
+}
+
+.friends-page .wp-block-friends-add-friend-form .subscription-preview-header,
+.friends-page .wp-block-friends-add-friend-form .subscribe-success {
+	display: flex;
+	align-items: center;
+	gap: .75rem;
+}
+
+.friends-page .wp-block-friends-add-friend-form .subscription-preview-header .avatar,
+.friends-page .wp-block-friends-add-friend-form .subscribe-success .avatar {
+	border-radius: 50%;
+	flex: 0 0 auto;
+}
+
+.friends-page .wp-block-friends-add-friend-form .subscription-preview-title,
+.friends-page .wp-block-friends-add-friend-form .subscription-feed-preview-title {
+	display: flex;
+	flex-direction: column;
+	min-width: 0;
+}
+
+.friends-page .wp-block-friends-add-friend-form .subscription-preview-title small,
+.friends-page .wp-block-friends-add-friend-form .subscription-feed-preview-title small {
+	color: color-mix(in srgb, currentColor 65%, transparent);
+	overflow-wrap: anywhere;
+}
+
+.friends-page .wp-block-friends-add-friend-form .subscription-settings,
+.friends-page .wp-block-friends-add-friend-form .subscription-feed-controls {
+	display: grid;
+	grid-template-columns: repeat(2, minmax(0, 1fr));
+	gap: .75rem;
+	margin-top: .85rem;
+}
+
+.friends-page .wp-block-friends-add-friend-form .subscription-settings label,
+.friends-page .wp-block-friends-add-friend-form .subscription-feed-controls label {
+	display: grid;
+	gap: .25rem;
+	font-weight: 600;
+}
+
+.friends-page .wp-block-friends-add-friend-form .subscription-feed-url-label {
+	grid-column: 1 / -1;
+}
+
+.friends-page .wp-block-friends-add-friend-form .subscription-feed-preview {
+	background: color-mix(in srgb, currentColor 4%, transparent);
+	border-radius: 4px;
+	margin-top: .75rem;
+	padding: .75rem;
+}
+
+.friends-page .wp-block-friends-add-friend-form .subscription-feed-preview ul {
+	display: grid;
+	gap: .7rem;
+	list-style: none;
+	margin: 0;
+	padding: 0;
+}
+
+.friends-page .wp-block-friends-add-friend-form .subscription-feed-preview p {
+	margin: .25rem 0 0;
+}
+
+.friends-page .wp-block-friends-add-friend-form .error,
+.friends-page .wp-block-friends-add-friend-form .subscription-preview-status.error,
+.friends-page .wp-block-friends-add-friend-form .bulk-feed-status.error {
+	color: #b91c1c;
+}
+
+@media (max-width: 640px) {
+	.friends-page .wp-block-friends-add-friend-form .add-subscription-input {
+		flex-direction: column;
+	}
+
+	.friends-page .wp-block-friends-add-friend-form .add-subscription-input .btn,
+	.friends-page .wp-block-friends-add-friend-form .bulk-controls .btn,
+	.friends-page .wp-block-friends-add-friend-form .subscription-feed-actions .btn,
+	.friends-page .wp-block-friends-add-friend-form .subscription-preview-actions .btn {
+		width: 100%;
+	}
+
+	.friends-page .wp-block-friends-add-friend-form .subscription-settings,
+	.friends-page .wp-block-friends-add-friend-form .subscription-feed-controls {
+		grid-template-columns: 1fr;
+	}
+}

--- a/friends.css
+++ b/friends.css
@@ -1897,6 +1897,20 @@ h2#page-title a.dashicons {
 		}
 	}
 
+	& section.subscriptions .feed-preview {
+		margin-top: 1em;
+
+		& .avatar { border-radius: 50%; vertical-align: middle; margin-right: .5em; }
+
+		& .feed-list {
+			list-style: none;
+			padding-left: 0;
+			margin: .5em 0;
+
+			& li { padding: 4px 0; }
+		}
+	}
+
 	& section.subscriptions {
 		& .subscription-item {
 			padding: 8px 0;

--- a/friends.css
+++ b/friends.css
@@ -1911,6 +1911,16 @@ h2#page-title a.dashicons {
 		}
 	}
 
+	& section.subscriptions .subscribe-success {
+		margin-top: 1em;
+		display: flex;
+		align-items: center;
+		gap: .5em;
+
+		& .avatar { border-radius: 50%; }
+		& a { font-weight: bold; font-size: 1.1em; }
+	}
+
 	& section.subscriptions {
 		& .subscription-item {
 			padding: 8px 0;

--- a/friends.css
+++ b/friends.css
@@ -1901,6 +1901,20 @@ h2#page-title a.dashicons {
 		}
 	}
 
+	& section.subscriptions .feed-preview {
+		margin-top: 1em;
+
+		& .avatar { border-radius: 50%; vertical-align: middle; margin-right: .5em; }
+
+		& .feed-list {
+			list-style: none;
+			padding-left: 0;
+			margin: .5em 0;
+
+			& li { padding: 4px 0; }
+		}
+	}
+
 	& section.subscriptions {
 		& .subscription-item {
 			padding: 8px 0;

--- a/friends.css
+++ b/friends.css
@@ -1915,6 +1915,16 @@ h2#page-title a.dashicons {
 		}
 	}
 
+	& section.subscriptions .subscribe-success {
+		margin-top: 1em;
+		display: flex;
+		align-items: center;
+		gap: .5em;
+
+		& .avatar { border-radius: 50%; }
+		& a { font-weight: bold; font-size: 1.1em; }
+	}
+
 	& section.subscriptions {
 		& .subscription-item {
 			padding: 8px 0;

--- a/friends.css
+++ b/friends.css
@@ -1901,10 +1901,61 @@ h2#page-title a.dashicons {
 		}
 	}
 
-	& section.subscriptions .feed-preview {
-		margin-top: 1em;
+	& section.subscriptions {
+		& .hidden { display: none; }
 
-		& .avatar { border-radius: 50%; vertical-align: middle; margin-right: .5em; }
+		&.add-friend-subscriptions {
+			display: grid;
+			gap: 1rem;
+
+			& .card {
+				margin: 0;
+			}
+		}
+
+		& .add-subscription-input {
+			display: flex;
+			gap: .6rem;
+			align-items: flex-start;
+
+			& .form-input {
+				flex: 1 1 auto;
+				min-height: 5.6rem;
+				resize: vertical;
+			}
+
+			& .btn { flex: 0 0 auto; }
+		}
+
+		& .opml-file-hint {
+			color: #5f5a7d;
+			font-size: .75rem;
+			margin: .6rem 0 0;
+		}
+
+		& #preview-subscription:not(:empty) {
+			margin-top: 1rem;
+		}
+
+		& .subscription-preview-results {
+			display: grid;
+			gap: .75rem;
+		}
+
+		& .bulk-controls,
+		& .subscription-bulk-actions,
+		& .subscription-feed-actions,
+		& .subscription-preview-actions {
+			display: flex;
+			flex-wrap: wrap;
+			gap: .4rem;
+			align-items: center;
+			margin-top: .8rem;
+		}
+
+		& .bulk-skip-entry {
+			margin-left: .35rem;
+		}
 
 		& .feed-list {
 			list-style: none;
@@ -1913,19 +1964,206 @@ h2#page-title a.dashicons {
 
 			& li { padding: 4px 0; }
 		}
-	}
 
-	& section.subscriptions .subscribe-success {
-		margin-top: 1em;
-		display: flex;
-		align-items: center;
-		gap: .5em;
+		& .bulk-feed-list {
+			display: grid;
+			gap: .6rem;
+			margin: 1rem 0 0;
+		}
 
-		& .avatar { border-radius: 50%; }
-		& a { font-weight: bold; font-size: 1.1em; }
-	}
+		& .bulk-feed-list > .bulk-feed-row {
+			background: #f8f8fc;
+			border-radius: .25rem;
+			padding: .65rem .75rem;
 
-	& section.subscriptions {
+			& > label {
+				display: block;
+				font-weight: 600;
+				overflow-wrap: anywhere;
+
+				& small {
+					display: block;
+					font-weight: 400;
+					margin-top: .15rem;
+				}
+			}
+		}
+
+		& .bulk-feed-list > .bulk-feed-row.is-reviewing > .label-for-bulkfeed,
+		& .bulk-feed-list > .bulk-feed-row.is-reviewing > .bulk-feed-status {
+			display: none;
+		}
+
+		& .bulk-feed-review {
+			margin: .7rem 0 0;
+		}
+
+		& .feed-preview {
+			background: #fff;
+			border-radius: .25rem;
+			box-shadow: inset 3px 0 0 #d9def7;
+			margin-top: 1rem;
+			padding: .8rem;
+
+			& .avatar { border-radius: 50%; }
+		}
+
+		& .bulk-feed-review .feed-preview {
+			background: transparent;
+			border-radius: 0;
+			box-shadow: none;
+			margin-top: 0;
+			padding: 0;
+		}
+
+		& .subscription-preview-header,
+		& .subscribe-success {
+			display: flex;
+			align-items: center;
+			gap: .6rem;
+		}
+
+		& .subscription-preview-title {
+			display: flex;
+			flex-direction: column;
+			min-width: 0;
+
+			& small {
+				color: #6b7280;
+				overflow-wrap: anywhere;
+			}
+		}
+
+		& .subscription-preview-description {
+			color: #5f5a7d;
+			margin: .6rem 0;
+		}
+
+		& .subscription-feed-list {
+			display: grid;
+			gap: .55rem;
+			margin-top: .8rem;
+		}
+
+		& .subscription-feed-list.hidden {
+			display: none;
+		}
+
+		& .subscription-settings,
+		& .subscription-feed-controls {
+			display: grid;
+			grid-template-columns: repeat(2, minmax(0, 1fr));
+			gap: .6rem;
+			margin-top: .7rem;
+
+			& label {
+				display: grid;
+				gap: .2rem;
+				font-size: .7rem;
+				font-weight: 600;
+			}
+
+			& .btn {
+				align-self: end;
+				justify-self: start;
+			}
+		}
+
+		& .subscription-feed-url-label {
+			grid-column: 1 / -1;
+		}
+
+		& .subscription-feed-option {
+			background: #f7f7fb;
+			border-radius: .25rem;
+			margin-top: 0;
+			padding: .65rem;
+
+			& > label {
+				display: block;
+				font-weight: 600;
+				overflow-wrap: anywhere;
+
+				& small {
+					color: #6b7280;
+					font-weight: 400;
+				}
+			}
+		}
+
+		& .subscription-feed-details {
+			color: #6b7280;
+			font-size: .7rem;
+			margin: .5rem 0 0;
+			overflow-wrap: anywhere;
+		}
+
+		& .subscription-feed-preview {
+			background: #fff;
+			border-radius: .2rem;
+			box-shadow: inset 0 0 0 1px #e8e8f3;
+			margin-top: .6rem;
+			padding: .6rem;
+
+			& ul {
+				list-style: none;
+				margin: 0;
+				padding: 0;
+			}
+
+			& li + li {
+				margin-top: .55rem;
+			}
+
+			& p {
+				color: #5f5a7d;
+				font-size: .75rem;
+				margin: .25rem 0 0;
+			}
+		}
+
+		& .subscription-feed-preview-title {
+			display: flex;
+			flex-direction: column;
+			gap: .1rem;
+
+			& small {
+				color: #6b7280;
+				font-size: .7rem;
+			}
+		}
+
+		& .subscription-preview-status,
+		& .bulk-feed-status {
+			color: #5f5a7d;
+			font-size: .75rem;
+
+			&.error { color: #b91c1c; }
+		}
+
+		& .subscribe-success {
+			& a { font-weight: bold; font-size: 1.1em; }
+		}
+
+		@media (max-width: 640px) {
+			& .add-subscription-input {
+				flex-direction: column;
+
+				& .btn { width: 100%; }
+			}
+
+			& .subscription-settings,
+			& .subscription-feed-controls {
+				grid-template-columns: 1fr;
+			}
+
+			& .subscription-preview-actions .btn,
+			& .subscription-feed-actions .btn,
+			& .bulk-controls .btn {
+				width: 100%;
+			}
+		}
+
 		& .subscription-item {
 			padding: 8px 0;
 			border-bottom: 1px solid #e8e8e8;

--- a/friends.css
+++ b/friends.css
@@ -1897,10 +1897,61 @@ h2#page-title a.dashicons {
 		}
 	}
 
-	& section.subscriptions .feed-preview {
-		margin-top: 1em;
+	& section.subscriptions {
+		& .hidden { display: none; }
 
-		& .avatar { border-radius: 50%; vertical-align: middle; margin-right: .5em; }
+		&.add-friend-subscriptions {
+			display: grid;
+			gap: 1rem;
+
+			& .card {
+				margin: 0;
+			}
+		}
+
+		& .add-subscription-input {
+			display: flex;
+			gap: .6rem;
+			align-items: flex-start;
+
+			& .form-input {
+				flex: 1 1 auto;
+				min-height: 5.6rem;
+				resize: vertical;
+			}
+
+			& .btn { flex: 0 0 auto; }
+		}
+
+		& .opml-file-hint {
+			color: #5f5a7d;
+			font-size: .75rem;
+			margin: .6rem 0 0;
+		}
+
+		& #preview-subscription:not(:empty) {
+			margin-top: 1rem;
+		}
+
+		& .subscription-preview-results {
+			display: grid;
+			gap: .75rem;
+		}
+
+		& .bulk-controls,
+		& .subscription-bulk-actions,
+		& .subscription-feed-actions,
+		& .subscription-preview-actions {
+			display: flex;
+			flex-wrap: wrap;
+			gap: .4rem;
+			align-items: center;
+			margin-top: .8rem;
+		}
+
+		& .bulk-skip-entry {
+			margin-left: .35rem;
+		}
 
 		& .feed-list {
 			list-style: none;
@@ -1909,19 +1960,206 @@ h2#page-title a.dashicons {
 
 			& li { padding: 4px 0; }
 		}
-	}
 
-	& section.subscriptions .subscribe-success {
-		margin-top: 1em;
-		display: flex;
-		align-items: center;
-		gap: .5em;
+		& .bulk-feed-list {
+			display: grid;
+			gap: .6rem;
+			margin: 1rem 0 0;
+		}
 
-		& .avatar { border-radius: 50%; }
-		& a { font-weight: bold; font-size: 1.1em; }
-	}
+		& .bulk-feed-list > .bulk-feed-row {
+			background: #f8f8fc;
+			border-radius: .25rem;
+			padding: .65rem .75rem;
 
-	& section.subscriptions {
+			& > label {
+				display: block;
+				font-weight: 600;
+				overflow-wrap: anywhere;
+
+				& small {
+					display: block;
+					font-weight: 400;
+					margin-top: .15rem;
+				}
+			}
+		}
+
+		& .bulk-feed-list > .bulk-feed-row.is-reviewing > .label-for-bulkfeed,
+		& .bulk-feed-list > .bulk-feed-row.is-reviewing > .bulk-feed-status {
+			display: none;
+		}
+
+		& .bulk-feed-review {
+			margin: .7rem 0 0;
+		}
+
+		& .feed-preview {
+			background: #fff;
+			border-radius: .25rem;
+			box-shadow: inset 3px 0 0 #d9def7;
+			margin-top: 1rem;
+			padding: .8rem;
+
+			& .avatar { border-radius: 50%; }
+		}
+
+		& .bulk-feed-review .feed-preview {
+			background: transparent;
+			border-radius: 0;
+			box-shadow: none;
+			margin-top: 0;
+			padding: 0;
+		}
+
+		& .subscription-preview-header,
+		& .subscribe-success {
+			display: flex;
+			align-items: center;
+			gap: .6rem;
+		}
+
+		& .subscription-preview-title {
+			display: flex;
+			flex-direction: column;
+			min-width: 0;
+
+			& small {
+				color: #6b7280;
+				overflow-wrap: anywhere;
+			}
+		}
+
+		& .subscription-preview-description {
+			color: #5f5a7d;
+			margin: .6rem 0;
+		}
+
+		& .subscription-feed-list {
+			display: grid;
+			gap: .55rem;
+			margin-top: .8rem;
+		}
+
+		& .subscription-feed-list.hidden {
+			display: none;
+		}
+
+		& .subscription-settings,
+		& .subscription-feed-controls {
+			display: grid;
+			grid-template-columns: repeat(2, minmax(0, 1fr));
+			gap: .6rem;
+			margin-top: .7rem;
+
+			& label {
+				display: grid;
+				gap: .2rem;
+				font-size: .7rem;
+				font-weight: 600;
+			}
+
+			& .btn {
+				align-self: end;
+				justify-self: start;
+			}
+		}
+
+		& .subscription-feed-url-label {
+			grid-column: 1 / -1;
+		}
+
+		& .subscription-feed-option {
+			background: #f7f7fb;
+			border-radius: .25rem;
+			margin-top: 0;
+			padding: .65rem;
+
+			& > label {
+				display: block;
+				font-weight: 600;
+				overflow-wrap: anywhere;
+
+				& small {
+					color: #6b7280;
+					font-weight: 400;
+				}
+			}
+		}
+
+		& .subscription-feed-details {
+			color: #6b7280;
+			font-size: .7rem;
+			margin: .5rem 0 0;
+			overflow-wrap: anywhere;
+		}
+
+		& .subscription-feed-preview {
+			background: #fff;
+			border-radius: .2rem;
+			box-shadow: inset 0 0 0 1px #e8e8f3;
+			margin-top: .6rem;
+			padding: .6rem;
+
+			& ul {
+				list-style: none;
+				margin: 0;
+				padding: 0;
+			}
+
+			& li + li {
+				margin-top: .55rem;
+			}
+
+			& p {
+				color: #5f5a7d;
+				font-size: .75rem;
+				margin: .25rem 0 0;
+			}
+		}
+
+		& .subscription-feed-preview-title {
+			display: flex;
+			flex-direction: column;
+			gap: .1rem;
+
+			& small {
+				color: #6b7280;
+				font-size: .7rem;
+			}
+		}
+
+		& .subscription-preview-status,
+		& .bulk-feed-status {
+			color: #5f5a7d;
+			font-size: .75rem;
+
+			&.error { color: #b91c1c; }
+		}
+
+		& .subscribe-success {
+			& a { font-weight: bold; font-size: 1.1em; }
+		}
+
+		@media (max-width: 640px) {
+			& .add-subscription-input {
+				flex-direction: column;
+
+				& .btn { width: 100%; }
+			}
+
+			& .subscription-settings,
+			& .subscription-feed-controls {
+				grid-template-columns: 1fr;
+			}
+
+			& .subscription-preview-actions .btn,
+			& .subscription-feed-actions .btn,
+			& .bulk-controls .btn {
+				width: 100%;
+			}
+		}
+
 		& .subscription-item {
 			padding: 8px 0;
 			border-bottom: 1px solid #e8e8e8;

--- a/friends.js
+++ b/friends.js
@@ -858,6 +858,7 @@
 				url: url,
 			},
 			success( r ) {
+				$preview.data( 'feeds', r.feeds );
 				let html = '<div class="feed-preview">';
 				if ( r.avatar ) {
 					html += '<img src="' + r.avatar + '" class="avatar" width="48" height="48" /> ';
@@ -884,6 +885,7 @@
 				html += ( friends.text_follow || 'Follow' ) + '</button>';
 				html += '</div>';
 				$preview.html( html );
+				$preview.find( '.subscribe-btn' ).focus();
 			},
 			error( result ) {
 				$preview.html( '<p class="error">' + ( result && result.length ? result : ( friends.text_error || 'An error occurred.' ) ) + '</p>' );
@@ -894,13 +896,15 @@
 	$document.on( 'click', '.subscribe-btn', function () {
 		const $this = $( this );
 		const $preview = $( '#preview-subscription' );
+		const allFeeds = $preview.data( 'feeds' ) || {};
 		const feeds = {};
 		$preview.find( 'input[name="feed"]' ).each( function () {
 			const $input = $( this );
-			feeds[ $input.val() ] = {
-				url: $input.val(),
+			const feedUrl = $input.val();
+			feeds[ feedUrl ] = $.extend( {}, allFeeds[ feedUrl ] || {}, {
+				url: feedUrl,
 				selected: $input.is( ':checked' ),
-			};
+			} );
 		} );
 		wp.ajax.send( 'friends-subscribe-frontend', {
 			data: {
@@ -910,7 +914,14 @@
 				feeds: feeds,
 			},
 			success( r ) {
-				$preview.html( '<p class="success">' + r.message + '</p>' );
+				let html = '<div class="subscribe-success">';
+				const avatar = $preview.find( '.avatar' ).attr( 'src' );
+				if ( avatar ) {
+					html += '<img src="' + avatar + '" class="avatar" width="48" height="48" /> ';
+				}
+				html += '<a href="' + r.url + '">' + r.message + '</a>';
+				html += '</div>';
+				$preview.html( html );
 			},
 			error( result ) {
 				$preview.html( '<p class="error">' + result + '</p>' );

--- a/friends.js
+++ b/friends.js
@@ -928,4 +928,5 @@
 			},
 		} );
 	} );
+
 } )( jQuery, window.wp, window.friends );

--- a/friends.js
+++ b/friends.js
@@ -843,4 +843,78 @@
 		} );
 	} );
 
+	$document.on( 'submit', '#add-subscription-form', function ( e ) {
+		e.preventDefault();
+		const $this = $( this );
+		const url = $this.find( 'input[name="url"]' ).val();
+		if ( ! url ) {
+			return;
+		}
+		const $preview = $( '#preview-subscription' );
+		$preview.html( '<p class="loading">' + ( friends.text_loading || 'Loading...' ) + '</p>' );
+		wp.ajax.send( 'friends-preview-subscription', {
+			data: {
+				_ajax_nonce: $this.find( 'input[name=_wpnonce]' ).val(),
+				url: url,
+			},
+			success( r ) {
+				let html = '<div class="feed-preview">';
+				if ( r.avatar ) {
+					html += '<img src="' + r.avatar + '" class="avatar" width="48" height="48" /> ';
+				}
+				html += '<strong>' + ( r.display_name || r.user_login || r.url ) + '</strong>';
+				if ( r.description ) {
+					html += '<p>' + r.description + '</p>';
+				}
+				html += '<ul class="feed-list">';
+				const feedUrls = Object.keys( r.feeds );
+				for ( let i = 0; i < feedUrls.length; i++ ) {
+					const feedUrl = feedUrls[ i ];
+					const feed = r.feeds[ feedUrl ];
+					if ( feed.parser === 'unsupported' ) {
+						continue;
+					}
+					const checked = feed.autoselect ? ' checked' : '';
+					html += '<li><label><input type="checkbox" name="feed" value="' + feedUrl + '"' + checked + ' /> ';
+					html += ( feed.title || feedUrl ) + ' <small>(' + ( feed.type || '' ) + ')</small>';
+					html += '</label></li>';
+				}
+				html += '</ul>';
+				html += '<button class="btn btn-primary subscribe-btn" data-url="' + r.url + '" data-display-name="' + ( r.display_name || '' ) + '" data-nonce="' + $this.find( 'input[name=_wpnonce]' ).val() + '">';
+				html += ( friends.text_follow || 'Follow' ) + '</button>';
+				html += '</div>';
+				$preview.html( html );
+			},
+			error( result ) {
+				$preview.html( '<p class="error">' + ( result && result.length ? result : ( friends.text_error || 'An error occurred.' ) ) + '</p>' );
+			},
+		} );
+	} );
+
+	$document.on( 'click', '.subscribe-btn', function () {
+		const $this = $( this );
+		const $preview = $( '#preview-subscription' );
+		const feeds = {};
+		$preview.find( 'input[name="feed"]' ).each( function () {
+			const $input = $( this );
+			feeds[ $input.val() ] = {
+				url: $input.val(),
+				selected: $input.is( ':checked' ),
+			};
+		} );
+		wp.ajax.send( 'friends-subscribe-frontend', {
+			data: {
+				_ajax_nonce: $this.data( 'nonce' ),
+				url: $this.data( 'url' ),
+				display_name: $this.data( 'display-name' ),
+				feeds: feeds,
+			},
+			success( r ) {
+				$preview.html( '<p class="success">' + r.message + '</p>' );
+			},
+			error( result ) {
+				$preview.html( '<p class="error">' + result + '</p>' );
+			},
+		} );
+	} );
 } )( jQuery, window.wp, window.friends );

--- a/friends.js
+++ b/friends.js
@@ -843,11 +843,26 @@
 		} );
 	} );
 
+	function looksLikeOpml( text ) {
+		if ( ! text ) {
+			return false;
+		}
+		const trimmed = text.trim();
+		if ( trimmed.charAt( 0 ) !== '<' ) {
+			return false;
+		}
+		return /<\s*(opml|outline)\b/i.test( trimmed );
+	}
+
 	$document.on( 'submit', '#add-subscription-form', function ( e ) {
 		e.preventDefault();
 		const $this = $( this );
 		const url = $this.find( 'input[name="url"]' ).val();
 		if ( ! url ) {
+			return;
+		}
+		if ( looksLikeOpml( url ) ) {
+			renderOpmlPreview( url );
 			return;
 		}
 		const $preview = $( '#preview-subscription' );
@@ -927,6 +942,155 @@
 				$preview.html( '<p class="error">' + result + '</p>' );
 			},
 		} );
+	} );
+
+	function renderOpmlPreview( opmlText ) {
+		const $preview = $( '#preview-subscription' );
+		const parser = new DOMParser();
+		const doc = parser.parseFromString( opmlText, 'application/xml' );
+		if ( doc.getElementsByTagName( 'parsererror' ).length ) {
+			$preview.html( '<p class="error">' + ( friends.text_opml_invalid || 'Could not parse the OPML file.' ) + '</p>' );
+			return;
+		}
+		const outlines = doc.querySelectorAll( 'outline[xmlUrl]' );
+		if ( ! outlines.length ) {
+			$preview.html( '<p class="error">' + ( friends.text_opml_no_feeds || 'No feeds were found in the OPML file.' ) + '</p>' );
+			return;
+		}
+
+		const $list = $( '<ul class="feed-list opml-feed-list"></ul>' );
+		outlines.forEach( function ( outline, idx ) {
+			const xmlUrl = outline.getAttribute( 'xmlUrl' ) || '';
+			const htmlUrl = outline.getAttribute( 'htmlUrl' ) || '';
+			const text = outline.getAttribute( 'text' ) || outline.getAttribute( 'title' ) || '';
+			const $cb = $( '<input type="checkbox" class="opml-feed-cb" checked />' )
+				.data( { xmlUrl: xmlUrl, htmlUrl: htmlUrl, text: text } )
+				.attr( 'data-idx', idx );
+			const $label = $( '<label></label>' ).append( $cb );
+			$label.append( document.createTextNode( ' ' + ( text || xmlUrl ) ) );
+			if ( htmlUrl ) {
+				$label.append( ' ' );
+				$label.append( $( '<small></small>' ).append( $( '<a target="_blank" rel="noopener noreferrer"></a>' ).attr( 'href', htmlUrl ).text( htmlUrl ) ) );
+			}
+			const $status = $( '<span class="opml-feed-status"></span>' );
+			$list.append( $( '<li></li>' ).attr( 'data-idx', idx ).append( $label ).append( ' ' ).append( $status ) );
+		} );
+
+		const $controls = $( '<div class="opml-controls"></div>' );
+		$controls.append( $( '<button type="button" class="btn btn-link opml-toggle-all"></button>' ).text( friends.text_opml_deselect_all || 'Deselect all' ) );
+		$controls.append( ' ' );
+		$controls.append( $( '<button type="button" class="btn btn-primary opml-import-selected"></button>' ).text( friends.text_opml_import_selected || 'Import selected' ) );
+
+		$preview.empty().append( $controls ).append( $list );
+	}
+
+	$document.on( 'change', '#opml-file', function () {
+		const file = this.files && this.files[ 0 ];
+		if ( ! file ) {
+			return;
+		}
+		const reader = new FileReader();
+		reader.onload = function ( e ) {
+			renderOpmlPreview( e.target.result );
+		};
+		reader.readAsText( file );
+	} );
+
+	$document.on( 'click', '.opml-toggle-all', function () {
+		const $this = $( this );
+		const $cbs = $( '.opml-feed-cb' );
+		const allChecked = $cbs.length === $cbs.filter( ':checked' ).length;
+		$cbs.prop( 'checked', ! allChecked );
+		$this.text( allChecked ? ( friends.text_opml_select_all || 'Select all' ) : ( friends.text_opml_deselect_all || 'Deselect all' ) );
+	} );
+
+	function importOpmlFeed( $li, nonce, done ) {
+		const $cb = $li.find( '.opml-feed-cb' );
+		const data = $cb.data();
+		const $status = $li.find( '.opml-feed-status' );
+		const url = data.htmlUrl || data.xmlUrl;
+		$status.text( '⏳' );
+		wp.ajax.send( 'friends-preview-subscription', {
+			data: {
+				_ajax_nonce: nonce,
+				url: url,
+			},
+			success( r ) {
+				const feedsForSubscribe = {};
+				const feedUrls = Object.keys( r.feeds );
+				let anySelected = false;
+				for ( let i = 0; i < feedUrls.length; i++ ) {
+					const fUrl = feedUrls[ i ];
+					const f = r.feeds[ fUrl ];
+					if ( f.parser === 'unsupported' ) {
+						continue;
+					}
+					const selected = !! f.autoselect;
+					if ( selected ) {
+						anySelected = true;
+					}
+					feedsForSubscribe[ fUrl ] = $.extend( {}, f, { url: fUrl, selected: selected } );
+				}
+				if ( ! anySelected ) {
+					// Fall back to selecting the first supported feed if no autoselect.
+					const keys = Object.keys( feedsForSubscribe );
+					if ( keys.length ) {
+						feedsForSubscribe[ keys[ 0 ] ].selected = true;
+					} else {
+						$status.text( '✗ ' + ( friends.text_opml_no_feeds_for_url || 'No feeds discovered.' ) );
+						done();
+						return;
+					}
+				}
+				wp.ajax.send( 'friends-subscribe-frontend', {
+					data: {
+						_ajax_nonce: nonce,
+						url: r.url,
+						display_name: r.display_name || data.text || '',
+						feeds: feedsForSubscribe,
+					},
+					success( r2 ) {
+						$status.empty().append( '✓ ' ).append( $( '<a></a>' ).attr( 'href', r2.url ).text( r2.message ) );
+						done();
+					},
+					error( result ) {
+						$status.text( '✗ ' + ( result && result.length ? result : ( friends.text_error || 'An error occurred.' ) ) );
+						done();
+					},
+				} );
+			},
+			error( result ) {
+				$status.text( '✗ ' + ( result && result.length ? result : ( friends.text_error || 'An error occurred.' ) ) );
+				done();
+			},
+		} );
+	}
+
+	$document.on( 'click', '.opml-import-selected', function () {
+		const $btn = $( this ).prop( 'disabled', true );
+		const nonce = $( '#add-subscription-form input[name=_wpnonce]' ).val();
+		const queue = [];
+		$( '.opml-feed-list li' ).each( function () {
+			const $li = $( this );
+			if ( $li.find( '.opml-feed-cb' ).is( ':checked' ) ) {
+				queue.push( $li );
+			}
+		} );
+		if ( ! queue.length ) {
+			alert( friends.text_opml_no_selected || 'Please select at least one feed.' );
+			$btn.prop( 'disabled', false );
+			return;
+		}
+		let i = 0;
+		function next() {
+			if ( i >= queue.length ) {
+				$btn.prop( 'disabled', false );
+				return;
+			}
+			const $li = queue[ i++ ];
+			importOpmlFeed( $li, nonce, next );
+		}
+		next();
 	} );
 
 } )( jQuery, window.wp, window.friends );

--- a/friends.js
+++ b/friends.js
@@ -843,6 +843,30 @@
 		} );
 	} );
 
+	let subscriptionPreviewId = 0;
+	let subscriptionPasteReviewTimer = null;
+
+	function friendsText( key, fallback ) {
+		return friends && friends[ key ] ? friends[ key ] : fallback;
+	}
+
+	function ajaxErrorText( result ) {
+		if ( $.isArray( result ) ) {
+			return result.join( ', ' );
+		}
+		if ( result && result.message ) {
+			return result.message;
+		}
+		if ( result ) {
+			return String( result );
+		}
+		return friendsText( 'text_error', 'An error occurred.' );
+	}
+
+	function getSubscriptionNonce() {
+		return $( '#add-subscription-form input[name=_wpnonce]' ).val();
+	}
+
 	function looksLikeOpml( text ) {
 		if ( ! text ) {
 			return false;
@@ -854,135 +878,591 @@
 		return /<\s*(opml|outline)\b/i.test( trimmed );
 	}
 
-	$document.on( 'submit', '#add-subscription-form', function ( e ) {
-		e.preventDefault();
-		const $this = $( this );
-		const url = $this.find( 'input[name="url"]' ).val();
-		if ( ! url ) {
-			return;
-		}
-		if ( looksLikeOpml( url ) ) {
-			renderOpmlPreview( url );
-			return;
-		}
-		const $preview = $( '#preview-subscription' );
-		$preview.html( '<p class="loading">' + ( friends.text_loading || 'Loading...' ) + '</p>' );
-		wp.ajax.send( 'friends-preview-subscription', {
-			data: {
-				_ajax_nonce: $this.find( 'input[name=_wpnonce]' ).val(),
-				url: url,
-			},
-			success( r ) {
-				$preview.data( 'feeds', r.feeds );
-				let html = '<div class="feed-preview">';
-				if ( r.avatar ) {
-					html += '<img src="' + r.avatar + '" class="avatar" width="48" height="48" /> ';
-				}
-				html += '<strong>' + ( r.display_name || r.user_login || r.url ) + '</strong>';
-				if ( r.description ) {
-					html += '<p>' + r.description + '</p>';
-				}
-				html += '<ul class="feed-list">';
-				const feedUrls = Object.keys( r.feeds );
-				for ( let i = 0; i < feedUrls.length; i++ ) {
-					const feedUrl = feedUrls[ i ];
-					const feed = r.feeds[ feedUrl ];
-					if ( feed.parser === 'unsupported' ) {
-						continue;
-					}
-					const checked = feed.autoselect ? ' checked' : '';
-					html += '<li><label><input type="checkbox" name="feed" value="' + feedUrl + '"' + checked + ' /> ';
-					html += ( feed.title || feedUrl ) + ' <small>(' + ( feed.type || '' ) + ')</small>';
-					html += '</label></li>';
-				}
-				html += '</ul>';
-				html += '<button class="btn btn-primary subscribe-btn" data-url="' + r.url + '" data-display-name="' + ( r.display_name || '' ) + '" data-nonce="' + $this.find( 'input[name=_wpnonce]' ).val() + '">';
-				html += ( friends.text_follow || 'Follow' ) + '</button>';
-				html += '</div>';
-				$preview.html( html );
-				$preview.find( '.subscribe-btn' ).focus();
-			},
-			error( result ) {
-				$preview.html( '<p class="error">' + ( result && result.length ? result : ( friends.text_error || 'An error occurred.' ) ) + '</p>' );
-			},
-		} );
-	} );
-
-	$document.on( 'click', '.subscribe-btn', function () {
-		const $this = $( this );
-		const $preview = $( '#preview-subscription' );
-		const allFeeds = $preview.data( 'feeds' ) || {};
-		const feeds = {};
-		$preview.find( 'input[name="feed"]' ).each( function () {
-			const $input = $( this );
-			const feedUrl = $input.val();
-			feeds[ feedUrl ] = $.extend( {}, allFeeds[ feedUrl ] || {}, {
-				url: feedUrl,
-				selected: $input.is( ':checked' ),
+	function parsePastedPeopleList( text ) {
+		const seen = {};
+		const items = [];
+		const lines = text.split( /\r?\n/ );
+		for ( let i = 0; i < lines.length; i++ ) {
+			const line = lines[ i ]
+				.replace( /^\s*[-*]\s+/, '' )
+				.replace( /^\s*\d+[.)]\s+/, '' )
+				.trim();
+			if ( ! line || seen[ line ] ) {
+				continue;
+			}
+			seen[ line ] = true;
+			items.push( {
+				url: line,
+				text: line,
 			} );
-		} );
-		wp.ajax.send( 'friends-subscribe-frontend', {
-			data: {
-				_ajax_nonce: $this.data( 'nonce' ),
-				url: $this.data( 'url' ),
-				display_name: $this.data( 'display-name' ),
-				feeds: feeds,
-			},
-			success( r ) {
-				let html = '<div class="subscribe-success">';
-				const avatar = $preview.find( '.avatar' ).attr( 'src' );
-				if ( avatar ) {
-					html += '<img src="' + avatar + '" class="avatar" width="48" height="48" /> ';
-				}
-				html += '<a href="' + r.url + '">' + r.message + '</a>';
-				html += '</div>';
-				$preview.html( html );
-			},
-			error( result ) {
-				$preview.html( '<p class="error">' + result + '</p>' );
-			},
-		} );
-	} );
+		}
+		return items.length > 1 ? items : [];
+	}
 
-	function renderOpmlPreview( opmlText ) {
-		const $preview = $( '#preview-subscription' );
+	function parseOpmlItems( opmlText ) {
 		const parser = new DOMParser();
 		const doc = parser.parseFromString( opmlText, 'application/xml' );
 		if ( doc.getElementsByTagName( 'parsererror' ).length ) {
-			$preview.html( '<p class="error">' + ( friends.text_opml_invalid || 'Could not parse the OPML file.' ) + '</p>' );
-			return;
+			return {
+				error: friendsText( 'text_opml_invalid', 'Could not parse the OPML file.' ),
+			};
 		}
+
 		const outlines = doc.querySelectorAll( 'outline[xmlUrl]' );
 		if ( ! outlines.length ) {
-			$preview.html( '<p class="error">' + ( friends.text_opml_no_feeds || 'No feeds were found in the OPML file.' ) + '</p>' );
+			return {
+				error: friendsText( 'text_opml_no_feeds', 'No feeds were found in the OPML file.' ),
+			};
+		}
+
+		const items = [];
+		$( outlines ).each( function () {
+			const xmlUrl = this.getAttribute( 'xmlUrl' ) || '';
+			const htmlUrl = this.getAttribute( 'htmlUrl' ) || '';
+			items.push( {
+				url: htmlUrl || xmlUrl,
+				feedUrl: xmlUrl,
+				htmlUrl: htmlUrl,
+				text: this.getAttribute( 'text' ) || this.getAttribute( 'title' ) || xmlUrl,
+			} );
+		} );
+
+		return { items: items };
+	}
+
+	function setSubscriptionPreviewError( message ) {
+		$( '#preview-subscription' ).empty().append( $( '<p class="error"></p>' ).text( message ) );
+	}
+
+	function createSelect( options, selected, className ) {
+		const $select = $( '<select></select>' ).addClass( 'form-select ' + className );
+		let selectedFound = false;
+		$.each( options, function ( value, label ) {
+			const $option = $( '<option></option>' ).attr( 'value', value ).text( label );
+			if ( selected === value ) {
+				$option.prop( 'selected', true );
+				selectedFound = true;
+			}
+			$select.append( $option );
+		} );
+		if ( selected && ! selectedFound ) {
+			$select.append( $( '<option></option>' ).attr( 'value', selected ).prop( 'selected', true ).text( selected ) );
+		}
+		return $select;
+	}
+
+	function generateUserLogin( value ) {
+		return String( value || '' )
+			.toLowerCase()
+			.replace( /[^a-z0-9.]+/g, '-' )
+			.replace( /^-+|-+$/g, '' );
+	}
+
+	function htmlToPlainText( value ) {
+		const doc = new DOMParser().parseFromString( String( value || '' ), 'text/html' );
+		if ( ! doc.body ) {
+			return String( value || '' );
+		}
+		$( doc.body ).find( 'script, style, noscript' ).remove();
+		return doc.body.textContent.replace( /\s+/g, ' ' ).trim();
+	}
+
+	function appendMetadataText( $details, label, value ) {
+		if ( ! value ) {
+			return;
+		}
+		if ( $details.contents().length ) {
+			$details.append( document.createTextNode( ' | ' ) );
+		}
+		$details.append( document.createTextNode( label + ': ' + value ) );
+	}
+
+	function getDefaultParser() {
+		const parsers = friends.registered_parsers || { simplepie: 'SimplePie' };
+		const parserKeys = Object.keys( parsers );
+		return parserKeys.length ? parserKeys[ 0 ] : 'simplepie';
+	}
+
+	function getFeedOptionUrl( $item ) {
+		const $input = $item.find( '.subscription-feed-url' );
+		if ( $input.length ) {
+			return $.trim( $input.val() );
+		}
+		return $.trim( $item.data( 'feedUrl' ) || '' );
+	}
+
+	function resetSubscriptionFeedPreview( $item ) {
+		const $preview = $item.find( '.subscription-feed-preview' );
+		$preview.removeData( 'loaded' ).empty().addClass( 'hidden' );
+		$item.find( '.subscription-feed-preview-toggle' ).text( friendsText( 'text_preview_feed', 'Preview feed' ) );
+	}
+
+	function renderSubscriptionFeedOption( panelId, feedIndex, feedUrl, feed, options ) {
+		const settings = $.extend( { hidden: false, unsupported: false, custom: false }, options || {} );
+		const feedDetails = $.extend( { url: feedUrl }, feed || {} );
+		const feedId = panelId + '-feed-' + feedIndex;
+		const parser = settings.unsupported || settings.custom ? getDefaultParser() : ( feedDetails.parser || getDefaultParser() );
+		const title = feedDetails.title || feedUrl || friendsText( 'text_custom_feed', 'Custom feed' );
+		const $item = $( '<li class="subscription-feed-option"></li>' )
+			.toggleClass( 'hidden rel-alternate', settings.hidden )
+			.toggleClass( 'unsupported-feed-option', settings.unsupported )
+			.toggleClass( 'custom-feed-option', settings.custom )
+			.data( {
+				feedUrl: feedUrl,
+				feed: feedDetails,
+			} );
+		const $checkbox = $( '<input type="checkbox" class="subscription-feed-selected" />' )
+			.attr( 'id', feedId )
+			.prop( 'checked', settings.custom ? true : ( ! settings.unsupported && !! feedDetails.autoselect ) );
+		const $label = $( '<label></label>' ).attr( 'for', feedId ).append( $checkbox ).append( ' ' );
+		if ( feedUrl ) {
+			$label.append(
+				$( '<a class="subscription-feed-title-link" target="_blank" rel="noopener noreferrer"></a>' )
+					.attr( 'href', feedUrl )
+					.text( title )
+			);
+		} else {
+			$label.append( $( '<span class="subscription-feed-title"></span>' ).text( title ) );
+		}
+		if ( feedDetails.type ) {
+			$label.append( ' ' ).append( $( '<small></small>' ).text( '(' + feedDetails.type + ')' ) );
+		}
+		$item.append( $label );
+
+		const $controls = $( '<div class="subscription-feed-controls"></div>' );
+		if ( settings.unsupported || settings.custom ) {
+			$controls.append(
+				$( '<label class="subscription-feed-url-label"></label>' )
+					.text( friendsText( 'text_feed_url', 'Feed URL' ) )
+					.append(
+						$( '<input type="url" class="form-input subscription-feed-url" />' )
+							.val( feedUrl )
+							.attr( 'placeholder', 'https://example.com/feed.xml' )
+					)
+			);
+		}
+		$controls.append(
+			$( '<label></label>' )
+				.text( friendsText( 'text_post_format', 'Post Format' ) )
+				.append( createSelect( friends.post_formats || { standard: 'Standard' }, feedDetails[ 'post-format' ] || 'standard', 'subscription-feed-post-format' ) )
+		);
+		$controls.append(
+			$( '<label></label>' )
+				.text( friendsText( 'text_feed_parser', 'Parser' ) )
+				.append( createSelect( friends.registered_parsers || { simplepie: 'SimplePie' }, parser, 'subscription-feed-parser' ) )
+		);
+		$controls.append(
+			$( '<button type="button" class="btn btn-link subscription-feed-preview-toggle"></button>' )
+				.text( friendsText( 'text_preview_feed', 'Preview feed' ) )
+		);
+		$item.append( $controls );
+
+		const $details = $( '<p class="description details subscription-feed-details hidden"></p>' );
+		appendMetadataText( $details, 'Type', feedDetails.type );
+		appendMetadataText( $details, 'rel', feedDetails.rel );
+		appendMetadataText( $details, 'URL', feedUrl );
+		appendMetadataText( $details, 'Parser', feedDetails.parser );
+		if ( feedDetails[ 'additional-info' ] ) {
+			$details.append( $( '<br />' ) ).append( document.createTextNode( feedDetails[ 'additional-info' ] ) );
+		}
+		$item.append( $details );
+		$item.append( $( '<div class="subscription-feed-preview hidden" aria-live="polite"></div>' ) );
+		return $item;
+	}
+
+	function renderSubscriptionCard( response, nonce, fallbackDisplayName ) {
+		const feeds = response.feeds || {};
+		const displayName = response.display_name || fallbackDisplayName || response.user_login || response.url;
+		const userLogin = response.user_login || generateUserLogin( displayName || response.url );
+		const panelId = 'subscription-preview-' + ( ++subscriptionPreviewId );
+		const $panel = $( '<div class="feed-preview subscription-preview"></div>' )
+			.attr( 'id', panelId )
+			.data( {
+				url: response.url,
+				nonce: nonce,
+			} );
+
+		const $header = $( '<div class="subscription-preview-header"></div>' );
+		if ( response.avatar ) {
+			$header.append( $( '<img class="avatar" width="48" height="48" alt="" />' ).attr( 'src', response.avatar ) );
+		}
+		const $title = $( '<div class="subscription-preview-title"></div>' );
+		$title.append( $( '<strong></strong>' ).text( displayName ) );
+		$title.append( $( '<small></small>' ).text( response.url ) );
+		$header.append( $title );
+		$panel.append( $header );
+
+		if ( response.description ) {
+			$panel.append( $( '<p class="subscription-preview-description"></p>' ).text( htmlToPlainText( response.description ) ) );
+		}
+
+		const $settings = $( '<div class="subscription-settings"></div>' );
+		const $displayNameInput = $( '<input type="text" class="form-input subscription-display-name" required />' ).val( displayName );
+		const $userLoginInput = $( '<input type="text" class="form-input subscription-user-login" required />' )
+			.val( userLogin )
+			.data( 'original', userLogin );
+		$settings.append(
+			$( '<label></label>' )
+				.text( friendsText( 'text_display_name', 'Display Name' ) )
+				.append( $displayNameInput )
+		);
+		$settings.append(
+			$( '<label></label>' )
+				.text( friendsText( 'text_username', 'Username' ) )
+				.append( $userLoginInput )
+		);
+		$panel.append( $settings );
+
+		const $feedList = $( '<ul class="feed-list subscription-feed-list"></ul>' );
+		const unsupportedFeeds = [];
+		let supportedCount = 0;
+		let hiddenFeedCount = 0;
+
+		$.each( feeds, function ( feedUrl, feed ) {
+			if ( ! feed || 'unsupported' === feed.parser ) {
+				unsupportedFeeds.push( {
+					url: feedUrl,
+					feed: feed || {},
+				} );
+				return;
+			}
+
+			supportedCount++;
+			const hidden = supportedCount > 1 && ! feed.autoselect;
+			if ( hidden ) {
+				hiddenFeedCount++;
+			}
+
+			$feedList.append( renderSubscriptionFeedOption( panelId, supportedCount, feedUrl, feed, { hidden: hidden } ) );
+		} );
+
+		if ( supportedCount ) {
+			$panel.append( $feedList );
+		} else {
+			$panel.append( $( '<p class="error"></p>' ).text( friendsText( 'text_no_supported_feeds', 'No supported feeds discovered.' ) ) );
+		}
+
+		const $feedActions = $( '<div class="subscription-feed-actions"></div>' );
+		if ( hiddenFeedCount ) {
+			$feedActions.append(
+				$( '<button type="button" class="btn btn-link show-alternate-feeds"></button>' )
+					.text( friendsText( 'text_show_more_feeds', 'Show more feeds' ) )
+			);
+		}
+		if ( supportedCount || unsupportedFeeds.length ) {
+			$feedActions.append(
+				$( '<button type="button" class="btn btn-link show-feed-details"></button>' )
+					.text( friendsText( 'text_feed_metadata', 'Display feed metadata' ) )
+			);
+		}
+		if ( unsupportedFeeds.length ) {
+			$feedActions.append(
+				$( '<button type="button" class="btn btn-link show-unsupported-feeds"></button>' )
+					.text( friendsText( 'text_show_unsupported_feeds', 'Show unsupported feeds' ) )
+			);
+			const $unsupported = $( '<ul class="feed-list subscription-feed-list unsupported-feed-list hidden"></ul>' );
+			$.each( unsupportedFeeds, function ( index, item ) {
+				$unsupported.append( renderSubscriptionFeedOption( panelId, supportedCount + index + 1, item.url, item.feed, { unsupported: true } ) );
+			} );
+			$panel.append( $unsupported );
+		}
+		$feedActions.append(
+			$( '<button type="button" class="btn btn-link add-custom-feed"></button>' )
+				.text( friendsText( 'text_add_feed_url', 'Add feed URL' ) )
+		);
+		if ( $feedActions.children().length ) {
+			$panel.append( $feedActions );
+		}
+
+		const $previewActions = $( '<div class="subscription-preview-actions"></div>' )
+			.append( $( '<button type="button" class="btn btn-link bulk-skip-entry"></button>' ).text( friendsText( 'text_skip', 'Skip' ) ) )
+			.append( $( '<button type="button" class="btn btn-primary subscribe-btn"></button>' ).text( friendsText( 'text_follow', 'Follow' ) ) )
+			.append( $( '<span class="subscription-preview-status" aria-live="polite"></span>' ) );
+		$panel.append( $previewActions );
+
+		return $panel;
+	}
+
+	function collectSubscriptionFeeds( $panel ) {
+		const feeds = [];
+		$panel.find( '.subscription-feed-option' ).each( function () {
+			const $item = $( this );
+			const feed = $.extend( {}, $item.data( 'feed' ) || {} );
+			feed.url = getFeedOptionUrl( $item );
+			if ( ! feed.url ) {
+				return;
+			}
+			feed.selected = $item.find( '.subscription-feed-selected' ).is( ':checked' );
+			feed[ 'post-format' ] = $item.find( '.subscription-feed-post-format' ).val();
+			feed.parser = $item.find( '.subscription-feed-parser' ).val();
+			feeds.push( feed );
+		} );
+		return feeds;
+	}
+
+	function renderFeedPreviewItems( $preview, items ) {
+		$preview.empty();
+		if ( ! items || ! items.length ) {
+			$preview.append( $( '<p class="description"></p>' ).text( friendsText( 'text_no_preview_items', 'No preview items were found.' ) ) );
 			return;
 		}
 
-		const $list = $( '<ul class="feed-list opml-feed-list"></ul>' );
-		outlines.forEach( function ( outline, idx ) {
-			const xmlUrl = outline.getAttribute( 'xmlUrl' ) || '';
-			const htmlUrl = outline.getAttribute( 'htmlUrl' ) || '';
-			const text = outline.getAttribute( 'text' ) || outline.getAttribute( 'title' ) || '';
-			const $cb = $( '<input type="checkbox" class="opml-feed-cb" checked />' )
-				.data( { xmlUrl: xmlUrl, htmlUrl: htmlUrl, text: text } )
-				.attr( 'data-idx', idx );
-			const $label = $( '<label></label>' ).append( $cb );
-			$label.append( document.createTextNode( ' ' + ( text || xmlUrl ) ) );
-			if ( htmlUrl ) {
-				$label.append( ' ' );
-				$label.append( $( '<small></small>' ).append( $( '<a target="_blank" rel="noopener noreferrer"></a>' ).attr( 'href', htmlUrl ).text( htmlUrl ) ) );
+		const $list = $( '<ul></ul>' );
+		$.each( items, function ( index, item ) {
+			const $item = $( '<li></li>' );
+			const $summary = $( '<div class="subscription-feed-preview-title"></div>' );
+			if ( item.permalink ) {
+				$summary.append(
+					$( '<a target="_blank" rel="noopener noreferrer"></a>' )
+						.attr( 'href', item.permalink )
+						.text( item.title || item.permalink )
+				);
+			} else {
+				$summary.text( item.title || '' );
 			}
-			const $status = $( '<span class="opml-feed-status"></span>' );
-			$list.append( $( '<li></li>' ).attr( 'data-idx', idx ).append( $label ).append( ' ' ).append( $status ) );
+			const meta = [];
+			if ( item.date ) {
+				meta.push( item.date );
+			}
+			if ( item.author ) {
+				meta.push( item.author );
+			}
+			if ( item.post_format ) {
+				meta.push( item.post_format );
+			}
+			if ( meta.length ) {
+				$summary.append( $( '<small></small>' ).text( meta.join( ' | ' ) ) );
+			}
+			$item.append( $summary );
+			if ( item.excerpt ) {
+				$item.append( $( '<p></p>' ).text( item.excerpt ) );
+			}
+			$list.append( $item );
+		} );
+		$preview.append( $list );
+	}
+
+	function previewSubscriptionFeed( $item, $button ) {
+		const $preview = $item.find( '.subscription-feed-preview' );
+		const feedUrl = getFeedOptionUrl( $item );
+		if ( ! feedUrl ) {
+			$preview.removeClass( 'hidden' ).empty().append( $( '<p class="error"></p>' ).text( friendsText( 'text_feed_url_required', 'Please enter a feed URL.' ) ) );
+			return;
+		}
+		if ( $preview.data( 'loaded' ) ) {
+			const isHidden = $preview.hasClass( 'hidden' );
+			$preview.toggleClass( 'hidden', ! isHidden );
+			$button.text( isHidden ? friendsText( 'text_hide_preview', 'Hide preview' ) : friendsText( 'text_preview_feed', 'Preview feed' ) );
+			return;
+		}
+
+		$button.prop( 'disabled', true );
+		$preview.removeClass( 'hidden' ).text( friendsText( 'text_loading', 'Loading...' ) );
+		wp.ajax.send( 'friends-preview-subscription-feed', {
+			data: {
+				_ajax_nonce: $item.closest( '.subscription-preview' ).data( 'nonce' ),
+				url: feedUrl,
+				parser: $item.find( '.subscription-feed-parser' ).val(),
+			},
+			success( response ) {
+				renderFeedPreviewItems( $preview, response.items );
+				$preview.data( 'loaded', true );
+				$button.prop( 'disabled', false ).text( friendsText( 'text_hide_preview', 'Hide preview' ) );
+			},
+			error( result ) {
+				$preview.empty().append( $( '<p class="error"></p>' ).text( ajaxErrorText( result ) ) );
+				$button.prop( 'disabled', false );
+			},
+		} );
+	}
+
+	function subscribeSubscriptionPanel( $panel, $button, done ) {
+		const feeds = collectSubscriptionFeeds( $panel );
+		let selectedFeedCount = 0;
+		for ( let i = 0; i < feeds.length; i++ ) {
+			if ( feeds[ i ].selected ) {
+				selectedFeedCount++;
+			}
+		}
+
+		const $status = $panel.find( '.subscription-preview-status' );
+		if ( ! selectedFeedCount ) {
+			$status.addClass( 'error' ).text( friendsText( 'text_no_feed_selected', 'Please select at least one feed.' ) );
+			if ( done ) {
+				done( false );
+			}
+			return;
+		}
+
+		$button.prop( 'disabled', true );
+		$status.removeClass( 'error' ).text( friendsText( 'text_loading', 'Loading...' ) );
+		wp.ajax.send( 'friends-subscribe-frontend', {
+			data: {
+				_ajax_nonce: $panel.data( 'nonce' ),
+				url: $panel.data( 'url' ),
+				display_name: $panel.find( '.subscription-display-name' ).val(),
+				user_login: $panel.find( '.subscription-user-login' ).val(),
+				feeds: feeds,
+			},
+			success( response ) {
+				const avatar = $panel.find( '.avatar' ).attr( 'src' );
+				const $success = $( '<div class="subscribe-success"></div>' );
+				if ( avatar ) {
+					$success.append( $( '<img class="avatar" width="48" height="48" alt="" />' ).attr( 'src', avatar ) );
+				}
+				$success.append( $( '<a></a>' ).attr( 'href', response.url ).text( response.message ) );
+				$panel.addClass( 'is-subscribed' ).empty().append( $success );
+				if ( done ) {
+					done( true );
+				}
+			},
+			error( result ) {
+				$status.addClass( 'error' ).text( ajaxErrorText( result ) );
+				$button.prop( 'disabled', false );
+				if ( done ) {
+					done( false );
+				}
+			},
+		} );
+	}
+
+	function discoverSubscription( url, nonce, fallbackDisplayName, $target, done ) {
+		wp.ajax.send( 'friends-preview-subscription', {
+			data: {
+				_ajax_nonce: nonce,
+				url: url,
+			},
+			success( response ) {
+				$target.append( renderSubscriptionCard( response, nonce, fallbackDisplayName ) );
+				if ( done ) {
+					done( true );
+				}
+			},
+			error( result ) {
+				if ( done ) {
+					done( false, ajaxErrorText( result ) );
+				} else {
+					setSubscriptionPreviewError( ajaxErrorText( result ) );
+				}
+			},
+		} );
+	}
+
+	function renderSingleSubscriptionPreview( url ) {
+		const $preview = $( '#preview-subscription' ).empty();
+		const $results = $( '<div class="subscription-preview-results"></div>' );
+		$preview.append( $( '<p class="loading"></p>' ).text( friendsText( 'text_loading', 'Loading...' ) ) );
+		$preview.append( $results );
+		discoverSubscription( url, getSubscriptionNonce(), '', $results, function ( success, message ) {
+			$preview.find( '.loading' ).remove();
+			if ( ! success ) {
+				setSubscriptionPreviewError( message || friendsText( 'text_error', 'An error occurred.' ) );
+			}
+		} );
+	}
+
+	function renderBulkPicker( items ) {
+		const $preview = $( '#preview-subscription' ).empty();
+		const $controls = $( '<div class="bulk-controls"></div>' );
+		$controls.append( $( '<button type="button" class="btn btn-link bulk-toggle-all"></button>' ).text( friendsText( 'text_opml_deselect_all', 'Deselect all' ) ) );
+		$controls.append( ' ' );
+		$controls.append( $( '<button type="button" class="btn btn-primary bulk-preview-selected"></button>' ).text( friendsText( 'text_review_selected', 'Review selected' ) ) );
+		$controls.append( ' ' );
+		$controls.append( $( '<button type="button" class="btn btn-primary bulk-follow-selected hidden"></button>' ).text( friendsText( 'text_follow_selected', 'Follow selected' ) ) );
+
+		const $list = $( '<ul class="feed-list bulk-feed-list"></ul>' );
+		$.each( items, function ( index, item ) {
+			const itemId = 'bulk-feed-' + index;
+			const $checkbox = $( '<input type="checkbox" class="bulk-feed-cb" checked />' )
+				.attr( 'id', itemId )
+				.data( item );
+			const $label = $( '<label class="label-for-bulkfeed"></label>' )
+				.attr( 'for', itemId )
+				.append( $checkbox )
+				.append( ' ' )
+				.append( document.createTextNode( item.text || item.url ) );
+			if ( item.htmlUrl ) {
+				$label.append( ' ' ).append(
+					$( '<small></small>' ).append(
+						$( '<a target="_blank" rel="noopener noreferrer"></a>' )
+							.attr( 'href', item.htmlUrl )
+							.text( item.htmlUrl )
+					)
+				);
+			}
+			$list.append(
+				$( '<li class="bulk-feed-row"></li>' )
+					.append( $label )
+					.append( ' ' )
+					.append( $( '<span class="bulk-feed-status"></span>' ) )
+					.append( $( '<div class="bulk-feed-review"></div>' ) )
+			);
 		} );
 
-		const $controls = $( '<div class="opml-controls"></div>' );
-		$controls.append( $( '<button type="button" class="btn btn-link opml-toggle-all"></button>' ).text( friends.text_opml_deselect_all || 'Deselect all' ) );
-		$controls.append( ' ' );
-		$controls.append( $( '<button type="button" class="btn btn-primary opml-import-selected"></button>' ).text( friends.text_opml_import_selected || 'Import selected' ) );
-
-		$preview.empty().append( $controls ).append( $list );
+		$preview.append( $controls ).append( $list );
 	}
+
+	function updateBulkFeedRowState( $row ) {
+		const isChecked = $row.find( '.bulk-feed-cb' ).is( ':checked' );
+		const hasPreview = !! $row.find( '.bulk-feed-review .subscription-preview' ).length;
+		const previewIsVisible = ! $row.find( '.bulk-feed-review' ).hasClass( 'hidden' );
+		const isReviewing = isChecked && hasPreview && previewIsVisible;
+		$row.toggleClass( 'is-reviewing', isReviewing );
+		$row.find( '.label-for-bulkfeed, .bulk-feed-status' ).toggleClass( 'hidden', isReviewing );
+	}
+
+	function reviewBulkSubscription( $item, nonce, done ) {
+		const data = $item.find( '.bulk-feed-cb' ).data();
+		const $status = $item.find( '.bulk-feed-status' );
+		const $review = $item.find( '.bulk-feed-review' ).empty();
+		$status.removeClass( 'error' ).text( friendsText( 'text_discovering', 'Discovering feeds...' ) );
+		updateBulkFeedRowState( $item );
+		discoverSubscription( data.url, nonce, data.text, $review, function ( success, message ) {
+			if ( success ) {
+				$status.text( friendsText( 'text_ready_to_follow', 'Ready' ) );
+			} else {
+				$status.addClass( 'error' ).text( message || friendsText( 'text_error', 'An error occurred.' ) );
+			}
+			updateBulkFeedRowState( $item );
+			done();
+		} );
+	}
+
+	$document.on( 'submit', '#add-subscription-form', function ( e ) {
+		e.preventDefault();
+		const value = $( this ).find( '[name="url"]' ).val();
+		if ( ! value ) {
+			return;
+		}
+
+		if ( looksLikeOpml( value ) ) {
+			const parsedOpml = parseOpmlItems( value );
+			if ( parsedOpml.error ) {
+				setSubscriptionPreviewError( parsedOpml.error );
+				return;
+			}
+			renderBulkPicker( parsedOpml.items );
+			return;
+		}
+
+		const pastedItems = parsePastedPeopleList( value );
+		if ( pastedItems.length ) {
+			renderBulkPicker( pastedItems );
+			return;
+		}
+
+		renderSingleSubscriptionPreview( value.trim() );
+	} );
+
+	$document.on( 'paste', '#subscription-url', function () {
+		const input = this;
+		clearTimeout( subscriptionPasteReviewTimer );
+		subscriptionPasteReviewTimer = setTimeout( function () {
+			if ( $( input ).val().trim() ) {
+				$( input ).closest( 'form' ).trigger( 'submit' );
+			}
+		}, 25 );
+	} );
 
 	$document.on( 'change', '#opml-file', function () {
 		const file = this.files && this.files[ 0 ];
@@ -991,106 +1471,176 @@
 		}
 		const reader = new FileReader();
 		reader.onload = function ( e ) {
-			renderOpmlPreview( e.target.result );
+			const parsedOpml = parseOpmlItems( e.target.result );
+			if ( parsedOpml.error ) {
+				setSubscriptionPreviewError( parsedOpml.error );
+				return;
+			}
+			renderBulkPicker( parsedOpml.items );
 		};
 		reader.readAsText( file );
 	} );
 
-	$document.on( 'click', '.opml-toggle-all', function () {
-		const $this = $( this );
-		const $cbs = $( '.opml-feed-cb' );
-		const allChecked = $cbs.length === $cbs.filter( ':checked' ).length;
-		$cbs.prop( 'checked', ! allChecked );
-		$this.text( allChecked ? ( friends.text_opml_select_all || 'Select all' ) : ( friends.text_opml_deselect_all || 'Deselect all' ) );
+	$document.on( 'keyup', '.subscription-display-name', function () {
+		const $login = $( this ).closest( '.subscription-preview' ).find( '.subscription-user-login' );
+		if ( this.value && $login.data( 'original' ) === $login.val() ) {
+			const generatedLogin = generateUserLogin( this.value );
+			$login.val( generatedLogin );
+			$login.data( 'original', generatedLogin );
+		}
 	} );
 
-	function importOpmlFeed( $li, nonce, done ) {
-		const $cb = $li.find( '.opml-feed-cb' );
-		const data = $cb.data();
-		const $status = $li.find( '.opml-feed-status' );
-		const url = data.htmlUrl || data.xmlUrl;
-		$status.text( '⏳' );
-		wp.ajax.send( 'friends-preview-subscription', {
-			data: {
-				_ajax_nonce: nonce,
-				url: url,
-			},
-			success( r ) {
-				const feedsForSubscribe = {};
-				const feedUrls = Object.keys( r.feeds );
-				let anySelected = false;
-				for ( let i = 0; i < feedUrls.length; i++ ) {
-					const fUrl = feedUrls[ i ];
-					const f = r.feeds[ fUrl ];
-					if ( f.parser === 'unsupported' ) {
-						continue;
-					}
-					const selected = !! f.autoselect;
-					if ( selected ) {
-						anySelected = true;
-					}
-					feedsForSubscribe[ fUrl ] = $.extend( {}, f, { url: fUrl, selected: selected } );
-				}
-				if ( ! anySelected ) {
-					// Fall back to selecting the first supported feed if no autoselect.
-					const keys = Object.keys( feedsForSubscribe );
-					if ( keys.length ) {
-						feedsForSubscribe[ keys[ 0 ] ].selected = true;
-					} else {
-						$status.text( '✗ ' + ( friends.text_opml_no_feeds_for_url || 'No feeds discovered.' ) );
-						done();
-						return;
-					}
-				}
-				wp.ajax.send( 'friends-subscribe-frontend', {
-					data: {
-						_ajax_nonce: nonce,
-						url: r.url,
-						display_name: r.display_name || data.text || '',
-						feeds: feedsForSubscribe,
-					},
-					success( r2 ) {
-						$status.empty().append( '✓ ' ).append( $( '<a></a>' ).attr( 'href', r2.url ).text( r2.message ) );
-						done();
-					},
-					error( result ) {
-						$status.text( '✗ ' + ( result && result.length ? result : ( friends.text_error || 'An error occurred.' ) ) );
-						done();
-					},
-				} );
-			},
-			error( result ) {
-				$status.text( '✗ ' + ( result && result.length ? result : ( friends.text_error || 'An error occurred.' ) ) );
-				done();
-			},
-		} );
-	}
+	$document.on( 'click', '.show-alternate-feeds', function () {
+		$( this ).closest( '.subscription-preview' ).find( '.rel-alternate' ).toggleClass( 'hidden' );
+		return false;
+	} );
 
-	$document.on( 'click', '.opml-import-selected', function () {
-		const $btn = $( this ).prop( 'disabled', true );
-		const nonce = $( '#add-subscription-form input[name=_wpnonce]' ).val();
+	$document.on( 'click', '.show-feed-details', function () {
+		const $this = $( this );
+		const $details = $this.closest( '.subscription-preview' ).find( '.subscription-feed-details' );
+		const isHidden = $details.first().hasClass( 'hidden' );
+		$details.toggleClass( 'hidden', ! isHidden );
+		$this.text( isHidden ? friendsText( 'text_hide_feed_metadata', 'Hide feed metadata' ) : friendsText( 'text_feed_metadata', 'Display feed metadata' ) );
+		return false;
+	} );
+
+	$document.on( 'click', '.show-unsupported-feeds', function () {
+		$( this ).closest( '.subscription-preview' ).find( '.unsupported-feed-list' ).toggleClass( 'hidden' );
+		return false;
+	} );
+
+	$document.on( 'change', '.subscription-feed-parser', function () {
+		resetSubscriptionFeedPreview( $( this ).closest( '.subscription-feed-option' ) );
+	} );
+
+	$document.on( 'input change', '.subscription-feed-url', function () {
+		const $item = $( this ).closest( '.subscription-feed-option' );
+		const feedUrl = getFeedOptionUrl( $item );
+		const feed = $.extend( {}, $item.data( 'feed' ) || {} );
+		feed.url = feedUrl;
+		$item.data( 'feedUrl', feedUrl ).data( 'feed', feed );
+		$item.find( '.subscription-feed-title-link' ).attr( 'href', feedUrl || '#' );
+		$item.find( '.subscription-feed-selected' ).prop( 'checked', !! feedUrl );
+		resetSubscriptionFeedPreview( $item );
+	} );
+
+	$document.on( 'click', '.add-custom-feed', function () {
+		const $panel = $( this ).closest( '.subscription-preview' );
+		let $list = $panel.find( '.custom-feed-list' );
+		if ( ! $list.length ) {
+			$list = $( '<ul class="feed-list subscription-feed-list custom-feed-list"></ul>' );
+			$list.insertBefore( $panel.find( '.subscription-feed-actions' ) );
+		}
+		const feedIndex = $panel.find( '.subscription-feed-option' ).length + 1;
+		const panelId = $panel.attr( 'id' ) || 'subscription-preview';
+		const $item = renderSubscriptionFeedOption(
+			panelId,
+			feedIndex,
+			'',
+			{
+				title: friendsText( 'text_custom_feed', 'Custom feed' ),
+				parser: getDefaultParser(),
+				rel: 'manual',
+				type: 'custom',
+			},
+			{ custom: true }
+		);
+		$list.append( $item );
+		$item.find( '.subscription-feed-url' ).trigger( 'focus' );
+		return false;
+	} );
+
+	$document.on( 'click', '.subscription-feed-preview-toggle', function () {
+		previewSubscriptionFeed( $( this ).closest( '.subscription-feed-option' ), $( this ) );
+		return false;
+	} );
+
+	$document.on( 'click', '.subscribe-btn', function () {
+		subscribeSubscriptionPanel( $( this ).closest( '.subscription-preview' ), $( this ) );
+		return false;
+	} );
+
+	$document.on( 'click', '.bulk-toggle-all', function () {
+		const $this = $( this );
+		const $checkboxes = $( '.bulk-feed-cb' );
+		const allChecked = $checkboxes.length === $checkboxes.filter( ':checked' ).length;
+		$checkboxes.prop( 'checked', ! allChecked ).trigger( 'change' );
+		$this.text( allChecked ? friendsText( 'text_opml_select_all', 'Select all' ) : friendsText( 'text_opml_deselect_all', 'Deselect all' ) );
+		return false;
+	} );
+
+	$document.on( 'change', '.bulk-feed-cb', function () {
+		const $row = $( this ).closest( '.bulk-feed-row' );
+		$row.find( '.bulk-feed-review' ).toggleClass( 'hidden', ! this.checked );
+		if ( ! this.checked ) {
+			$row.find( '.bulk-feed-status' ).text( '' ).removeClass( 'error' );
+		}
+		updateBulkFeedRowState( $row );
+	} );
+
+	$document.on( 'click', '.bulk-skip-entry', function () {
+		const $panel = $( this ).closest( '.subscription-preview' );
+		const $row = $panel.closest( '.bulk-feed-row' );
+		if ( $row.length ) {
+			$row.find( '.bulk-feed-cb' ).prop( 'checked', false ).trigger( 'change' );
+		} else {
+			$panel.addClass( 'hidden' );
+		}
+		return false;
+	} );
+
+	$document.on( 'click', '.bulk-preview-selected', function () {
+		const $button = $( this ).prop( 'disabled', true );
+		const nonce = getSubscriptionNonce();
 		const queue = [];
-		$( '.opml-feed-list li' ).each( function () {
-			const $li = $( this );
-			if ( $li.find( '.opml-feed-cb' ).is( ':checked' ) ) {
-				queue.push( $li );
+		$( '.bulk-feed-list > .bulk-feed-row' ).each( function () {
+			const $item = $( this );
+			if ( $item.find( '.bulk-feed-cb' ).is( ':checked' ) ) {
+				queue.push( $item );
 			}
 		} );
 		if ( ! queue.length ) {
-			alert( friends.text_opml_no_selected || 'Please select at least one feed.' );
-			$btn.prop( 'disabled', false );
-			return;
+			alert( friendsText( 'text_opml_no_selected', 'Please select at least one feed.' ) );
+			$button.prop( 'disabled', false );
+			return false;
 		}
-		let i = 0;
+
+		let index = 0;
 		function next() {
-			if ( i >= queue.length ) {
-				$btn.prop( 'disabled', false );
+			if ( index >= queue.length ) {
+				if ( $( '.bulk-feed-review .subscription-preview .subscribe-btn' ).length ) {
+					$( '.bulk-follow-selected' ).removeClass( 'hidden' );
+				}
+				$button.prop( 'disabled', false );
 				return;
 			}
-			const $li = queue[ i++ ];
-			importOpmlFeed( $li, nonce, next );
+			reviewBulkSubscription( queue[ index++ ], nonce, next );
 		}
 		next();
+		return false;
+	} );
+
+	$document.on( 'click', '.bulk-follow-selected', function () {
+		const $button = $( this ).prop( 'disabled', true );
+		const queue = [];
+		$( '.bulk-feed-list > .bulk-feed-row' ).each( function () {
+			if ( $( this ).find( '.bulk-feed-cb' ).is( ':checked' ) ) {
+				$( this ).find( '.bulk-feed-review .subscription-preview' ).has( '.subscribe-btn' ).not( '.is-subscribed' ).each( function () {
+					queue.push( this );
+				} );
+			}
+		} );
+		let index = 0;
+		function next() {
+			if ( index >= queue.length ) {
+				$button.prop( 'disabled', false );
+				return;
+			}
+			const $panel = $( queue[ index++ ] );
+			subscribeSubscriptionPanel( $panel, $panel.find( '.subscribe-btn' ), next );
+		}
+		next();
+		return false;
 	} );
 
 } )( jQuery, window.wp, window.friends );

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -54,6 +54,8 @@ class Admin {
 		add_action( 'wp_ajax_friends_fetch_feeds', array( $this, 'ajax_fetch_feeds' ) );
 		add_action( 'wp_ajax_friends_set_avatar', array( $this, 'ajax_set_avatar' ) );
 		add_action( 'wp_ajax_friends-refresh-feeds', array( $this, 'ajax_refresh_feeds' ) );
+		add_action( 'wp_ajax_friends-preview-subscription', array( $this, 'ajax_preview_subscription' ) );
+		add_action( 'wp_ajax_friends-subscribe-frontend', array( $this, 'ajax_subscribe_frontend' ) );
 		add_action( 'delete_user_form', array( $this, 'delete_user_form' ), 10, 2 );
 		add_action( 'delete_user', array( $this, 'delete_user' ) );
 		add_action( 'remove_user_from_blog', array( $this, 'delete_user' ) );
@@ -1662,6 +1664,112 @@ class Admin {
 		wp_send_json_success();
 	}
 
+	public function ajax_preview_subscription() {
+		if ( ! isset( $_POST['url'] ) ) {
+			wp_send_json_error( __( 'No URL provided.', 'friends' ) );
+		}
+
+		check_ajax_referer( 'friends_add_subscription' );
+
+		$url = wp_unslash( $_POST['url'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+
+		$protocol = wp_parse_url( $url, PHP_URL_SCHEME );
+		if ( ! $protocol ) {
+			$url = apply_filters( 'friends_rewrite_incoming_url', 'https://' . $url, $url );
+		} else {
+			$url = apply_filters( 'friends_rewrite_incoming_url', $url, $url );
+		}
+
+		$feeds = $this->friends->feed->discover_available_feeds( $url );
+
+		if ( is_wp_error( $feeds ) ) {
+			wp_send_json_error( $feeds->get_error_message() );
+		}
+
+		if ( empty( $feeds ) ) {
+			wp_send_json_error( __( 'No suitable feed was found at the provided address.', 'friends' ) );
+		}
+
+		$display_name = User::get_display_name_from_feeds( $feeds );
+		$user_login = User::get_user_login_from_feeds( $feeds );
+		$avatar = null;
+		$description = null;
+		foreach ( $feeds as $feed_details ) {
+			if ( ! $avatar && ! empty( $feed_details['avatar'] ) ) {
+				$avatar = $feed_details['avatar'];
+			}
+			if ( ! $description && ! empty( $feed_details['description'] ) ) {
+				$description = $feed_details['description'];
+			}
+		}
+
+		wp_send_json_success(
+			array(
+				'feeds'        => $feeds,
+				'display_name' => $display_name ? $display_name : '',
+				'user_login'   => $user_login ? $user_login : '',
+				'avatar'       => $avatar,
+				'description'  => $description,
+				'url'          => $url,
+			)
+		);
+	}
+
+	public function ajax_subscribe_frontend() {
+		check_ajax_referer( 'friends_add_subscription' );
+
+		if ( ! Friends::has_required_privileges() ) {
+			wp_send_json_error( __( 'You do not have permission to do this.', 'friends' ) );
+		}
+
+		$url = isset( $_POST['url'] ) ? wp_unslash( $_POST['url'] ) : ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		$display_name = isset( $_POST['display_name'] ) ? sanitize_text_field( wp_unslash( $_POST['display_name'] ) ) : '';
+		$feeds = isset( $_POST['feeds'] ) ? wp_unslash( $_POST['feeds'] ) : array(); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+
+		if ( empty( $url ) || empty( $feeds ) ) {
+			wp_send_json_error( __( 'Missing required data.', 'friends' ) );
+		}
+
+		$user_login = User::get_user_login_for_url( $url );
+
+		$avatar = null;
+		$description = null;
+		foreach ( $feeds as $feed ) {
+			if ( ! $avatar && ! empty( $feed['avatar'] ) ) {
+				$avatar = $feed['avatar'];
+			}
+			if ( ! $description && ! empty( $feed['description'] ) ) {
+				$description = $feed['description'];
+			}
+		}
+
+		$friend_user = User::create( $user_login, 'subscription', $url, $display_name, $avatar, $description );
+
+		if ( is_wp_error( $friend_user ) ) {
+			wp_send_json_error( $friend_user->get_error_message() );
+		}
+
+		$feed_options = array();
+		foreach ( $feeds as $feed ) {
+			if ( ! empty( $feed['selected'] ) && ! empty( $feed['url'] ) ) {
+				$feed_options[ $feed['url'] ] = $feed;
+			}
+		}
+
+		$friend_user->save_feeds( $feed_options );
+
+		wp_send_json_success(
+			array(
+				'message' => sprintf(
+					// translators: %s is the name of a friend.
+					__( 'You are now following %s.', 'friends' ),
+					$display_name
+				),
+				'url' => $friend_user->get_local_friends_page_url(),
+			)
+		);
+	}
+
 	public function ajax_set_avatar() {
 		if ( ! isset( $_POST['user'] ) ) {
 			wp_send_json_error( __( 'No user specified.', 'friends' ) );
@@ -2648,6 +2756,14 @@ class Admin {
 			)
 		);
 
+		$wp_menu->add_menu(
+			array(
+				'id'     => 'add-friend',
+				'parent' => 'friends-menu',
+				'title'  => esc_html__( 'Add a friend', 'friends' ),
+				'href'   => home_url( '/friends/add-friend' ),
+			)
+		);
 		$wp_menu->add_menu(
 			array(
 				'id'     => 'friends',

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -56,7 +56,6 @@ class Admin {
 		add_action( 'wp_ajax_friends-refresh-feeds', array( $this, 'ajax_refresh_feeds' ) );
 		add_action( 'wp_ajax_friends-preview-subscription', array( $this, 'ajax_preview_subscription' ) );
 		add_action( 'wp_ajax_friends-subscribe-frontend', array( $this, 'ajax_subscribe_frontend' ) );
-		add_action( 'wp_ajax_friends-refresh-feeds', array( $this, 'ajax_refresh_feeds' ) );
 		add_action( 'delete_user_form', array( $this, 'delete_user_form' ), 10, 2 );
 		add_action( 'delete_user', array( $this, 'delete_user' ) );
 		add_action( 'remove_user_from_blog', array( $this, 'delete_user' ) );
@@ -1786,28 +1785,6 @@ class Admin {
 				'url' => $friend_user->get_local_friends_page_url(),
 			)
 		);
-	}
-
-	public function ajax_refresh_feeds() {
-		check_ajax_referer( 'friends-refresh' );
-
-		if ( ! Friends::has_required_privileges() ) {
-			wp_send_json_error( __( 'You do not have permission to do this.', 'friends' ) );
-		}
-
-		add_filter( 'notify_about_new_friend_post', '__return_false', 999 );
-
-		if ( ! empty( $_POST['user'] ) ) {
-			$friend_user = User::get_by_username( sanitize_user( wp_unslash( $_POST['user'] ) ) );
-			if ( ! $friend_user || is_wp_error( $friend_user ) || ! $friend_user->can_refresh_feeds() ) {
-				wp_send_json_error( __( 'Invalid user ID.' ) ); // phpcs:ignore WordPress.WP.I18n.MissingArgDomain
-			}
-			$friend_user->retrieve_posts_from_active_feeds();
-		} else {
-			$this->friends->feed->retrieve_friend_posts();
-		}
-
-		wp_send_json_success();
 	}
 
 	public function ajax_set_avatar() {

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -56,6 +56,7 @@ class Admin {
 		add_action( 'wp_ajax_friends-refresh-feeds', array( $this, 'ajax_refresh_feeds' ) );
 		add_action( 'wp_ajax_friends-preview-subscription', array( $this, 'ajax_preview_subscription' ) );
 		add_action( 'wp_ajax_friends-subscribe-frontend', array( $this, 'ajax_subscribe_frontend' ) );
+		add_action( 'wp_ajax_friends-refresh-feeds', array( $this, 'ajax_refresh_feeds' ) );
 		add_action( 'delete_user_form', array( $this, 'delete_user_form' ), 10, 2 );
 		add_action( 'delete_user', array( $this, 'delete_user' ) );
 		add_action( 'remove_user_from_blog', array( $this, 'delete_user' ) );
@@ -1750,13 +1751,30 @@ class Admin {
 		}
 
 		$feed_options = array();
+		$subscribe = array();
 		foreach ( $feeds as $feed ) {
-			if ( ! empty( $feed['selected'] ) && ! empty( $feed['url'] ) ) {
+			if ( ! empty( $feed['url'] ) ) {
 				$feed_options[ $feed['url'] ] = $feed;
+				if ( ! empty( $feed['selected'] ) ) {
+					$subscribe[] = $feed['url'];
+				}
 			}
 		}
 
 		$friend_user->save_feeds( $feed_options );
+
+		foreach ( $subscribe as $feed_url ) {
+			if ( ! isset( $feed_options[ $feed_url ] ) ) {
+				continue;
+			}
+			$new_feed = $friend_user->subscribe( $feed_url, $feed_options[ $feed_url ] );
+			if ( ! is_wp_error( $new_feed ) ) {
+				do_action( 'friends_user_feed_activated', $new_feed );
+			}
+		}
+
+		add_filter( 'notify_about_new_friend_post', '__return_false', 999 );
+		$friend_user->retrieve_posts_from_active_feeds();
 
 		wp_send_json_success(
 			array(
@@ -1768,6 +1786,28 @@ class Admin {
 				'url' => $friend_user->get_local_friends_page_url(),
 			)
 		);
+	}
+
+	public function ajax_refresh_feeds() {
+		check_ajax_referer( 'friends-refresh' );
+
+		if ( ! Friends::has_required_privileges() ) {
+			wp_send_json_error( __( 'You do not have permission to do this.', 'friends' ) );
+		}
+
+		add_filter( 'notify_about_new_friend_post', '__return_false', 999 );
+
+		if ( ! empty( $_POST['user'] ) ) {
+			$friend_user = User::get_by_username( sanitize_user( wp_unslash( $_POST['user'] ) ) );
+			if ( ! $friend_user || is_wp_error( $friend_user ) || ! $friend_user->can_refresh_feeds() ) {
+				wp_send_json_error( __( 'Invalid user ID.' ) ); // phpcs:ignore WordPress.WP.I18n.MissingArgDomain
+			}
+			$friend_user->retrieve_posts_from_active_feeds();
+		} else {
+			$this->friends->feed->retrieve_friend_posts();
+		}
+
+		wp_send_json_success();
 	}
 
 	public function ajax_set_avatar() {

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -1671,6 +1671,10 @@ class Admin {
 
 		check_ajax_referer( 'friends_add_subscription' );
 
+		if ( ! Friends::has_required_privileges() ) {
+			wp_send_json_error( __( 'You do not have permission to do this.', 'friends' ) );
+		}
+
 		$url = wp_unslash( $_POST['url'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 
 		$protocol = wp_parse_url( $url, PHP_URL_SCHEME );
@@ -1782,7 +1786,7 @@ class Admin {
 					__( 'You are now following %s.', 'friends' ),
 					$display_name
 				),
-				'url' => $friend_user->get_local_friends_page_url(),
+				'url'     => $friend_user->get_local_friends_page_url(),
 			)
 		);
 	}

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -54,6 +54,8 @@ class Admin {
 		add_action( 'wp_ajax_friends_fetch_feeds', array( $this, 'ajax_fetch_feeds' ) );
 		add_action( 'wp_ajax_friends_set_avatar', array( $this, 'ajax_set_avatar' ) );
 		add_action( 'wp_ajax_friends-refresh-feeds', array( $this, 'ajax_refresh_feeds' ) );
+		add_action( 'wp_ajax_friends-preview-subscription', array( $this, 'ajax_preview_subscription' ) );
+		add_action( 'wp_ajax_friends-subscribe-frontend', array( $this, 'ajax_subscribe_frontend' ) );
 		add_action( 'delete_user_form', array( $this, 'delete_user_form' ), 10, 2 );
 		add_action( 'delete_user', array( $this, 'delete_user' ) );
 		add_action( 'remove_user_from_blog', array( $this, 'delete_user' ) );
@@ -1662,6 +1664,112 @@ class Admin {
 		wp_send_json_success();
 	}
 
+	public function ajax_preview_subscription() {
+		if ( ! isset( $_POST['url'] ) ) {
+			wp_send_json_error( __( 'No URL provided.', 'friends' ) );
+		}
+
+		check_ajax_referer( 'friends_add_subscription' );
+
+		$url = wp_unslash( $_POST['url'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+
+		$protocol = wp_parse_url( $url, PHP_URL_SCHEME );
+		if ( ! $protocol ) {
+			$url = apply_filters( 'friends_rewrite_incoming_url', 'https://' . $url, $url );
+		} else {
+			$url = apply_filters( 'friends_rewrite_incoming_url', $url, $url );
+		}
+
+		$feeds = $this->friends->feed->discover_available_feeds( $url );
+
+		if ( is_wp_error( $feeds ) ) {
+			wp_send_json_error( $feeds->get_error_message() );
+		}
+
+		if ( empty( $feeds ) ) {
+			wp_send_json_error( __( 'No suitable feed was found at the provided address.', 'friends' ) );
+		}
+
+		$display_name = User::get_display_name_from_feeds( $feeds );
+		$user_login = User::get_user_login_from_feeds( $feeds );
+		$avatar = null;
+		$description = null;
+		foreach ( $feeds as $feed_details ) {
+			if ( ! $avatar && ! empty( $feed_details['avatar'] ) ) {
+				$avatar = $feed_details['avatar'];
+			}
+			if ( ! $description && ! empty( $feed_details['description'] ) ) {
+				$description = $feed_details['description'];
+			}
+		}
+
+		wp_send_json_success(
+			array(
+				'feeds'        => $feeds,
+				'display_name' => $display_name ? $display_name : '',
+				'user_login'   => $user_login ? $user_login : '',
+				'avatar'       => $avatar,
+				'description'  => $description,
+				'url'          => $url,
+			)
+		);
+	}
+
+	public function ajax_subscribe_frontend() {
+		check_ajax_referer( 'friends_add_subscription' );
+
+		if ( ! Friends::has_required_privileges() ) {
+			wp_send_json_error( __( 'You do not have permission to do this.', 'friends' ) );
+		}
+
+		$url = isset( $_POST['url'] ) ? wp_unslash( $_POST['url'] ) : ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		$display_name = isset( $_POST['display_name'] ) ? sanitize_text_field( wp_unslash( $_POST['display_name'] ) ) : '';
+		$feeds = isset( $_POST['feeds'] ) ? wp_unslash( $_POST['feeds'] ) : array(); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+
+		if ( empty( $url ) || empty( $feeds ) ) {
+			wp_send_json_error( __( 'Missing required data.', 'friends' ) );
+		}
+
+		$user_login = User::get_user_login_for_url( $url );
+
+		$avatar = null;
+		$description = null;
+		foreach ( $feeds as $feed ) {
+			if ( ! $avatar && ! empty( $feed['avatar'] ) ) {
+				$avatar = $feed['avatar'];
+			}
+			if ( ! $description && ! empty( $feed['description'] ) ) {
+				$description = $feed['description'];
+			}
+		}
+
+		$friend_user = User::create( $user_login, 'subscription', $url, $display_name, $avatar, $description );
+
+		if ( is_wp_error( $friend_user ) ) {
+			wp_send_json_error( $friend_user->get_error_message() );
+		}
+
+		$feed_options = array();
+		foreach ( $feeds as $feed ) {
+			if ( ! empty( $feed['selected'] ) && ! empty( $feed['url'] ) ) {
+				$feed_options[ $feed['url'] ] = $feed;
+			}
+		}
+
+		$friend_user->save_feeds( $feed_options );
+
+		wp_send_json_success(
+			array(
+				'message' => sprintf(
+					// translators: %s is the name of a friend.
+					__( 'You are now following %s.', 'friends' ),
+					$display_name
+				),
+				'url' => $friend_user->get_local_friends_page_url(),
+			)
+		);
+	}
+
 	public function ajax_set_avatar() {
 		if ( ! isset( $_POST['user'] ) ) {
 			wp_send_json_error( __( 'No user specified.', 'friends' ) );
@@ -2634,6 +2742,14 @@ class Admin {
 			)
 		);
 
+		$wp_menu->add_menu(
+			array(
+				'id'     => 'add-friend',
+				'parent' => 'friends-menu',
+				'title'  => esc_html__( 'Add a friend', 'friends' ),
+				'href'   => home_url( '/friends/add-friend' ),
+			)
+		);
 		$wp_menu->add_menu(
 			array(
 				'id'     => 'friends',

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -55,6 +55,7 @@ class Admin {
 		add_action( 'wp_ajax_friends_set_avatar', array( $this, 'ajax_set_avatar' ) );
 		add_action( 'wp_ajax_friends-refresh-feeds', array( $this, 'ajax_refresh_feeds' ) );
 		add_action( 'wp_ajax_friends-preview-subscription', array( $this, 'ajax_preview_subscription' ) );
+		add_action( 'wp_ajax_friends-preview-subscription-feed', array( $this, 'ajax_preview_subscription_feed' ) );
 		add_action( 'wp_ajax_friends-subscribe-frontend', array( $this, 'ajax_subscribe_frontend' ) );
 		add_action( 'delete_user_form', array( $this, 'delete_user_form' ), 10, 2 );
 		add_action( 'delete_user', array( $this, 'delete_user' ) );
@@ -1664,8 +1665,26 @@ class Admin {
 		wp_send_json_success();
 	}
 
+	private function normalize_frontend_subscription_url( $url ) {
+		if ( ! is_string( $url ) ) {
+			return '';
+		}
+
+		$url = trim( $url );
+		if ( '' === $url ) {
+			return '';
+		}
+
+		$protocol = wp_parse_url( $url, PHP_URL_SCHEME );
+		if ( ! $protocol ) {
+			return apply_filters( 'friends_rewrite_incoming_url', 'https://' . $url, $url );
+		}
+
+		return apply_filters( 'friends_rewrite_incoming_url', $url, $url );
+	}
+
 	public function ajax_preview_subscription() {
-		if ( ! isset( $_POST['url'] ) ) {
+		if ( ! isset( $_POST['url'] ) || is_array( $_POST['url'] ) ) {
 			wp_send_json_error( __( 'No URL provided.', 'friends' ) );
 		}
 
@@ -1675,14 +1694,22 @@ class Admin {
 			wp_send_json_error( __( 'You do not have permission to do this.', 'friends' ) );
 		}
 
-		$url = wp_unslash( $_POST['url'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		$url = $this->normalize_frontend_subscription_url( wp_unslash( $_POST['url'] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 
-		$protocol = wp_parse_url( $url, PHP_URL_SCHEME );
-		if ( ! $protocol ) {
-			$url = apply_filters( 'friends_rewrite_incoming_url', 'https://' . $url, $url );
-		} else {
-			$url = apply_filters( 'friends_rewrite_incoming_url', $url, $url );
+		if ( '' === $url ) {
+			wp_send_json_error( __( 'No URL provided.', 'friends' ) );
 		}
+
+		if ( str_starts_with( $url, home_url() ) ) {
+			wp_send_json_error( __( 'It seems like you sent a friend request to yourself.', 'friends' ) );
+		}
+
+		if ( ! Friends::check_url( $url ) ) {
+			wp_send_json_error( __( 'You entered an invalid URL.', 'friends' ) );
+		}
+
+		$user_login   = apply_filters( 'friends_suggest_user_login', User::get_user_login_for_url( $url ), $url );
+		$display_name = apply_filters( 'friends_suggest_display_name', User::get_display_name_for_url( $url ), $url );
 
 		$feeds = $this->friends->feed->discover_available_feeds( $url );
 
@@ -1694,8 +1721,29 @@ class Admin {
 			wp_send_json_error( __( 'No suitable feed was found at the provided address.', 'friends' ) );
 		}
 
-		$display_name = User::get_display_name_from_feeds( $feeds );
-		$user_login = User::get_user_login_from_feeds( $feeds );
+		$better_user_login = User::get_user_login_from_feeds( $feeds );
+		if ( $better_user_login ) {
+			$user_login = trim( $better_user_login, '-' );
+		}
+
+		$better_display_name = User::get_display_name_from_feeds( $feeds );
+		if ( $better_display_name ) {
+			$display_name = $better_display_name;
+			if ( ! $better_user_login ) {
+				$user_login = trim( User::sanitize_username( $better_display_name ), '-' );
+			}
+		}
+
+		$friend_user = User::get_user( $user_login );
+		if ( ! $friend_user || is_wp_error( $friend_user ) ) {
+			$friend_user = Subscription::get_by_username( $user_login );
+		}
+
+		if ( $friend_user && ! is_wp_error( $friend_user ) ) {
+			// translators: %s is the name of a friend / site.
+			wp_send_json_error( sprintf( __( 'You are already subscribed to this site: %s', 'friends' ), $friend_user->display_name ) );
+		}
+
 		$avatar = null;
 		$description = null;
 		foreach ( $feeds as $feed_details ) {
@@ -1719,6 +1767,52 @@ class Admin {
 		);
 	}
 
+	public function ajax_preview_subscription_feed() {
+		check_ajax_referer( 'friends_add_subscription' );
+
+		if ( ! Friends::has_required_privileges() ) {
+			wp_send_json_error( __( 'You do not have permission to do this.', 'friends' ) );
+		}
+
+		$url = isset( $_POST['url'] ) && ! is_array( $_POST['url'] ) ? $this->normalize_frontend_subscription_url( wp_unslash( $_POST['url'] ) ) : ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		if ( '' === $url || ! Friends::check_url( $url ) ) {
+			wp_send_json_error( __( 'You entered an invalid URL.', 'friends' ) );
+		}
+
+		$parser = isset( $_POST['parser'] ) && ! is_array( $_POST['parser'] ) ? sanitize_key( wp_unslash( $_POST['parser'] ) ) : '';
+		if ( ! $parser ) {
+			wp_send_json_error( __( 'An invalid parser was supplied.', 'friends' ) );
+		}
+
+		$items = $this->friends->feed->preview( $parser, $url );
+		if ( is_wp_error( $items ) ) {
+			wp_send_json_error( $items->get_error_message() );
+		}
+
+		$preview_items = array();
+		foreach ( array_slice( $items, 0, 5 ) as $item ) {
+			$title = $item->title;
+			if ( 'status' === $item->post_format || ! $title ) {
+				$title = wp_strip_all_tags( $item->content );
+			}
+
+			$preview_items[] = array(
+				'title'       => wp_trim_words( wp_strip_all_tags( $title ), 16 ),
+				'excerpt'     => wp_trim_words( wp_strip_all_tags( $item->content ), 40 ),
+				'permalink'   => $item->permalink,
+				'date'        => $item->date,
+				'author'      => $item->author,
+				'post_format' => $item->post_format,
+			);
+		}
+
+		wp_send_json_success(
+			array(
+				'items' => $preview_items,
+			)
+		);
+	}
+
 	public function ajax_subscribe_frontend() {
 		check_ajax_referer( 'friends_add_subscription' );
 
@@ -1726,25 +1820,107 @@ class Admin {
 			wp_send_json_error( __( 'You do not have permission to do this.', 'friends' ) );
 		}
 
-		$url = isset( $_POST['url'] ) ? wp_unslash( $_POST['url'] ) : ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-		$display_name = isset( $_POST['display_name'] ) ? sanitize_text_field( wp_unslash( $_POST['display_name'] ) ) : '';
-		$feeds = isset( $_POST['feeds'] ) ? wp_unslash( $_POST['feeds'] ) : array(); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		$url          = isset( $_POST['url'] ) && ! is_array( $_POST['url'] ) ? $this->normalize_frontend_subscription_url( wp_unslash( $_POST['url'] ) ) : ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		$display_name = isset( $_POST['display_name'] ) && ! is_array( $_POST['display_name'] ) ? sanitize_text_field( wp_unslash( $_POST['display_name'] ) ) : '';
+		$user_login   = isset( $_POST['user_login'] ) && ! is_array( $_POST['user_login'] ) ? User::sanitize_username( wp_unslash( $_POST['user_login'] ) ) : User::get_user_login_for_url( $url ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		$feeds        = isset( $_POST['feeds'] ) && is_array( $_POST['feeds'] ) ? wp_unslash( $_POST['feeds'] ) : array(); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 
 		if ( empty( $url ) || empty( $feeds ) ) {
 			wp_send_json_error( __( 'Missing required data.', 'friends' ) );
 		}
 
-		$user_login = User::get_user_login_for_url( $url );
+		if ( ! Friends::check_url( $url ) ) {
+			wp_send_json_error( __( 'You entered an invalid URL.', 'friends' ) );
+		}
+
+		$user_login = trim( $user_login, '-' );
+		if ( ! $user_login ) {
+			wp_send_json_error( __( 'Please enter a valid username.', 'friends' ) );
+		}
+
+		if ( ! $display_name ) {
+			$display_name = User::get_display_name_for_url( $url );
+		}
+
+		if ( ! is_multisite() && username_exists( $user_login ) ) {
+			wp_send_json_error( __( 'This username is already registered. Please choose another one.' ) ); // phpcs:ignore WordPress.WP.I18n.MissingArgDomain
+		}
 
 		$avatar = null;
 		$description = null;
+		$feed_options = array();
+		$subscribe = array();
+		$post_formats = array_merge( array( 'autodetect' => true ), array_fill_keys( array_keys( get_post_format_strings() ), true ) );
+
 		foreach ( $feeds as $feed ) {
-			if ( ! $avatar && ! empty( $feed['avatar'] ) ) {
-				$avatar = $feed['avatar'];
+			if ( ! is_array( $feed ) ) {
+				continue;
 			}
-			if ( ! $description && ! empty( $feed['description'] ) ) {
-				$description = $feed['description'];
+
+			$feed_url = '';
+			if ( ! empty( $feed['url'] ) && is_scalar( $feed['url'] ) ) {
+				$feed_url = esc_url_raw( trim( $feed['url'] ) );
 			}
+
+			if ( ! $feed_url || ! Friends::check_url( $feed_url ) ) {
+				continue;
+			}
+
+			$parser = isset( $feed['parser'] ) && is_scalar( $feed['parser'] ) ? sanitize_key( $feed['parser'] ) : 'simplepie';
+			if ( ! $parser || 'unsupported' === $parser ) {
+				continue;
+			}
+
+			$post_format = isset( $feed['post-format'] ) && is_scalar( $feed['post-format'] ) ? sanitize_key( $feed['post-format'] ) : 'standard';
+			if ( ! isset( $post_formats[ $post_format ] ) ) {
+				$post_format = 'standard';
+			}
+
+			$mime_type = isset( $feed['mime-type'] ) && is_scalar( $feed['mime-type'] ) ? sanitize_text_field( $feed['mime-type'] ) : '';
+			if ( ! $mime_type && ! empty( $feed['type'] ) && is_scalar( $feed['type'] ) ) {
+				$mime_type = sanitize_text_field( $feed['type'] );
+			}
+
+			$feed_options[ $feed_url ] = array(
+				'url'         => $feed_url,
+				'parser'      => $parser,
+				'post-format' => $post_format,
+				'title'       => isset( $feed['title'] ) && is_scalar( $feed['title'] ) ? sanitize_text_field( $feed['title'] ) : $feed_url,
+			);
+
+			if ( $mime_type ) {
+				$feed_options[ $feed_url ]['mime-type'] = $mime_type;
+			}
+
+			$is_selected = isset( $feed['selected'] ) && in_array( $feed['selected'], array( true, 'true', '1', 1, 'on' ), true );
+			if ( $is_selected ) {
+				$subscribe[] = $feed_url;
+			}
+
+			if ( ! $avatar && ! empty( $feed['avatar'] ) && is_scalar( $feed['avatar'] ) ) {
+				$avatar = esc_url_raw( $feed['avatar'] );
+			}
+			if ( ! $description && ! empty( $feed['description'] ) && is_scalar( $feed['description'] ) ) {
+				$description = wp_encode_emoji( sanitize_textarea_field( $feed['description'] ) );
+			}
+		}
+
+		if ( empty( $feed_options ) ) {
+			wp_send_json_error( __( 'No suitable feed was found at the provided address.', 'friends' ) );
+		}
+
+		if ( empty( $subscribe ) ) {
+			wp_send_json_error( __( 'Please select at least one feed.', 'friends' ) );
+		}
+
+		$friend_user = User::get_user( $user_login );
+		if ( ! $friend_user || is_wp_error( $friend_user ) ) {
+			$friend_user = Subscription::get_by_username( $user_login );
+		}
+
+		if ( $friend_user && ! is_wp_error( $friend_user ) ) {
+			// translators: %s is the name of a friend / site.
+			wp_send_json_error( sprintf( __( 'You are already subscribed to this site: %s', 'friends' ), $friend_user->display_name ) );
 		}
 
 		$friend_user = User::create( $user_login, 'subscription', $url, $display_name, $avatar, $description );
@@ -1753,18 +1929,10 @@ class Admin {
 			wp_send_json_error( $friend_user->get_error_message() );
 		}
 
-		$feed_options = array();
-		$subscribe = array();
-		foreach ( $feeds as $feed ) {
-			if ( ! empty( $feed['url'] ) ) {
-				$feed_options[ $feed['url'] ] = $feed;
-				if ( ! empty( $feed['selected'] ) ) {
-					$subscribe[] = $feed['url'];
-				}
-			}
+		$saved_feeds = $friend_user->save_feeds( $feed_options );
+		if ( is_wp_error( $saved_feeds ) ) {
+			wp_send_json_error( $saved_feeds->get_error_message() );
 		}
-
-		$friend_user->save_feeds( $feed_options );
 
 		foreach ( $subscribe as $feed_url ) {
 			if ( ! isset( $feed_options[ $feed_url ] ) ) {
@@ -1777,7 +1945,7 @@ class Admin {
 		}
 
 		add_filter( 'notify_about_new_friend_post', '__return_false', 999 );
-		$friend_user->retrieve_posts_from_active_feeds();
+		wp_schedule_single_event( time(), 'friends_retrieve_user_feeds', array( $friend_user->ID ) );
 
 		wp_send_json_success(
 			array(

--- a/includes/class-blocks.php
+++ b/includes/class-blocks.php
@@ -96,6 +96,13 @@ class Blocks {
 			)
 		);
 
+		register_block_type(
+			'friends/add-friend-form',
+			array(
+				'render_callback' => array( $this, 'render_add_friend_form_block' ),
+			)
+		);
+
 		$list_supports = array(
 			'color'      => array(
 				'background' => true,
@@ -322,6 +329,19 @@ class Blocks {
 		}
 
 		return '<ul class="wp-block-friends-subscriptions-query">' . $items . '</ul>';
+	}
+
+	/**
+	 * Render the friends/add-friend-form block.
+	 *
+	 * @return string The rendered block HTML.
+	 */
+	public function render_add_friend_form_block() {
+		ob_start();
+		Friends::template_loader()->get_template_part( 'frontend/add-friend-form' );
+		$form = ob_get_clean();
+
+		return '<div' . $this->get_wrapper_attributes( array( 'class' => 'wp-block-friends-add-friend-form' ) ) . '>' . $form . '</div>';
 	}
 
 	/**
@@ -873,6 +893,17 @@ class Blocks {
 
 		// Determine feed title.
 		$title = __( 'Main Feed', 'friends' );
+		if ( $frontend->template ) {
+			$template_titles = array(
+				'frontend/add-friend'    => __( 'Add Friend', 'friends' ),
+				'frontend/followers'     => __( 'Followers', 'friends' ),
+				'frontend/subscriptions' => __( 'Following', 'friends' ),
+			);
+			if ( isset( $template_titles[ $frontend->template ] ) ) {
+				$title = $template_titles[ $frontend->template ];
+			}
+		}
+
 		$format_titles = array(
 			'standard' => _x( 'Post feed', 'Post format', 'friends' ),
 			'aside'    => _x( 'Aside feed', 'Post format', 'friends' ),

--- a/includes/class-blocks.php
+++ b/includes/class-blocks.php
@@ -96,6 +96,13 @@ class Blocks {
 			)
 		);
 
+		register_block_type(
+			'friends/add-friend-form',
+			array(
+				'render_callback' => array( $this, 'render_add_friend_form_block' ),
+			)
+		);
+
 		$list_supports = array(
 			'color'      => array(
 				'background' => true,
@@ -336,6 +343,19 @@ class Blocks {
 		}
 
 		return '<ul class="wp-block-friends-subscriptions-query">' . $items . '</ul>';
+	}
+
+	/**
+	 * Render the friends/add-friend-form block.
+	 *
+	 * @return string The rendered block HTML.
+	 */
+	public function render_add_friend_form_block() {
+		ob_start();
+		Friends::template_loader()->get_template_part( 'frontend/add-friend-form' );
+		$form = ob_get_clean();
+
+		return '<div' . $this->get_wrapper_attributes( array( 'class' => 'wp-block-friends-add-friend-form' ) ) . '>' . $form . '</div>';
 	}
 
 	/**
@@ -887,6 +907,17 @@ class Blocks {
 
 		// Determine feed title.
 		$title = __( 'Main Feed', 'friends' );
+		if ( $frontend->template ) {
+			$template_titles = array(
+				'frontend/add-friend'    => __( 'Add Friend', 'friends' ),
+				'frontend/followers'     => __( 'Followers', 'friends' ),
+				'frontend/subscriptions' => __( 'Following', 'friends' ),
+			);
+			if ( isset( $template_titles[ $frontend->template ] ) ) {
+				$title = $template_titles[ $frontend->template ];
+			}
+		}
+
 		$format_titles = array(
 			'standard' => _x( 'Post feed', 'Post format', 'friends' ),
 			'aside'    => _x( 'Aside feed', 'Post format', 'friends' ),

--- a/includes/class-frontend.php
+++ b/includes/class-frontend.php
@@ -378,6 +378,9 @@ class Frontend {
 		// translators: %s is a user handle.
 		$variables['text_confirm_delete_follower'] = __( 'Do you really want to delete the follower %s?', 'friends' );
 		$variables['text_new_folder']              = __( 'Folder name:', 'friends' );
+		$variables['text_loading']                 = __( 'Loading...', 'friends' );
+		$variables['text_follow']                  = __( 'Follow', 'friends' );
+		$variables['text_error']                   = __( 'An error occurred.', 'friends' );
 		wp_localize_script( 'friends', 'friends', $variables );
 	}
 
@@ -1619,6 +1622,10 @@ class Frontend {
 		$wp_query->is_singular = false;
 
 		switch ( $path ) {
+			case 'add-friend':
+				$path = 'frontend/add-friend';
+				break;
+
 			case 'subscriptions':
 				wp_safe_redirect( home_url( '/friends/following/' ) );
 				exit;

--- a/includes/class-frontend.php
+++ b/includes/class-frontend.php
@@ -378,6 +378,9 @@ class Frontend {
 		// translators: %s is a user handle.
 		$variables['text_confirm_delete_follower'] = __( 'Do you really want to delete the follower %s?', 'friends' );
 		$variables['text_new_folder']              = __( 'Folder name:', 'friends' );
+		$variables['text_loading']                 = __( 'Loading...', 'friends' );
+		$variables['text_follow']                  = __( 'Follow', 'friends' );
+		$variables['text_error']                   = __( 'An error occurred.', 'friends' );
 		wp_localize_script( 'friends', 'friends', $variables );
 	}
 
@@ -1615,6 +1618,10 @@ class Frontend {
 		$wp_query->is_singular = false;
 
 		switch ( $path ) {
+			case 'add-friend':
+				$path = 'frontend/add-friend';
+				break;
+
 			case 'subscriptions':
 				wp_safe_redirect( home_url( '/friends/following/' ) );
 				exit;

--- a/includes/class-frontend.php
+++ b/includes/class-frontend.php
@@ -379,15 +379,39 @@ class Frontend {
 		$variables['text_confirm_delete_follower'] = __( 'Do you really want to delete the follower %s?', 'friends' );
 		$variables['text_new_folder']              = __( 'Folder name:', 'friends' );
 		$variables['text_loading']                 = __( 'Loading...', 'friends' );
+		$variables['text_discovering']             = __( 'Discovering feeds...', 'friends' );
+		$variables['text_ready_to_follow']         = __( 'Ready', 'friends' );
 		$variables['text_follow']                  = __( 'Follow', 'friends' );
+		$variables['text_follow_selected']         = __( 'Follow selected', 'friends' );
+		$variables['text_review_selected']         = __( 'Review selected', 'friends' );
+		$variables['text_skip']                    = __( 'Skip', 'friends' );
 		$variables['text_error']                   = __( 'An error occurred.', 'friends' );
+		$variables['text_display_name']            = __( 'Display Name', 'friends' );
+		$variables['text_username']                = __( 'Username', 'friends' );
+		$variables['text_post_format']             = __( 'Post Format', 'friends' );
+		$variables['text_feed_parser']             = __( 'Parser', 'friends' );
+		$variables['text_feed_metadata']           = __( 'Display feed metadata', 'friends' );
+		$variables['text_hide_feed_metadata']      = __( 'Hide feed metadata', 'friends' );
+		$variables['text_preview_feed']            = __( 'Preview feed', 'friends' );
+		$variables['text_hide_preview']            = __( 'Hide preview', 'friends' );
+		$variables['text_no_preview_items']        = __( 'No preview items were found.', 'friends' );
+		$variables['text_add_feed_url']            = __( 'Add feed URL', 'friends' );
+		$variables['text_feed_url']                = __( 'Feed URL', 'friends' );
+		$variables['text_custom_feed']             = __( 'Custom feed', 'friends' );
+		$variables['text_feed_url_required']       = __( 'Please enter a feed URL.', 'friends' );
+		$variables['text_show_more_feeds']         = __( 'Show more feeds', 'friends' );
+		$variables['text_show_unsupported_feeds']  = __( 'Show unsupported feeds', 'friends' );
+		$variables['text_no_supported_feeds']      = __( 'No supported feeds discovered.', 'friends' );
+		$variables['text_no_feed_selected']        = __( 'Please select at least one feed.', 'friends' );
 		$variables['text_opml_no_feeds']           = __( 'No feeds were found in the OPML file.', 'friends' );
 		$variables['text_opml_invalid']            = __( 'Could not parse the OPML file.', 'friends' );
 		$variables['text_opml_select_all']         = __( 'Select all', 'friends' );
 		$variables['text_opml_deselect_all']       = __( 'Deselect all', 'friends' );
-		$variables['text_opml_import_selected']    = __( 'Import selected', 'friends' );
+		$variables['text_opml_import_selected']    = __( 'Review selected', 'friends' );
 		$variables['text_opml_no_selected']        = __( 'Please select at least one feed.', 'friends' );
 		$variables['text_opml_no_feeds_for_url']   = __( 'No feeds discovered.', 'friends' );
+		$variables['post_formats']                 = array_merge( array( 'autodetect' => __( 'Autodetect Post Format', 'friends' ) ), get_post_format_strings() );
+		$variables['registered_parsers']           = array_map( 'wp_strip_all_tags', $this->friends->feed->get_registered_parsers() );
 		wp_localize_script( 'friends', 'friends', $variables );
 	}
 
@@ -629,8 +653,12 @@ class Frontend {
 	}
 
 	public function block_theme() {
-		// No theme swap needed — templates are registered as plugin templates
+		// No theme swap needed; templates are registered as plugin templates
 		// and injected via template_override.
+		$handle  = 'friends-blocks';
+		$file    = 'friends-blocks.css';
+		$version = Friends::VERSION;
+		wp_enqueue_style( $handle, plugins_url( $file, FRIENDS_PLUGIN_FILE ), array(), apply_filters( 'friends_debug_enqueue', $version, $handle, dirname( FRIENDS_PLUGIN_FILE ) . '/' . $file ) );
 	}
 
 	/**
@@ -654,6 +682,10 @@ class Frontend {
 			'friends//friends-followers'     => array(
 				'title'   => __( 'Friends Followers', 'friends' ),
 				'content' => 'friends-followers',
+			),
+			'friends//friends-add-friend'    => array(
+				'title'   => __( 'Friends Add Friend', 'friends' ),
+				'content' => 'friends-add-friend',
 			),
 			'friends//friends-subscriptions' => array(
 				'title'   => __( 'Friends Following', 'friends' ),
@@ -1607,6 +1639,7 @@ class Frontend {
 			'frontend/author-index'  => 'friends-author-index',
 			'frontend/single'        => 'single-friend_post_cache',
 			'frontend/followers'     => 'friends-followers',
+			'frontend/add-friend'    => 'friends-add-friend',
 			'frontend/subscriptions' => 'friends-subscriptions',
 		);
 		if ( ! isset( $map[ $template_path ] ) ) {

--- a/includes/class-frontend.php
+++ b/includes/class-frontend.php
@@ -381,6 +381,13 @@ class Frontend {
 		$variables['text_loading']                 = __( 'Loading...', 'friends' );
 		$variables['text_follow']                  = __( 'Follow', 'friends' );
 		$variables['text_error']                   = __( 'An error occurred.', 'friends' );
+		$variables['text_opml_no_feeds']           = __( 'No feeds were found in the OPML file.', 'friends' );
+		$variables['text_opml_invalid']            = __( 'Could not parse the OPML file.', 'friends' );
+		$variables['text_opml_select_all']         = __( 'Select all', 'friends' );
+		$variables['text_opml_deselect_all']       = __( 'Deselect all', 'friends' );
+		$variables['text_opml_import_selected']    = __( 'Import selected', 'friends' );
+		$variables['text_opml_no_selected']        = __( 'Please select at least one feed.', 'friends' );
+		$variables['text_opml_no_feeds_for_url']   = __( 'No feeds discovered.', 'friends' );
 		wp_localize_script( 'friends', 'friends', $variables );
 	}
 

--- a/templates/frontend/add-friend-form.php
+++ b/templates/frontend/add-friend-form.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * The Add Friend form.
+ *
+ * @version 1.0
+ * @package Friends
+ */
+
+?>
+<section class="subscriptions add-friend-subscriptions">
+	<div class="card add-friend-card">
+		<div class="card-body">
+			<form id="add-subscription-form" action="" method="post">
+				<?php wp_nonce_field( 'friends_add_subscription' ); ?>
+				<div class="add-subscription-input">
+					<textarea name="url" id="subscription-url" class="form-input" rows="4" placeholder="<?php esc_attr_e( 'Enter URLs, @user@instance handles, or paste OPML content', 'friends' ); ?>" required></textarea>
+					<button type="submit" class="btn btn-primary"><?php esc_html_e( 'Review', 'friends' ); ?></button>
+				</div>
+				<p class="opml-file-hint">
+					<label for="opml-file"><?php esc_html_e( 'Or upload an OPML file:', 'friends' ); ?></label>
+					<input type="file" id="opml-file" accept=".opml,.xml,application/xml,text/xml">
+				</p>
+			</form>
+			<div id="preview-subscription"></div>
+		</div>
+	</div>
+
+	<div class="card add-friend-discovery-card">
+		<div class="card-body">
+			<h5><?php esc_html_e( 'Discover People', 'friends' ); ?></h5>
+			<p><?php esc_html_e( 'Browse the local timeline of a Mastodon server to find interesting people. Copy their profile URL and paste it in the field above to follow them.', 'friends' ); ?></p>
+			<ul>
+				<?php
+				$instances = apply_filters(
+					'friends_mastodon_instances',
+					array(
+						'mastodon.social',
+						'mastodon.online',
+						'fosstodon.org',
+						'hachyderm.io',
+						'infosec.exchange',
+						'indieweb.social',
+					)
+				);
+				foreach ( $instances as $instance ) :
+					?>
+					<li><a href="<?php echo esc_url( 'https://' . $instance . '/public/local' ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( $instance ); ?></a></li>
+				<?php endforeach; ?>
+			</ul>
+		</div>
+	</div>
+</section>

--- a/templates/frontend/add-friend.php
+++ b/templates/frontend/add-friend.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * This is the Add Friend page
+ *
+ * @version 1.0
+ * @package Friends
+ */
+
+$args['title'] = __( 'Add Friend', 'friends' );
+$args['no-bottom-margin'] = true;
+
+Friends\Friends::template_loader()->get_template_part( 'frontend/header', null, $args );
+
+?>
+<section class="subscriptions">
+	<div class="card">
+		<div class="card-body">
+			<form id="add-subscription-form" action="" method="post">
+				<?php wp_nonce_field( 'friends_add_subscription' ); ?>
+				<div class="input-group">
+					<input type="text" name="url" id="subscription-url" class="form-input" placeholder="<?php esc_attr_e( 'Enter a URL or @user@instance', 'friends' ); ?>" required>
+					<button type="submit" class="btn btn-primary input-group-btn"><?php esc_html_e( 'Follow', 'friends' ); ?></button>
+				</div>
+			</form>
+			<div id="preview-subscription"></div>
+		</div>
+	</div>
+
+	<div class="card">
+		<div class="card-body">
+			<h5><?php esc_html_e( 'Discover People', 'friends' ); ?></h5>
+			<p><?php esc_html_e( 'Browse the local timeline of a Mastodon server to find interesting people. Copy their profile URL and paste it in the field above to follow them.', 'friends' ); ?></p>
+			<ul>
+				<?php
+				$instances = apply_filters(
+					'friends_mastodon_instances',
+					array(
+						'mastodon.social',
+						'mastodon.online',
+						'fosstodon.org',
+						'hachyderm.io',
+						'infosec.exchange',
+						'indieweb.social',
+					)
+				);
+				foreach ( $instances as $instance ) :
+					?>
+					<li><a href="<?php echo esc_url( 'https://' . $instance . '/public/local' ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( $instance ); ?></a></li>
+				<?php endforeach; ?>
+			</ul>
+		</div>
+	</div>
+</section>
+<?php
+Friends\Friends::template_loader()->get_template_part(
+	'frontend/footer',
+	null,
+	$args
+);

--- a/templates/frontend/add-friend.php
+++ b/templates/frontend/add-friend.php
@@ -18,9 +18,13 @@ Friends\Friends::template_loader()->get_template_part( 'frontend/header', null, 
 			<form id="add-subscription-form" action="" method="post">
 				<?php wp_nonce_field( 'friends_add_subscription' ); ?>
 				<div class="input-group">
-					<input type="text" name="url" id="subscription-url" class="form-input" placeholder="<?php esc_attr_e( 'Enter a URL or @user@instance', 'friends' ); ?>" required>
+					<input type="text" name="url" id="subscription-url" class="form-input" placeholder="<?php esc_attr_e( 'Enter a URL, @user@instance, or paste OPML content', 'friends' ); ?>" required>
 					<button type="submit" class="btn btn-primary input-group-btn"><?php esc_html_e( 'Follow', 'friends' ); ?></button>
 				</div>
+				<p class="opml-file-hint">
+					<label for="opml-file"><?php esc_html_e( 'Or upload an OPML file:', 'friends' ); ?></label>
+					<input type="file" id="opml-file" accept=".opml,.xml,application/xml,text/xml">
+				</p>
 			</form>
 			<div id="preview-subscription"></div>
 		</div>

--- a/templates/frontend/add-friend.php
+++ b/templates/frontend/add-friend.php
@@ -11,51 +11,8 @@ $args['no-bottom-margin'] = true;
 
 Friends\Friends::template_loader()->get_template_part( 'frontend/header', null, $args );
 
-?>
-<section class="subscriptions">
-	<div class="card">
-		<div class="card-body">
-			<form id="add-subscription-form" action="" method="post">
-				<?php wp_nonce_field( 'friends_add_subscription' ); ?>
-				<div class="input-group">
-					<input type="text" name="url" id="subscription-url" class="form-input" placeholder="<?php esc_attr_e( 'Enter a URL, @user@instance, or paste OPML content', 'friends' ); ?>" required>
-					<button type="submit" class="btn btn-primary input-group-btn"><?php esc_html_e( 'Follow', 'friends' ); ?></button>
-				</div>
-				<p class="opml-file-hint">
-					<label for="opml-file"><?php esc_html_e( 'Or upload an OPML file:', 'friends' ); ?></label>
-					<input type="file" id="opml-file" accept=".opml,.xml,application/xml,text/xml">
-				</p>
-			</form>
-			<div id="preview-subscription"></div>
-		</div>
-	</div>
+Friends\Friends::template_loader()->get_template_part( 'frontend/add-friend-form', null, $args );
 
-	<div class="card">
-		<div class="card-body">
-			<h5><?php esc_html_e( 'Discover People', 'friends' ); ?></h5>
-			<p><?php esc_html_e( 'Browse the local timeline of a Mastodon server to find interesting people. Copy their profile URL and paste it in the field above to follow them.', 'friends' ); ?></p>
-			<ul>
-				<?php
-				$instances = apply_filters(
-					'friends_mastodon_instances',
-					array(
-						'mastodon.social',
-						'mastodon.online',
-						'fosstodon.org',
-						'hachyderm.io',
-						'infosec.exchange',
-						'indieweb.social',
-					)
-				);
-				foreach ( $instances as $instance ) :
-					?>
-					<li><a href="<?php echo esc_url( 'https://' . $instance . '/public/local' ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( $instance ); ?></a></li>
-				<?php endforeach; ?>
-			</ul>
-		</div>
-	</div>
-</section>
-<?php
 Friends\Friends::template_loader()->get_template_part(
 	'frontend/footer',
 	null,

--- a/templates/frontend/main-feed-header.php
+++ b/templates/frontend/main-feed-header.php
@@ -116,6 +116,7 @@ if ( $args['friends']->frontend->reaction ) {
 			<?php esc_html_e( 'Newest first', 'friends' ); ?>
 		</a>
 	<?php endif; ?>
+	<a class="chip" href="<?php echo esc_url( home_url( '/friends/add-friend/' ) ); ?>"><?php echo esc_html__( 'Add Friend', 'friends' ); ?></a>
 	<a class="chip toggle-compact" href=""><?php echo esc_html( 'collapsed' === $args['frontend_default_view'] ? __( 'Expanded mode', 'friends' ) : __( 'Compact mode', 'friends' ) ); ?></a>
 <?php else : ?>
 	<?php foreach ( $data['post_count_by_post_format'] as $post_format => $count ) : ?>
@@ -151,6 +152,7 @@ if ( $args['friends']->frontend->reaction ) {
 	</a>
 	<?php endforeach; ?>
 
+	<a class="chip" href="<?php echo esc_url( home_url( '/friends/add-friend/' ) ); ?>"><?php echo esc_html__( 'Add Friend', 'friends' ); ?></a>
 	<a class="chip toggle-compact" href=""><?php echo esc_html( 'collapsed' === $args['frontend_default_view'] ? __( 'Expanded mode', 'friends' ) : __( 'Compact mode', 'friends' ) ); ?></a>
 <?php endif; ?>
 

--- a/templates/google-reader/google-reader.css
+++ b/templates/google-reader/google-reader.css
@@ -965,6 +965,226 @@
 .friends-page .text { font-size: 11px; }
 .friends-page .btn-link { background: none; border: none; cursor: pointer; padding: 2px; }
 
+/* --- Add friend review flow --- */
+.friends-page section.add-friend-subscriptions {
+	display: grid;
+	gap: 8px;
+	padding: 12px 16px;
+}
+
+.friends-page section.add-friend-subscriptions .card {
+	background: light-dark(#fff, #292a2d);
+	border: 1px solid light-dark(#e8e8e8, #3c4043);
+	border-radius: 2px;
+	margin: 0;
+}
+
+.friends-page section.add-friend-subscriptions .card-body {
+	padding: 10px;
+}
+
+.friends-page section.add-friend-subscriptions .hidden {
+	display: none;
+}
+
+.friends-page section.add-friend-subscriptions .add-subscription-input {
+	display: flex;
+	align-items: flex-start;
+	gap: 6px;
+}
+
+.friends-page section.add-friend-subscriptions textarea.form-input {
+	flex: 1 1 auto;
+	min-height: 84px;
+	resize: vertical;
+	width: 100%;
+}
+
+.friends-page section.add-friend-subscriptions .form-select {
+	background: light-dark(#fff, #292a2d);
+	border: 1px solid light-dark(#d4d4d4, #3c4043);
+	border-radius: 1px;
+	color: light-dark(#222, #e8eaed);
+	font: inherit;
+	padding: 4px 8px;
+	width: 100%;
+}
+
+.friends-page section.add-friend-subscriptions .opml-file-hint,
+.friends-page section.add-friend-subscriptions .subscription-preview-description,
+.friends-page section.add-friend-subscriptions .subscription-feed-details,
+.friends-page section.add-friend-subscriptions .subscription-preview-status,
+.friends-page section.add-friend-subscriptions .bulk-feed-status {
+	color: light-dark(#666, #bdc1c6);
+	font-size: 12px;
+}
+
+.friends-page section.add-friend-subscriptions #preview-subscription:not(:empty) {
+	margin-top: 8px;
+}
+
+.friends-page section.add-friend-subscriptions .bulk-controls,
+.friends-page section.add-friend-subscriptions .subscription-feed-actions,
+.friends-page section.add-friend-subscriptions .subscription-preview-actions {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 5px;
+	margin-top: 8px;
+}
+
+.friends-page section.add-friend-subscriptions .subscription-preview-results,
+.friends-page section.add-friend-subscriptions .bulk-feed-list,
+.friends-page section.add-friend-subscriptions .subscription-feed-list {
+	display: grid;
+	gap: 6px;
+	list-style: none;
+	margin: 8px 0 0;
+	padding: 0;
+}
+
+.friends-page section.add-friend-subscriptions .subscription-feed-list.hidden {
+	display: none;
+}
+
+.friends-page section.add-friend-subscriptions .bulk-feed-row,
+.friends-page section.add-friend-subscriptions .subscription-feed-option {
+	background: light-dark(#f8fafd, #2f3135);
+	border-radius: 2px;
+	box-shadow: inset 0 0 0 1px light-dark(#eceff3, #3c4043);
+	padding: 8px;
+}
+
+.friends-page section.add-friend-subscriptions .bulk-feed-row > label,
+.friends-page section.add-friend-subscriptions .subscription-feed-option > label {
+	display: block;
+	font-weight: bold;
+	overflow-wrap: anywhere;
+}
+
+.friends-page section.add-friend-subscriptions .bulk-feed-row > label small,
+.friends-page section.add-friend-subscriptions .subscription-feed-option > label small {
+	color: light-dark(#666, #bdc1c6);
+	font-weight: normal;
+}
+
+.friends-page section.add-friend-subscriptions .bulk-feed-row.is-reviewing > .label-for-bulkfeed,
+.friends-page section.add-friend-subscriptions .bulk-feed-row.is-reviewing > .bulk-feed-status {
+	display: none;
+}
+
+.friends-page section.add-friend-subscriptions .bulk-feed-review {
+	margin-top: 6px;
+}
+
+.friends-page section.add-friend-subscriptions .feed-preview {
+	background: light-dark(#fff, #292a2d);
+	border-radius: 2px;
+	box-shadow: inset 3px 0 0 #4d90fe, inset 0 0 0 1px light-dark(#e8e8e8, #3c4043);
+	margin-top: 8px;
+	padding: 8px;
+}
+
+.friends-page section.add-friend-subscriptions .bulk-feed-review .feed-preview {
+	background: transparent;
+	border-radius: 0;
+	box-shadow: none;
+	margin-top: 0;
+	padding: 0;
+}
+
+.friends-page section.add-friend-subscriptions .subscription-preview-header,
+.friends-page section.add-friend-subscriptions .subscribe-success {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+}
+
+.friends-page section.add-friend-subscriptions .subscription-preview-header .avatar,
+.friends-page section.add-friend-subscriptions .subscribe-success .avatar {
+	border-radius: 50%;
+	flex: 0 0 auto;
+}
+
+.friends-page section.add-friend-subscriptions .subscription-preview-title,
+.friends-page section.add-friend-subscriptions .subscription-feed-preview-title {
+	display: flex;
+	flex-direction: column;
+	min-width: 0;
+}
+
+.friends-page section.add-friend-subscriptions .subscription-preview-title small,
+.friends-page section.add-friend-subscriptions .subscription-feed-preview-title small {
+	color: light-dark(#666, #bdc1c6);
+	overflow-wrap: anywhere;
+}
+
+.friends-page section.add-friend-subscriptions .subscription-settings,
+.friends-page section.add-friend-subscriptions .subscription-feed-controls {
+	display: grid;
+	grid-template-columns: repeat(2, minmax(0, 1fr));
+	gap: 6px;
+	margin-top: 8px;
+}
+
+.friends-page section.add-friend-subscriptions .subscription-settings label,
+.friends-page section.add-friend-subscriptions .subscription-feed-controls label {
+	display: grid;
+	gap: 3px;
+	font-size: 12px;
+	font-weight: bold;
+}
+
+.friends-page section.add-friend-subscriptions .subscription-feed-url-label {
+	grid-column: 1 / -1;
+}
+
+.friends-page section.add-friend-subscriptions .subscription-feed-preview {
+	background: light-dark(#fff, #292a2d);
+	border-radius: 2px;
+	box-shadow: inset 0 0 0 1px light-dark(#e8e8e8, #3c4043);
+	margin-top: 6px;
+	padding: 8px;
+}
+
+.friends-page section.add-friend-subscriptions .subscription-feed-preview ul {
+	display: grid;
+	gap: 6px;
+	list-style: none;
+	margin: 0;
+	padding: 0;
+}
+
+.friends-page section.add-friend-subscriptions .subscription-feed-preview p {
+	color: light-dark(#666, #bdc1c6);
+	font-size: 12px;
+	margin: 2px 0 0;
+}
+
+.friends-page section.add-friend-subscriptions .error,
+.friends-page section.add-friend-subscriptions .subscription-preview-status.error,
+.friends-page section.add-friend-subscriptions .bulk-feed-status.error {
+	color: light-dark(#dd4b39, #ea4335);
+}
+
+@media (max-width: 640px) {
+	.friends-page section.add-friend-subscriptions .add-subscription-input {
+		flex-direction: column;
+	}
+
+	.friends-page section.add-friend-subscriptions .add-subscription-input .btn,
+	.friends-page section.add-friend-subscriptions .bulk-controls .btn,
+	.friends-page section.add-friend-subscriptions .subscription-feed-actions .btn,
+	.friends-page section.add-friend-subscriptions .subscription-preview-actions .btn {
+		width: 100%;
+	}
+
+	.friends-page section.add-friend-subscriptions .subscription-settings,
+	.friends-page section.add-friend-subscriptions .subscription-feed-controls {
+		grid-template-columns: 1fr;
+	}
+}
+
 /* Mention indicator */
 .friends-page .mention-indicator {
 	color: light-dark(#dd4b39, #ea4335);

--- a/templates/google-reader/google-reader.css
+++ b/templates/google-reader/google-reader.css
@@ -985,6 +985,226 @@
 .friends-page .text { font-size: 11px; }
 .friends-page .btn-link { background: none; border: none; cursor: pointer; padding: 2px; }
 
+/* --- Add friend review flow --- */
+.friends-page section.add-friend-subscriptions {
+	display: grid;
+	gap: 8px;
+	padding: 12px 16px;
+}
+
+.friends-page section.add-friend-subscriptions .card {
+	background: light-dark(#fff, #292a2d);
+	border: 1px solid light-dark(#e8e8e8, #3c4043);
+	border-radius: 2px;
+	margin: 0;
+}
+
+.friends-page section.add-friend-subscriptions .card-body {
+	padding: 10px;
+}
+
+.friends-page section.add-friend-subscriptions .hidden {
+	display: none;
+}
+
+.friends-page section.add-friend-subscriptions .add-subscription-input {
+	display: flex;
+	align-items: flex-start;
+	gap: 6px;
+}
+
+.friends-page section.add-friend-subscriptions textarea.form-input {
+	flex: 1 1 auto;
+	min-height: 84px;
+	resize: vertical;
+	width: 100%;
+}
+
+.friends-page section.add-friend-subscriptions .form-select {
+	background: light-dark(#fff, #292a2d);
+	border: 1px solid light-dark(#d4d4d4, #3c4043);
+	border-radius: 1px;
+	color: light-dark(#222, #e8eaed);
+	font: inherit;
+	padding: 4px 8px;
+	width: 100%;
+}
+
+.friends-page section.add-friend-subscriptions .opml-file-hint,
+.friends-page section.add-friend-subscriptions .subscription-preview-description,
+.friends-page section.add-friend-subscriptions .subscription-feed-details,
+.friends-page section.add-friend-subscriptions .subscription-preview-status,
+.friends-page section.add-friend-subscriptions .bulk-feed-status {
+	color: light-dark(#666, #bdc1c6);
+	font-size: 12px;
+}
+
+.friends-page section.add-friend-subscriptions #preview-subscription:not(:empty) {
+	margin-top: 8px;
+}
+
+.friends-page section.add-friend-subscriptions .bulk-controls,
+.friends-page section.add-friend-subscriptions .subscription-feed-actions,
+.friends-page section.add-friend-subscriptions .subscription-preview-actions {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 5px;
+	margin-top: 8px;
+}
+
+.friends-page section.add-friend-subscriptions .subscription-preview-results,
+.friends-page section.add-friend-subscriptions .bulk-feed-list,
+.friends-page section.add-friend-subscriptions .subscription-feed-list {
+	display: grid;
+	gap: 6px;
+	list-style: none;
+	margin: 8px 0 0;
+	padding: 0;
+}
+
+.friends-page section.add-friend-subscriptions .subscription-feed-list.hidden {
+	display: none;
+}
+
+.friends-page section.add-friend-subscriptions .bulk-feed-row,
+.friends-page section.add-friend-subscriptions .subscription-feed-option {
+	background: light-dark(#f8fafd, #2f3135);
+	border-radius: 2px;
+	box-shadow: inset 0 0 0 1px light-dark(#eceff3, #3c4043);
+	padding: 8px;
+}
+
+.friends-page section.add-friend-subscriptions .bulk-feed-row > label,
+.friends-page section.add-friend-subscriptions .subscription-feed-option > label {
+	display: block;
+	font-weight: bold;
+	overflow-wrap: anywhere;
+}
+
+.friends-page section.add-friend-subscriptions .bulk-feed-row > label small,
+.friends-page section.add-friend-subscriptions .subscription-feed-option > label small {
+	color: light-dark(#666, #bdc1c6);
+	font-weight: normal;
+}
+
+.friends-page section.add-friend-subscriptions .bulk-feed-row.is-reviewing > .label-for-bulkfeed,
+.friends-page section.add-friend-subscriptions .bulk-feed-row.is-reviewing > .bulk-feed-status {
+	display: none;
+}
+
+.friends-page section.add-friend-subscriptions .bulk-feed-review {
+	margin-top: 6px;
+}
+
+.friends-page section.add-friend-subscriptions .feed-preview {
+	background: light-dark(#fff, #292a2d);
+	border-radius: 2px;
+	box-shadow: inset 3px 0 0 #4d90fe, inset 0 0 0 1px light-dark(#e8e8e8, #3c4043);
+	margin-top: 8px;
+	padding: 8px;
+}
+
+.friends-page section.add-friend-subscriptions .bulk-feed-review .feed-preview {
+	background: transparent;
+	border-radius: 0;
+	box-shadow: none;
+	margin-top: 0;
+	padding: 0;
+}
+
+.friends-page section.add-friend-subscriptions .subscription-preview-header,
+.friends-page section.add-friend-subscriptions .subscribe-success {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+}
+
+.friends-page section.add-friend-subscriptions .subscription-preview-header .avatar,
+.friends-page section.add-friend-subscriptions .subscribe-success .avatar {
+	border-radius: 50%;
+	flex: 0 0 auto;
+}
+
+.friends-page section.add-friend-subscriptions .subscription-preview-title,
+.friends-page section.add-friend-subscriptions .subscription-feed-preview-title {
+	display: flex;
+	flex-direction: column;
+	min-width: 0;
+}
+
+.friends-page section.add-friend-subscriptions .subscription-preview-title small,
+.friends-page section.add-friend-subscriptions .subscription-feed-preview-title small {
+	color: light-dark(#666, #bdc1c6);
+	overflow-wrap: anywhere;
+}
+
+.friends-page section.add-friend-subscriptions .subscription-settings,
+.friends-page section.add-friend-subscriptions .subscription-feed-controls {
+	display: grid;
+	grid-template-columns: repeat(2, minmax(0, 1fr));
+	gap: 6px;
+	margin-top: 8px;
+}
+
+.friends-page section.add-friend-subscriptions .subscription-settings label,
+.friends-page section.add-friend-subscriptions .subscription-feed-controls label {
+	display: grid;
+	gap: 3px;
+	font-size: 12px;
+	font-weight: bold;
+}
+
+.friends-page section.add-friend-subscriptions .subscription-feed-url-label {
+	grid-column: 1 / -1;
+}
+
+.friends-page section.add-friend-subscriptions .subscription-feed-preview {
+	background: light-dark(#fff, #292a2d);
+	border-radius: 2px;
+	box-shadow: inset 0 0 0 1px light-dark(#e8e8e8, #3c4043);
+	margin-top: 6px;
+	padding: 8px;
+}
+
+.friends-page section.add-friend-subscriptions .subscription-feed-preview ul {
+	display: grid;
+	gap: 6px;
+	list-style: none;
+	margin: 0;
+	padding: 0;
+}
+
+.friends-page section.add-friend-subscriptions .subscription-feed-preview p {
+	color: light-dark(#666, #bdc1c6);
+	font-size: 12px;
+	margin: 2px 0 0;
+}
+
+.friends-page section.add-friend-subscriptions .error,
+.friends-page section.add-friend-subscriptions .subscription-preview-status.error,
+.friends-page section.add-friend-subscriptions .bulk-feed-status.error {
+	color: light-dark(#dd4b39, #ea4335);
+}
+
+@media (max-width: 640px) {
+	.friends-page section.add-friend-subscriptions .add-subscription-input {
+		flex-direction: column;
+	}
+
+	.friends-page section.add-friend-subscriptions .add-subscription-input .btn,
+	.friends-page section.add-friend-subscriptions .bulk-controls .btn,
+	.friends-page section.add-friend-subscriptions .subscription-feed-actions .btn,
+	.friends-page section.add-friend-subscriptions .subscription-preview-actions .btn {
+		width: 100%;
+	}
+
+	.friends-page section.add-friend-subscriptions .subscription-settings,
+	.friends-page section.add-friend-subscriptions .subscription-feed-controls {
+		grid-template-columns: 1fr;
+	}
+}
+
 /* Mention indicator */
 .friends-page .mention-indicator {
 	color: light-dark(#dd4b39, #ea4335);

--- a/templates/mastodon/mastodon.css
+++ b/templates/mastodon/mastodon.css
@@ -1763,6 +1763,223 @@ body.friends-page {
 	color: light-dark(#282c37, #fff);
 }
 
+/* --- Add friend review flow --- */
+.friends-page section.add-friend-subscriptions {
+	display: grid;
+	gap: 12px;
+	padding: 16px;
+}
+
+.friends-page section.add-friend-subscriptions .card {
+	background: light-dark(#fff, #282c37);
+	border-radius: 12px;
+	margin: 0;
+}
+
+.friends-page section.add-friend-subscriptions .card-body {
+	padding: 16px;
+}
+
+.friends-page section.add-friend-subscriptions .hidden {
+	display: none;
+}
+
+.friends-page section.add-friend-subscriptions .add-subscription-input {
+	display: flex;
+	align-items: flex-start;
+	gap: 10px;
+}
+
+.friends-page section.add-friend-subscriptions textarea.form-input {
+	flex: 1 1 auto;
+	min-height: 96px;
+	resize: vertical;
+	width: 100%;
+}
+
+.friends-page section.add-friend-subscriptions .form-select {
+	background: light-dark(#eaedf1, #313543);
+	border: 1px solid transparent;
+	border-radius: 100px;
+	color: light-dark(#282c37, #dadada);
+	font: inherit;
+	padding: 8px 16px;
+	width: 100%;
+}
+
+.friends-page section.add-friend-subscriptions .opml-file-hint,
+.friends-page section.add-friend-subscriptions .subscription-preview-description,
+.friends-page section.add-friend-subscriptions .subscription-feed-details,
+.friends-page section.add-friend-subscriptions .subscription-preview-status,
+.friends-page section.add-friend-subscriptions .bulk-feed-status {
+	color: light-dark(#606984, #9baec8);
+	font-size: 13px;
+}
+
+.friends-page section.add-friend-subscriptions #preview-subscription:not(:empty) {
+	margin-top: 14px;
+}
+
+.friends-page section.add-friend-subscriptions .bulk-controls,
+.friends-page section.add-friend-subscriptions .subscription-feed-actions,
+.friends-page section.add-friend-subscriptions .subscription-preview-actions {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 8px;
+	margin-top: 12px;
+}
+
+.friends-page section.add-friend-subscriptions .subscription-preview-results,
+.friends-page section.add-friend-subscriptions .bulk-feed-list,
+.friends-page section.add-friend-subscriptions .subscription-feed-list {
+	display: grid;
+	gap: 10px;
+	list-style: none;
+	margin: 12px 0 0;
+	padding: 0;
+}
+
+.friends-page section.add-friend-subscriptions .subscription-feed-list.hidden {
+	display: none;
+}
+
+.friends-page section.add-friend-subscriptions .bulk-feed-row,
+.friends-page section.add-friend-subscriptions .subscription-feed-option {
+	background: light-dark(#f7f9fb, #313543);
+	border-radius: 10px;
+	padding: 12px;
+}
+
+.friends-page section.add-friend-subscriptions .bulk-feed-row > label,
+.friends-page section.add-friend-subscriptions .subscription-feed-option > label {
+	display: block;
+	font-weight: 700;
+	overflow-wrap: anywhere;
+}
+
+.friends-page section.add-friend-subscriptions .bulk-feed-row > label small,
+.friends-page section.add-friend-subscriptions .subscription-feed-option > label small {
+	color: light-dark(#606984, #9baec8);
+	font-weight: 400;
+}
+
+.friends-page section.add-friend-subscriptions .bulk-feed-row.is-reviewing > .label-for-bulkfeed,
+.friends-page section.add-friend-subscriptions .bulk-feed-row.is-reviewing > .bulk-feed-status {
+	display: none;
+}
+
+.friends-page section.add-friend-subscriptions .bulk-feed-review {
+	margin-top: 10px;
+}
+
+.friends-page section.add-friend-subscriptions .feed-preview {
+	background: light-dark(#f7f9fb, #313543);
+	border-radius: 12px;
+	box-shadow: inset 4px 0 0 light-dark(rgba(86,58,204,.18), rgba(99,100,255,.25));
+	margin-top: 12px;
+	padding: 14px;
+}
+
+.friends-page section.add-friend-subscriptions .bulk-feed-review .feed-preview {
+	background: transparent;
+	border-radius: 0;
+	box-shadow: none;
+	margin-top: 0;
+	padding: 0;
+}
+
+.friends-page section.add-friend-subscriptions .subscription-preview-header,
+.friends-page section.add-friend-subscriptions .subscribe-success {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+}
+
+.friends-page section.add-friend-subscriptions .subscription-preview-header .avatar,
+.friends-page section.add-friend-subscriptions .subscribe-success .avatar {
+	border-radius: 8px;
+	flex: 0 0 auto;
+}
+
+.friends-page section.add-friend-subscriptions .subscription-preview-title,
+.friends-page section.add-friend-subscriptions .subscription-feed-preview-title {
+	display: flex;
+	flex-direction: column;
+	min-width: 0;
+}
+
+.friends-page section.add-friend-subscriptions .subscription-preview-title small,
+.friends-page section.add-friend-subscriptions .subscription-feed-preview-title small {
+	color: light-dark(#606984, #9baec8);
+	overflow-wrap: anywhere;
+}
+
+.friends-page section.add-friend-subscriptions .subscription-settings,
+.friends-page section.add-friend-subscriptions .subscription-feed-controls {
+	display: grid;
+	grid-template-columns: repeat(2, minmax(0, 1fr));
+	gap: 10px;
+	margin-top: 12px;
+}
+
+.friends-page section.add-friend-subscriptions .subscription-settings label,
+.friends-page section.add-friend-subscriptions .subscription-feed-controls label {
+	display: grid;
+	gap: 4px;
+	font-size: 13px;
+	font-weight: 700;
+}
+
+.friends-page section.add-friend-subscriptions .subscription-feed-url-label {
+	grid-column: 1 / -1;
+}
+
+.friends-page section.add-friend-subscriptions .subscription-feed-preview {
+	background: light-dark(#fff, #282c37);
+	border-radius: 8px;
+	margin-top: 10px;
+	padding: 10px;
+}
+
+.friends-page section.add-friend-subscriptions .subscription-feed-preview ul {
+	display: grid;
+	gap: 10px;
+	list-style: none;
+	margin: 0;
+	padding: 0;
+}
+
+.friends-page section.add-friend-subscriptions .subscription-feed-preview p {
+	color: light-dark(#606984, #9baec8);
+	font-size: 13px;
+	margin: 3px 0 0;
+}
+
+.friends-page section.add-friend-subscriptions .error,
+.friends-page section.add-friend-subscriptions .subscription-preview-status.error,
+.friends-page section.add-friend-subscriptions .bulk-feed-status.error {
+	color: light-dark(#c0392b, #e74c3c);
+}
+
+@media (max-width: 640px) {
+	.friends-page section.add-friend-subscriptions .add-subscription-input {
+		flex-direction: column;
+	}
+
+	.friends-page section.add-friend-subscriptions .add-subscription-input .btn,
+	.friends-page section.add-friend-subscriptions .bulk-controls .btn,
+	.friends-page section.add-friend-subscriptions .subscription-feed-actions .btn,
+	.friends-page section.add-friend-subscriptions .subscription-preview-actions .btn {
+		width: 100%;
+	}
+
+	.friends-page section.add-friend-subscriptions .subscription-settings,
+	.friends-page section.add-friend-subscriptions .subscription-feed-controls {
+		grid-template-columns: 1fr;
+	}
+}
+
 /* === Pagination === */
 .friends-page .navigation {
 	padding: 16px;

--- a/templates/mastodon/mastodon.css
+++ b/templates/mastodon/mastodon.css
@@ -1738,6 +1738,223 @@ body.friends-page {
 	color: light-dark(#282c37, #fff);
 }
 
+/* --- Add friend review flow --- */
+.friends-page section.add-friend-subscriptions {
+	display: grid;
+	gap: 12px;
+	padding: 16px;
+}
+
+.friends-page section.add-friend-subscriptions .card {
+	background: light-dark(#fff, #282c37);
+	border-radius: 12px;
+	margin: 0;
+}
+
+.friends-page section.add-friend-subscriptions .card-body {
+	padding: 16px;
+}
+
+.friends-page section.add-friend-subscriptions .hidden {
+	display: none;
+}
+
+.friends-page section.add-friend-subscriptions .add-subscription-input {
+	display: flex;
+	align-items: flex-start;
+	gap: 10px;
+}
+
+.friends-page section.add-friend-subscriptions textarea.form-input {
+	flex: 1 1 auto;
+	min-height: 96px;
+	resize: vertical;
+	width: 100%;
+}
+
+.friends-page section.add-friend-subscriptions .form-select {
+	background: light-dark(#eaedf1, #313543);
+	border: 1px solid transparent;
+	border-radius: 100px;
+	color: light-dark(#282c37, #dadada);
+	font: inherit;
+	padding: 8px 16px;
+	width: 100%;
+}
+
+.friends-page section.add-friend-subscriptions .opml-file-hint,
+.friends-page section.add-friend-subscriptions .subscription-preview-description,
+.friends-page section.add-friend-subscriptions .subscription-feed-details,
+.friends-page section.add-friend-subscriptions .subscription-preview-status,
+.friends-page section.add-friend-subscriptions .bulk-feed-status {
+	color: light-dark(#606984, #9baec8);
+	font-size: 13px;
+}
+
+.friends-page section.add-friend-subscriptions #preview-subscription:not(:empty) {
+	margin-top: 14px;
+}
+
+.friends-page section.add-friend-subscriptions .bulk-controls,
+.friends-page section.add-friend-subscriptions .subscription-feed-actions,
+.friends-page section.add-friend-subscriptions .subscription-preview-actions {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 8px;
+	margin-top: 12px;
+}
+
+.friends-page section.add-friend-subscriptions .subscription-preview-results,
+.friends-page section.add-friend-subscriptions .bulk-feed-list,
+.friends-page section.add-friend-subscriptions .subscription-feed-list {
+	display: grid;
+	gap: 10px;
+	list-style: none;
+	margin: 12px 0 0;
+	padding: 0;
+}
+
+.friends-page section.add-friend-subscriptions .subscription-feed-list.hidden {
+	display: none;
+}
+
+.friends-page section.add-friend-subscriptions .bulk-feed-row,
+.friends-page section.add-friend-subscriptions .subscription-feed-option {
+	background: light-dark(#f7f9fb, #313543);
+	border-radius: 10px;
+	padding: 12px;
+}
+
+.friends-page section.add-friend-subscriptions .bulk-feed-row > label,
+.friends-page section.add-friend-subscriptions .subscription-feed-option > label {
+	display: block;
+	font-weight: 700;
+	overflow-wrap: anywhere;
+}
+
+.friends-page section.add-friend-subscriptions .bulk-feed-row > label small,
+.friends-page section.add-friend-subscriptions .subscription-feed-option > label small {
+	color: light-dark(#606984, #9baec8);
+	font-weight: 400;
+}
+
+.friends-page section.add-friend-subscriptions .bulk-feed-row.is-reviewing > .label-for-bulkfeed,
+.friends-page section.add-friend-subscriptions .bulk-feed-row.is-reviewing > .bulk-feed-status {
+	display: none;
+}
+
+.friends-page section.add-friend-subscriptions .bulk-feed-review {
+	margin-top: 10px;
+}
+
+.friends-page section.add-friend-subscriptions .feed-preview {
+	background: light-dark(#f7f9fb, #313543);
+	border-radius: 12px;
+	box-shadow: inset 4px 0 0 light-dark(rgba(86,58,204,.18), rgba(99,100,255,.25));
+	margin-top: 12px;
+	padding: 14px;
+}
+
+.friends-page section.add-friend-subscriptions .bulk-feed-review .feed-preview {
+	background: transparent;
+	border-radius: 0;
+	box-shadow: none;
+	margin-top: 0;
+	padding: 0;
+}
+
+.friends-page section.add-friend-subscriptions .subscription-preview-header,
+.friends-page section.add-friend-subscriptions .subscribe-success {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+}
+
+.friends-page section.add-friend-subscriptions .subscription-preview-header .avatar,
+.friends-page section.add-friend-subscriptions .subscribe-success .avatar {
+	border-radius: 8px;
+	flex: 0 0 auto;
+}
+
+.friends-page section.add-friend-subscriptions .subscription-preview-title,
+.friends-page section.add-friend-subscriptions .subscription-feed-preview-title {
+	display: flex;
+	flex-direction: column;
+	min-width: 0;
+}
+
+.friends-page section.add-friend-subscriptions .subscription-preview-title small,
+.friends-page section.add-friend-subscriptions .subscription-feed-preview-title small {
+	color: light-dark(#606984, #9baec8);
+	overflow-wrap: anywhere;
+}
+
+.friends-page section.add-friend-subscriptions .subscription-settings,
+.friends-page section.add-friend-subscriptions .subscription-feed-controls {
+	display: grid;
+	grid-template-columns: repeat(2, minmax(0, 1fr));
+	gap: 10px;
+	margin-top: 12px;
+}
+
+.friends-page section.add-friend-subscriptions .subscription-settings label,
+.friends-page section.add-friend-subscriptions .subscription-feed-controls label {
+	display: grid;
+	gap: 4px;
+	font-size: 13px;
+	font-weight: 700;
+}
+
+.friends-page section.add-friend-subscriptions .subscription-feed-url-label {
+	grid-column: 1 / -1;
+}
+
+.friends-page section.add-friend-subscriptions .subscription-feed-preview {
+	background: light-dark(#fff, #282c37);
+	border-radius: 8px;
+	margin-top: 10px;
+	padding: 10px;
+}
+
+.friends-page section.add-friend-subscriptions .subscription-feed-preview ul {
+	display: grid;
+	gap: 10px;
+	list-style: none;
+	margin: 0;
+	padding: 0;
+}
+
+.friends-page section.add-friend-subscriptions .subscription-feed-preview p {
+	color: light-dark(#606984, #9baec8);
+	font-size: 13px;
+	margin: 3px 0 0;
+}
+
+.friends-page section.add-friend-subscriptions .error,
+.friends-page section.add-friend-subscriptions .subscription-preview-status.error,
+.friends-page section.add-friend-subscriptions .bulk-feed-status.error {
+	color: light-dark(#c0392b, #e74c3c);
+}
+
+@media (max-width: 640px) {
+	.friends-page section.add-friend-subscriptions .add-subscription-input {
+		flex-direction: column;
+	}
+
+	.friends-page section.add-friend-subscriptions .add-subscription-input .btn,
+	.friends-page section.add-friend-subscriptions .bulk-controls .btn,
+	.friends-page section.add-friend-subscriptions .subscription-feed-actions .btn,
+	.friends-page section.add-friend-subscriptions .subscription-preview-actions .btn {
+		width: 100%;
+	}
+
+	.friends-page section.add-friend-subscriptions .subscription-settings,
+	.friends-page section.add-friend-subscriptions .subscription-feed-controls {
+		grid-template-columns: 1fr;
+	}
+}
+
 /* === Pagination === */
 .friends-page .navigation {
 	padding: 16px;

--- a/themes/friends/templates/friends-add-friend.html
+++ b/themes/friends/templates/friends-add-friend.html
@@ -1,0 +1,12 @@
+<!-- wp:columns {"style":{"spacing":{"padding":{"top":"40px"}}}} -->
+<div class="wp-block-columns" style="padding-top:40px"><!-- wp:column {"width":"25%"} -->
+<div class="wp-block-column" style="flex-basis:25%"><!-- wp:template-part {"slug":"sidebar","theme":"friends","tagName":"sidebar","area":"sidebar"} /--></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"width":"75%"} -->
+<div class="wp-block-column" style="flex-basis:75%"><!-- wp:template-part {"slug":"header","theme":"friends","tagName":"header","area":"header"} /-->
+
+<!-- wp:friends/add-friend-form /-->
+</div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->


### PR DESCRIPTION
## Summary

- Adds a frontend `/friends/add-friend/` page and block template so subscriptions can be reviewed and created outside wp-admin.
- Adds a review flow for single URLs, Mastodon-style handles, pasted URL lists, pasted OPML, and uploaded OPML files.
- Lets users choose discovered feeds, edit display name/username, adjust parser and post format settings, preview feed items, add custom feed URLs, and follow selected entries in bulk.
- Adds authenticated AJAX handlers for feed discovery, feed-item previews, and frontend subscription creation, then schedules the new subscription's first retrieval.
- Adds Add Friend entry points and styles for the default, block, Google Reader, and Mastodon frontend themes.

## Testing

- `composer check-cs`
- `git diff --check main...HEAD`

<details><summary>Changelog</summary>

- [x] Automatically create a changelog entry from the details below

#### Type
- [x] Added
- [ ] Changed
- [ ] Fixed
- [ ] Removed

#### Message
Add a frontend Add Friend page with feed review and OPML import support.

</details>
