### PR TITLE
Add support for following via textbox on Mastodon

### DIFF
--- a/feed-parsers/class-feed-parser-activitypub.php
+++ b/feed-parsers/class-feed-parser-activitypub.php
@@ -50,6 +50,7 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 		\add_action( 'activitypub_inbox_move', array( $this, 'handle_received_move' ), 15, 2 );
 		\add_action( 'activitypub_inbox_update', array( $this, 'handle_received_update' ), 15, 2 );
 		\add_action( 'activitypub_handled_create', array( $this, 'activitypub_handled_create' ), 10, 4 );
+		\add_action( 'activitypub_interactions_follow_url', array( $this, 'activitypub_interactions_follow_url' ), 10, 2 );
 
 		\add_action( 'friends_user_feed_activated', array( $this, 'queue_follow_user' ), 10 );
 		\add_action( 'friends_user_feed_deactivated', array( $this, 'queue_unfollow_user' ), 10 );
@@ -1793,6 +1794,13 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 		}
 
 		return $follow_list;
+	}
+
+	public function activitypub_interactions_follow_url( $redirect_uri, $uri ) {
+		if ( ! $redirect_uri ) {
+			$redirect_uri = add_query_arg( 'url', $uri, self_admin_url( 'admin.php?page=add-friend' ) );
+		}
+		return $redirect_uri;
 	}
 
 	private function show_message_on_frontend( $message, $error = null ) {


### PR DESCRIPTION
When you are on a Mastodon instance and click the Follow button, this popup appears where you can enter your own "Mastodon handle":

![Screenshot 2025-06-15 at 15 06 12](https://github.com/user-attachments/assets/62ab5192-f224-4d82-b652-4f767874b782)

This is now supported and will redirect to the "Add friend" page. Requires this fix to work properly: https://github.com/Automattic/wordpress-activitypub/pull/1819