### PR TITLE
Use a Github action to extract the hooks

### DIFF
--- a/.github/workflows/extract-hooks.yml
+++ b/.github/workflows/extract-hooks.yml
@@ -1,0 +1,14 @@
+name: Extract WordPress Hooks
+
+on:
+  push:
+    branches: [main, master]
+    paths: ["**.php"]
+  workflow_dispatch:
+
+jobs:
+  extract-hooks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: akirk/extract-wp-hooks@main


### PR DESCRIPTION
Make use of the [new Github action I added to the extract-wp-hooks repo](https://github.com/akirk/extract-wp-hooks). It will update the [Hooks documentation in the Github wiki of this repo](https://github.com/akirk/friends/wiki/Hooks).