### PR TITLE
Create GitHub Action for PR Comments

### DIFF
--- a/.github/workflows/pr-playground-comment.yml
+++ b/.github/workflows/pr-playground-comment.yml
@@ -1,0 +1,56 @@
+name: PR Playground Comment
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post Playground Link Comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const playgroundUrl = `https://playground.wordpress.net/#{%22steps%22:[{%22step%22:%22installPlugin%22,%22pluginData%22:{%22resource%22:%22git:directory%22,%22url%22:%22https://github.com/akirk/friends%22,%22ref%22:%22refs/pull/${prNumber}/head%22,%22refType%22:%22refname%22},%22options%22:{%22activate%22:true}}]}`;
+
+            const commentBody = `## Test this PR in WordPress Playground
+
+You can test this pull request directly in WordPress Playground:
+
+[Launch WordPress Playground](${playgroundUrl})
+
+This will install and activate the plugin with the changes from this PR.`;
+
+            // Check if we already posted a comment
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+
+            const botComment = comments.find(comment =>
+              comment.user.type === 'Bot' &&
+              comment.body.includes('Test this PR in WordPress Playground')
+            );
+
+            if (botComment) {
+              // Update existing comment
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body: commentBody
+              });
+            } else {
+              // Create new comment
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: commentBody
+              });
+            }


### PR DESCRIPTION
This action automatically posts a comment on pull requests with a link to test the PR in WordPress Playground. The link includes the PR changes and activates the plugin for immediate testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)