### PR TITLE
Always apply replace rules and fix html entity replacing

### DIFF
--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -2157,22 +2157,24 @@ class Admin {
 						$title = wp_strip_all_tags( $item->content );
 					}
 					?>
-					<li><a href="<?php echo esc_url( $item->permalink ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( $item->date ); ?></a> (author: <?php echo esc_html( $item->author ); ?>, type: <?php echo esc_html( $item->post_format ); ?>):
+					<li>
 						<?php if ( $title ) : ?>
-							<a href="<?php echo esc_url( $item->permalink ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( $title ); ?></a> <?php echo esc_html( str_word_count( wp_strip_all_tags( $item->content ) ) ); ?> words
-							<?php else : ?>
-								<p>
-									<?php
-									echo wp_kses(
-										wp_trim_excerpt( $item->content ),
-										array(
-											'a'   => array( 'href' => array() ),
-											'img' => array( 'src' => array() ),
-										)
-									);
-									?>
-								</p>
-							<?php endif; ?>
+							<details><summary>
+						<?php endif; ?>
+							<a href="<?php echo esc_url( $item->permalink ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( $item->date ); ?></a> (author: <?php echo esc_html( $item->author ); ?>, type: <?php echo esc_html( $item->post_format ); ?>):
+						<?php if ( $title ) : ?>
+							<a href="<?php echo esc_url( $item->permalink ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( $title ); ?></a> <?php echo esc_html( str_word_count( wp_strip_all_tags( $item->content ) ) ); ?> words</summary>
+						<?php else : ?>
+							<p>
+						<?php endif; ?>
+							<?php
+								echo esc_textarea( $item->content );
+							?>
+						<?php if ( $title ) : ?>
+							</details>
+						<?php else : ?>
+							</p>
+						<?php endif; ?>
 						</li>
 						<?php
 				}

--- a/templates/admin/edit-rules.php
+++ b/templates/admin/edit-rules.php
@@ -23,7 +23,7 @@
 						<option value="permalink" <?php selected( 'permalink', $rule['field'] ); ?>><?php echo esc_html_e( 'If the URL contains', 'friends' ); ?></option>
 					</select>
 				</th>
-				<td><input type="text" name="rules[regex][]" value="<?php echo esc_attr( $rule['regex'] ); ?>" class="regular-text" placeholder="<?php esc_attr_e( 'Enter a text or regular expression', 'friends' ); ?>" /></td>
+				<td><input type="text" name="rules[regex][]" value="<?php echo esc_textarea( $rule['regex'] ); ?>" class="regular-text" placeholder="<?php esc_attr_e( 'Enter a text or regular expression', 'friends' ); ?>" /></td>
 				<td>
 					<select name="rules[action][]" class="rule-action">
 						<option value="accept" <?php selected( 'accept', $rule['action'] ); ?>><?php echo esc_html_e( 'accept the item', 'friends' ); ?></option>
@@ -32,7 +32,7 @@
 						<option value="replace" <?php selected( 'replace', $rule['action'] ); ?>><?php echo esc_html_e( 'replace the match with this:', 'friends' ); ?></option>
 					</select>
 				</td>
-				<td style="<?php echo esc_attr( 'replace' !== $rule['action'] ? 'display: none' : '' ); ?>" class="replace-with"><input type="text" name="rules[replace][]" value="<?php echo esc_attr( isset( $rule['replace'] ) ? $rule['replace'] : '' ); ?>" class="regular-text" placeholder="<?php esc_attr_e( 'Enter the text to replace it with', 'friends' ); ?>" /></td>
+				<td style="<?php echo esc_attr( 'replace' !== $rule['action'] ? 'display: none' : '' ); ?>" class="replace-with"><input type="text" name="rules[replace][]" value="<?php echo esc_textarea( isset( $rule['replace'] ) ? $rule['replace'] : '' ); ?>" class="regular-text" placeholder="<?php esc_attr_e( 'Enter the text to replace it with', 'friends' ); ?>" /></td>
 				<?php if ( empty( $rule['regex'] ) ) : ?>
 					<td><span class="description">(<?php esc_html_e( 'Unsubmitted rule', 'friends' ); ?>)</span></td>
 				<?php endif; ?>


### PR DESCRIPTION
Before this change, rules processing would stop as soon as you get to a accept/trash/delete conclusion. Now further `replace` rules will be processed.

This also fixes a display problem when replacing HTML entities like `&lt;` (it would not show the entities in the textbox when you had entered them but convert them back to HTML)

Before:
![Screenshot 2025-05-21 at 11 25 14](https://github.com/user-attachments/assets/74a47f81-c5a7-42c9-8b14-a43d3f5b0416)
After:
![Screenshot 2025-05-21 at 11 24 44](https://github.com/user-attachments/assets/f66389b4-5b64-48a4-9676-de29c30feafa)

