### PR TITLE
Don't replace tags outside of the friends page

### DIFF
--- a/feed-parsers/class-feed-parser-activitypub.php
+++ b/feed-parsers/class-feed-parser-activitypub.php
@@ -1884,6 +1884,10 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 	}
 
 	public function the_content( $the_content ) {
+		if ( ! Friends::on_frontend() ) {
+			return $the_content;
+		}
+
 		// replace all links in <a href="mention hashtag"> with /friends/tag/tagname using the WP_HTML_Tag_Processor.
 		$processor = new \WP_HTML_Tag_Processor( $the_content );
 		while ( $processor->next_tag( array( 'tag_name' => 'a' ) ) ) {


### PR DESCRIPTION
Fixes #502 by not modifying the tags links outside the friends page.

See also https://rheinneckar.social/@hdvalentin/114625963100862760