### PR TITLE
Show as who you'll follow

### DIFF
--- a/feed-parsers/class-feed-parser-activitypub.php
+++ b/feed-parsers/class-feed-parser-activitypub.php
@@ -623,6 +623,10 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 
 		$feed_details['type'] = 'application/activity+json';
 		$feed_details['autoselect'] = true;
+		$actor = $this->get_activitypub_actor( get_current_user_id() );
+		if ( $actor ) {
+			$feed_details['additional-info'] = 'You will follow as <tt>' . $actor->get_webfinger() . '</tt>';
+		}
 
 		$feed_details['suggested-username'] = str_replace( ' ', '-', sanitize_user( $meta['name'] ) );
 

--- a/templates/admin/select-feeds.php
+++ b/templates/admin/select-feeds.php
@@ -223,6 +223,16 @@ foreach ( $args['feeds'] as $feed_url => $details ) {
 								echo ' | ';
 								// translators: %s is relation to the URL, e.g. self or alternate.
 								echo esc_html( sprintf( __( 'rel: %s', 'friends' ), $details['rel'] ) );
+								if ( isset( $details['additional-info'] ) ) {
+									echo '<br>' . wp_kses(
+										$details['additional-info'],
+										array(
+											'b'  => true,
+											'tt' => true,
+											'a'  => array( 'href' => array() ),
+										)
+									);
+								}
 								?>
 							</p>
 						</li>


### PR DESCRIPTION
To build confidence as who you'll be following, this adds this to be shown (mentioned to me as a worthwhile thing to add by https://bonn.social/@annette)
![Screenshot 2025-06-15 at 15 25 08](https://github.com/user-attachments/assets/17ac2faf-3313-47f6-95ae-f767480d261d)

Also shows that it works when only the blog user is enabled (cc @Menrath):
![Screenshot 2025-06-15 at 15 27 59](https://github.com/user-attachments/assets/37813109-a2a5-4c57-bd24-07ead3005d69)
