### PR TITLE
Fix Fatal when previewing an ActivityPub profile that contains a person update

### DIFF
--- a/feed-parsers/class-feed-parser-activitypub.php
+++ b/feed-parsers/class-feed-parser-activitypub.php
@@ -1067,6 +1067,9 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 				return $this->handle_incoming_create( $activity['object'] );
 			case 'update':
 				if ( isset( $activity['object']['type'] ) && 'Person' === $activity['object']['type'] ) {
+					if ( ! $user_feed instanceof User_Feed ) {
+						return null;
+					}
 					return $this->handle_incoming_update_person( $activity['object'], $user_feed );
 				}
 				$item = $this->handle_incoming_create( $activity['object'] );


### PR DESCRIPTION
Reported in https://wordpress.org/support/topic/fatal-error-when-adding-new-friend/