### PR TITLE
Refactor Friend Tag

### DIFF
--- a/feed-parsers/class-feed-parser-activitypub.php
+++ b/feed-parsers/class-feed-parser-activitypub.php
@@ -1458,10 +1458,10 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 		if ( $item instanceof Feed_Item ) {
 			$i = $this->friends_feed->process_incoming_feed_items( array( $item ), $user_feed );
 
-			// If this is a reply that mentions the site owner, queue for background conversion.
+			// If this is a reply and the user was mentioned, queue for background conversion to comment.
 			if ( 'create' === $type && ! empty( $activity['object']['inReplyTo'] ) && ! empty( $item->friend_mention_tags ) ) {
 				$post_id = Feed::url_to_postid( $item->permalink );
-				if ( $post_id ) {
+				if ( $post_id && Friend_Tag::has_mention( $post_id ) ) {
 					wp_schedule_single_event( time() + 30, 'friends_convert_single_reply', array( $post_id ) );
 				}
 			}
@@ -1491,7 +1491,7 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 			if ( in_array( $my_activitypub_id, (array) $activity['cc'], true ) ) {
 				$local_user = get_userdata( $user_id );
 				if ( $local_user ) {
-					$mention_tags[] = 'mention-' . $local_user->user_login;
+					$mention_tags[] = Friend_Tag::mention_tag( $local_user->user_login );
 				}
 			}
 		}

--- a/friends.php
+++ b/friends.php
@@ -57,6 +57,7 @@ require_once __DIR__ . '/includes/class-site-health.php';
 require_once __DIR__ . '/includes/class-shortcodes.php';
 require_once __DIR__ . '/includes/class-template-loader.php';
 require_once __DIR__ . '/includes/class-third-parties.php';
+require_once __DIR__ . '/includes/class-friend-tag.php';
 require_once __DIR__ . '/includes/class-friends.php';
 
 add_action( 'plugins_loaded', array( __NAMESPACE__ . '\Friends', 'init' ) );

--- a/includes/class-feed.php
+++ b/includes/class-feed.php
@@ -735,11 +735,11 @@ class Feed {
 			}
 
 			if ( ! get_option( 'friends_disable_auto_tagging' ) && isset( $item->friend_tags ) && ! empty( $item->friend_tags ) && is_array( $item->friend_tags ) ) {
-				wp_set_post_terms( $post_id, $item->friend_tags, Friends::TAG_TAXONOMY, true );
+				Friend_Tag::add_tags( $post_id, $item->friend_tags );
 			}
 
 			if ( isset( $item->friend_mention_tags ) && ! empty( $item->friend_mention_tags ) && is_array( $item->friend_mention_tags ) ) {
-				wp_set_post_terms( $post_id, $item->friend_mention_tags, Friends::TAG_TAXONOMY, true );
+				Friend_Tag::add_tags( $post_id, $item->friend_mention_tags );
 			}
 
 			update_post_meta( $post_id, 'parser', $user_feed->get_parser() );

--- a/includes/class-friend-tag.php
+++ b/includes/class-friend-tag.php
@@ -1,0 +1,214 @@
+<?php
+/**
+ * Friend Tag Taxonomy
+ *
+ * Handles the friend_tag taxonomy for categorizing and filtering friend posts.
+ *
+ * @package Friends
+ */
+
+namespace Friends;
+
+/**
+ * Friend_Tag class for managing the friend_tag taxonomy.
+ */
+class Friend_Tag {
+	/**
+	 * The taxonomy name.
+	 */
+	const TAXONOMY = 'friend_tag';
+
+	/**
+	 * Prefix for mention tags.
+	 */
+	const MENTION_PREFIX = 'mention-';
+
+	/**
+	 * Register the friend_tag taxonomy.
+	 */
+	public static function register() {
+		$labels = array(
+			'name'          => __( 'Friend Tags', 'friends' ),
+			'singular_name' => __( 'Friend Tag', 'friends' ),
+			'search_items'  => __( 'Search Friend Tags', 'friends' ),
+			'all_items'     => __( 'All Friend Tags', 'friends' ),
+			'edit_item'     => __( 'Edit Friend Tag', 'friends' ),
+			'update_item'   => __( 'Update Friend Tag', 'friends' ),
+			'add_new_item'  => __( 'Add New Friend Tag', 'friends' ),
+			'new_item_name' => __( 'New Friend Tag Name', 'friends' ),
+			'menu_name'     => __( 'Friend Tags', 'friends' ),
+		);
+
+		$args = array(
+			'hierarchical'       => false,
+			'labels'             => $labels,
+			'show_ui'            => true,
+			'show_admin_column'  => true,
+			'query_var'          => true,
+			'rewrite'            => array( 'slug' => 'friend-tag' ),
+			'public'             => false,
+			'publicly_queryable' => false,
+			'show_in_rest'       => true,
+		);
+
+		register_taxonomy( self::TAXONOMY, Friends::CPT, $args );
+	}
+
+	/**
+	 * Check if a post has a specific tag.
+	 *
+	 * @param int    $post_id The post ID.
+	 * @param string $tag     The tag slug to check for.
+	 * @return bool True if the post has the tag.
+	 */
+	public static function has_tag( $post_id, $tag ) {
+		$terms = wp_get_post_terms( $post_id, self::TAXONOMY, array( 'fields' => 'slugs' ) );
+		if ( is_wp_error( $terms ) ) {
+			return false;
+		}
+		return in_array( $tag, $terms, true );
+	}
+
+	/**
+	 * Check if a post has any tag with a given prefix.
+	 *
+	 * @param int    $post_id The post ID.
+	 * @param string $prefix  The tag prefix to check for.
+	 * @return bool True if the post has a tag with the prefix.
+	 */
+	public static function has_tag_prefix( $post_id, $prefix ) {
+		$terms = wp_get_post_terms( $post_id, self::TAXONOMY, array( 'fields' => 'slugs' ) );
+		if ( is_wp_error( $terms ) ) {
+			return false;
+		}
+		foreach ( $terms as $slug ) {
+			if ( 0 === strpos( $slug, $prefix ) ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Check if a post has any mention tag.
+	 *
+	 * @param int $post_id The post ID.
+	 * @return bool True if the post has a mention tag.
+	 */
+	public static function has_mention( $post_id ) {
+		return self::has_tag_prefix( $post_id, self::MENTION_PREFIX );
+	}
+
+	/**
+	 * Get all tags for a post.
+	 *
+	 * @param int    $post_id The post ID.
+	 * @param string $fields  What fields to return ('slugs', 'names', 'ids', 'all').
+	 * @return array Array of tags or empty array on error.
+	 */
+	public static function get_tags( $post_id, $fields = 'slugs' ) {
+		$terms = wp_get_post_terms( $post_id, self::TAXONOMY, array( 'fields' => $fields ) );
+		if ( is_wp_error( $terms ) ) {
+			return array();
+		}
+		return $terms;
+	}
+
+	/**
+	 * Get all mention tags for a post.
+	 *
+	 * @param int $post_id The post ID.
+	 * @return array Array of mention tag slugs.
+	 */
+	public static function get_mention_tags( $post_id ) {
+		$terms = self::get_tags( $post_id, 'slugs' );
+		return array_filter(
+			$terms,
+			function ( $slug ) {
+				return 0 === strpos( $slug, self::MENTION_PREFIX );
+			}
+		);
+	}
+
+	/**
+	 * Add a tag to a post.
+	 *
+	 * @param int    $post_id The post ID.
+	 * @param string $tag     The tag slug to add.
+	 * @param bool   $append  Whether to append to existing tags (default true).
+	 * @return array|false|\WP_Error Array of term IDs on success, false or WP_Error on failure.
+	 */
+	public static function add_tag( $post_id, $tag, $append = true ) {
+		return wp_set_post_terms( $post_id, array( $tag ), self::TAXONOMY, $append );
+	}
+
+	/**
+	 * Add multiple tags to a post.
+	 *
+	 * @param int   $post_id The post ID.
+	 * @param array $tags    Array of tag slugs to add.
+	 * @param bool  $append  Whether to append to existing tags (default true).
+	 * @return array|false|\WP_Error Array of term IDs on success, false or WP_Error on failure.
+	 */
+	public static function add_tags( $post_id, $tags, $append = true ) {
+		return wp_set_post_terms( $post_id, $tags, self::TAXONOMY, $append );
+	}
+
+	/**
+	 * Add a mention tag for a user.
+	 *
+	 * @param int    $post_id  The post ID.
+	 * @param string $username The username to create a mention tag for.
+	 * @return array|false|\WP_Error Array of term IDs on success, false or WP_Error on failure.
+	 */
+	public static function add_mention( $post_id, $username ) {
+		return self::add_tag( $post_id, self::MENTION_PREFIX . $username );
+	}
+
+	/**
+	 * Create a mention tag slug for a username.
+	 *
+	 * @param string $username The username.
+	 * @return string The mention tag slug.
+	 */
+	public static function mention_tag( $username ) {
+		return self::MENTION_PREFIX . $username;
+	}
+
+	/**
+	 * Remove a tag from a post.
+	 *
+	 * @param int    $post_id The post ID.
+	 * @param string $tag     The tag slug to remove.
+	 * @return bool True on success, false on failure.
+	 */
+	public static function remove_tag( $post_id, $tag ) {
+		$term = get_term_by( 'slug', $tag, self::TAXONOMY );
+		if ( ! $term ) {
+			return false;
+		}
+		return wp_remove_object_terms( $post_id, $term->term_id, self::TAXONOMY );
+	}
+
+	/**
+	 * Clean up orphaned friend tags that have no posts.
+	 */
+	public static function cleanup_orphaned() {
+		$terms = get_terms(
+			array(
+				'taxonomy'   => self::TAXONOMY,
+				'hide_empty' => false,
+			)
+		);
+
+		if ( is_wp_error( $terms ) ) {
+			return;
+		}
+
+		foreach ( $terms as $term ) {
+			if ( 0 === $term->count ) {
+				wp_delete_term( $term->term_id, self::TAXONOMY );
+			}
+		}
+	}
+}

--- a/includes/class-friends.php
+++ b/includes/class-friends.php
@@ -18,7 +18,7 @@ namespace Friends;
 class Friends {
 	const VERSION       = FRIENDS_VERSION;
 	const CPT           = 'friend_post_cache';
-	const TAG_TAXONOMY  = 'friend_tag';
+	const TAG_TAXONOMY  = Friend_Tag::TAXONOMY;
 	const FEED_URL      = 'friends-feed-url';
 	const PLUGIN_URL    = 'https://wordpress.org/plugins/friends/';
 	const REQUIRED_ROLE = 'edit_private_posts';
@@ -226,31 +226,7 @@ class Friends {
 	 * Register the friend tag taxonomy
 	 */
 	public function register_friend_tag_taxonomy() {
-		$labels = array(
-			'name'          => __( 'Friend Tags', 'friends' ),
-			'singular_name' => __( 'Friend Tag', 'friends' ),
-			'search_items'  => __( 'Search Friend Tags', 'friends' ),
-			'all_items'     => __( 'All Friend Tags', 'friends' ),
-			'edit_item'     => __( 'Edit Friend Tag', 'friends' ),
-			'update_item'   => __( 'Update Friend Tag', 'friends' ),
-			'add_new_item'  => __( 'Add New Friend Tag', 'friends' ),
-			'new_item_name' => __( 'New Friend Tag Name', 'friends' ),
-			'menu_name'     => __( 'Friend Tags', 'friends' ),
-		);
-
-		$args = array(
-			'hierarchical'       => false,
-			'labels'             => $labels,
-			'show_ui'            => true,
-			'show_admin_column'  => true,
-			'query_var'          => true,
-			'rewrite'            => array( 'slug' => 'friend-tag' ),
-			'public'             => false,
-			'publicly_queryable' => false,
-			'show_in_rest'       => true,
-		);
-
-		register_taxonomy( self::TAG_TAXONOMY, self::CPT, $args );
+		Friend_Tag::register();
 	}
 
 	/**
@@ -1750,22 +1726,7 @@ class Friends {
 	 * Clean up orphaned friend tags that have no posts.
 	 */
 	public function cleanup_orphaned_friend_tags() {
-		$terms = get_terms(
-			array(
-				'taxonomy'   => self::TAG_TAXONOMY,
-				'hide_empty' => false,
-			)
-		);
-
-		if ( is_wp_error( $terms ) ) {
-			return;
-		}
-
-		foreach ( $terms as $term ) {
-			if ( 0 === $term->count ) {
-				wp_delete_term( $term->term_id, self::TAG_TAXONOMY );
-			}
-		}
+		Friend_Tag::cleanup_orphaned();
 	}
 
 	/**

--- a/integrations/class-enable-mastodon-apps.php
+++ b/integrations/class-enable-mastodon-apps.php
@@ -131,7 +131,7 @@ class Enable_Mastodon_Apps {
 		// Add tax_query to filter for mention tags for the current user.
 		$current_user = wp_get_current_user();
 		if ( $current_user && $current_user->ID ) {
-			$mention_tag = 'mention-' . $current_user->user_login;
+			$mention_tag = Friend_Tag::mention_tag( $current_user->user_login );
 
 			$mention_query = array(
 				'taxonomy' => Friends::TAG_TAXONOMY,


### PR DESCRIPTION
## Summary

Extracts the `friend_tag` taxonomy logic into a dedicated `Friend_Tag` class (`includes/class-friend-tag.php`), replacing scattered inline usage of the taxonomy throughout the codebase.

### Changes

- **New `Friend_Tag` class** with static methods for all tag operations: `register()`, `has_tag()`, `has_mention()`, `add_tag()`, `add_tags()`, `mention_tag()`, `remove_tag()`, `cleanup_orphaned()`, etc.
- **`Friends` class** now delegates to `Friend_Tag::register()` and `Friend_Tag::cleanup_orphaned()` instead of inlining the taxonomy registration and cleanup logic. `Friends::TAG_TAXONOMY` references `Friend_Tag::TAXONOMY`.
- **`Feed` class** uses `Friend_Tag::add_tags()` instead of calling `wp_set_post_terms()` directly for both `friend_tags` and `friend_mention_tags`.
- **ActivityPub parser** uses `Friend_Tag::mention_tag()` to build mention slugs and `Friend_Tag::has_mention()` to check for mentions before queuing reply-to-comment conversion.
- **Migration class** replaces inline `wp_get_post_terms()` + prefix-matching loops with `Friend_Tag::has_mention()` and uses `Friend_Tag::mention_tag()` for building mention slugs.
- **Enable Mastodon Apps integration** uses `Friend_Tag::mention_tag()` instead of hardcoding the `mention-` prefix.

### Motivation

The `mention-` prefix and `friend_tag` taxonomy name were hardcoded in many places. This consolidates them behind constants (`Friend_Tag::TAXONOMY`, `Friend_Tag::MENTION_PREFIX`) and a single class, making the tag system easier to maintain and less error-prone.