### PR TITLE
Fix non-ASCII display names producing broken usernames

### DIFF
--- a/feed-parsers/class-feed-parser-activitypub.php
+++ b/feed-parsers/class-feed-parser-activitypub.php
@@ -874,7 +874,10 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 			$feed_details['additional-info'] = 'You will follow as <tt>' . $actor->get_webfinger() . '</tt>';
 		}
 
-		$feed_details['suggested-username'] = str_replace( ' ', '-', sanitize_user( $meta['name'] ) );
+		if ( ! empty( $meta['preferredUsername'] ) ) {
+			$host = wp_parse_url( $feed_details['url'], PHP_URL_HOST );
+			$feed_details['suggested-username'] = User::sanitize_username( $meta['preferredUsername'] . '.' . $host );
+		}
 
 		return $feed_details;
 	}

--- a/tests/test-activitypub.php
+++ b/tests/test-activitypub.php
@@ -500,6 +500,93 @@ class ActivityPubTest extends Friends_TestCase_Cache_HTTP {
 		$this->assertEquals( 'https://mastodon.local/users/akirk', $details['url'] );
 		$this->assertEquals( 'Alex Kirk', $details['title'] );
 		$this->assertEquals( 'https://mastodon.local/users/akirk.png', $details['avatar'] );
+		$this->assertEquals( 'akirk.mastodon.local', $details['suggested-username'] );
+	}
+
+	public function test_feed_details_suggested_username_with_emoji_display_name() {
+		$actor_url = 'https://mastodon.local/users/dcoder';
+		self::$users[ $actor_url ] = array(
+			'id'                => $actor_url,
+			'url'               => $actor_url,
+			'name'              => 'DCoder 🇱🇹❤🇺🇦',
+			'preferredUsername' => 'dcoder',
+			'icon'              => array(
+				'type' => 'Image',
+				'url'  => $actor_url . '.png',
+			),
+		);
+
+		$friends = Friends::get_instance();
+		$friend = new User( $this->friend_id );
+		$feeds = $friend->get_feeds();
+		$feed = array_pop( $feeds );
+		$parser = $friends->feed->get_feed_parser( $feed->get_parser() );
+
+		$details = $parser->update_feed_details(
+			array(
+				'url' => $actor_url,
+			)
+		);
+
+		$this->assertEquals( 'DCoder 🇱🇹❤🇺🇦', $details['title'] );
+		$this->assertEquals( 'dcoder.mastodon.local', $details['suggested-username'] );
+	}
+
+	public function test_feed_details_suggested_username_with_cyrillic_display_name() {
+		$actor_url = 'https://mastodon.local/users/roskomsvoboda';
+		self::$users[ $actor_url ] = array(
+			'id'                => $actor_url,
+			'url'               => $actor_url,
+			'name'              => 'РосКомСвобода',
+			'preferredUsername' => 'roskomsvoboda',
+			'icon'              => array(
+				'type' => 'Image',
+				'url'  => $actor_url . '.png',
+			),
+		);
+
+		$friends = Friends::get_instance();
+		$friend = new User( $this->friend_id );
+		$feeds = $friend->get_feeds();
+		$feed = array_pop( $feeds );
+		$parser = $friends->feed->get_feed_parser( $feed->get_parser() );
+
+		$details = $parser->update_feed_details(
+			array(
+				'url' => $actor_url,
+			)
+		);
+
+		$this->assertEquals( 'РосКомСвобода', $details['title'] );
+		$this->assertEquals( 'roskomsvoboda.mastodon.local', $details['suggested-username'] );
+	}
+
+	public function test_feed_details_suggested_username_with_special_chars_display_name() {
+		$actor_url = 'https://mastodon.local/users/sidler';
+		self::$users[ $actor_url ] = array(
+			'id'                => $actor_url,
+			'url'               => $actor_url,
+			'name'              => 'D:\\side\\>:idle:',
+			'preferredUsername' => 'sidler',
+			'icon'              => array(
+				'type' => 'Image',
+				'url'  => $actor_url . '.png',
+			),
+		);
+
+		$friends = Friends::get_instance();
+		$friend = new User( $this->friend_id );
+		$feeds = $friend->get_feeds();
+		$feed = array_pop( $feeds );
+		$parser = $friends->feed->get_feed_parser( $feed->get_parser() );
+
+		$details = $parser->update_feed_details(
+			array(
+				'url' => $actor_url,
+			)
+		);
+
+		$this->assertEquals( 'sidler.mastodon.local', $details['suggested-username'] );
 	}
 
 	/**

--- a/tests/test-friend-user.php
+++ b/tests/test-friend-user.php
@@ -6,3 +6,115 @@
  */
 
 namespace Friends;
+
+class UserTest extends \WP_UnitTestCase {
+
+	public function test_sanitize_username_ascii() {
+		$this->assertEquals( 'alex-kirk', User::sanitize_username( 'Alex Kirk' ) );
+	}
+
+	public function test_sanitize_username_with_accents() {
+		$this->assertEquals( 'rene', User::sanitize_username( 'René' ) );
+	}
+
+	public function test_sanitize_username_with_emojis() {
+		$result = User::sanitize_username( 'DCoder 🇱🇹❤🇺🇦' );
+		$this->assertNotEmpty( $result );
+		$this->assertNotEquals( '-', trim( $result, '-' ) === '' ? '-' : $result );
+		$this->assertStringContainsString( 'dcoder', $result );
+	}
+
+	public function test_sanitize_username_pure_cyrillic() {
+		$result = User::sanitize_username( 'РосКомСвобода' );
+		// Pure Cyrillic produces empty/unusable result.
+		$this->assertTrue( '' === $result || '' === trim( $result, '-' ) );
+	}
+
+	public function test_sanitize_username_special_chars() {
+		$result = User::sanitize_username( 'D:\\side\\>:idle:' );
+		$this->assertNotEmpty( trim( $result, '-' ) );
+	}
+
+	public function test_get_user_login_from_feeds_with_suggested_username() {
+		$feeds = array(
+			'https://example.com/feed' => array(
+				'rel'                => 'self',
+				'title'              => 'Some Title',
+				'suggested-username' => 'dcoder.mastodon.social',
+			),
+		);
+		$this->assertEquals( 'dcoder.mastodon.social', User::get_user_login_from_feeds( $feeds ) );
+	}
+
+	public function test_get_user_login_from_feeds_cyrillic_display_name_no_suggested_username() {
+		$feeds = array(
+			'https://example.com/feed' => array(
+				'rel'   => 'self',
+				'title' => 'РосКомСвобода',
+			),
+		);
+		$result = User::get_user_login_from_feeds( $feeds );
+		// Without a suggested-username, it falls back to sanitize_username on
+		// the display name which produces an empty result for pure Cyrillic.
+		$this->assertTrue( ! $result || '' === trim( $result, '-' ) );
+	}
+
+	public function test_activitypub_suggested_username_uses_preferred_username() {
+		// Simulate what update_feed_details does with our fix.
+		$meta = array(
+			'name'              => 'DCoder 🇱🇹❤🇺🇦',
+			'preferredUsername' => 'dcoder',
+		);
+		$feed_url = 'https://mastodon.social/users/dcoder';
+
+		$feed_details = array( 'url' => $feed_url );
+		if ( ! empty( $meta['preferredUsername'] ) ) {
+			$host = wp_parse_url( $feed_details['url'], PHP_URL_HOST );
+			$feed_details['suggested-username'] = User::sanitize_username( $meta['preferredUsername'] . '.' . $host );
+		}
+
+		$this->assertEquals( 'dcoder.mastodon.social', $feed_details['suggested-username'] );
+
+		$feeds = array( $feed_url => $feed_details );
+		$this->assertEquals( 'dcoder.mastodon.social', User::get_user_login_from_feeds( $feeds ) );
+	}
+
+	public function test_activitypub_suggested_username_cyrillic_name_with_preferred_username() {
+		$meta = array(
+			'name'              => 'РосКомСвобода',
+			'preferredUsername' => 'roskomsvoboda',
+		);
+		$feed_url = 'https://mastodon.social/users/roskomsvoboda';
+
+		$feed_details = array( 'url' => $feed_url );
+		if ( ! empty( $meta['preferredUsername'] ) ) {
+			$host = wp_parse_url( $feed_details['url'], PHP_URL_HOST );
+			$feed_details['suggested-username'] = User::sanitize_username( $meta['preferredUsername'] . '.' . $host );
+		}
+
+		$this->assertEquals( 'roskomsvoboda.mastodon.social', $feed_details['suggested-username'] );
+	}
+
+	public function test_activitypub_no_preferred_username_no_suggested_username() {
+		// If preferredUsername is missing, no suggested-username should be set.
+		$meta = array(
+			'name' => 'РосКомСвобода',
+		);
+		$feed_url = 'https://mastodon.social/users/roskomsvoboda';
+
+		$feed_details = array( 'url' => $feed_url );
+		if ( ! empty( $meta['preferredUsername'] ) ) {
+			$host = wp_parse_url( $feed_details['url'], PHP_URL_HOST );
+			$feed_details['suggested-username'] = User::sanitize_username( $meta['preferredUsername'] . '.' . $host );
+		}
+
+		$this->assertArrayNotHasKey( 'suggested-username', $feed_details );
+	}
+
+	public function test_get_user_login_for_url_always_produces_usable_result() {
+		// URL-based fallback should always work since URLs are ASCII.
+		$result = User::get_user_login_for_url( 'https://mastodon.social/@roskomsvoboda' );
+		$this->assertNotEmpty( $result );
+		$this->assertNotEmpty( trim( $result, '-' ) );
+	}
+}


### PR DESCRIPTION
## Summary

- Fixed `update_feed_details()` using the ActivityPub `name` (display name) for `suggested-username` instead of `preferredUsername` (the actual handle)
- Display names with emojis (`DCoder 🇱🇹❤🇺🇦`), Cyrillic (`РосКомСвобода`), or special characters (`D:\side\>:idle:`) would get stripped by `sanitize_username()`, producing empty or unusable WordPress usernames
- `preferredUsername` is always ASCII-safe on Mastodon/Fediverse, so it produces clean usernames like `dcoder.mastodon.social`
- If `preferredUsername` is not available, no `suggested-username` is set, falling back to the URL-based username which is always ASCII-safe

## Test plan

- [x] Added tests in `test-activitypub.php` that call `update_feed_details()` with emoji, Cyrillic, and special character display names and verify `suggested-username` is derived from `preferredUsername`
- [x] Added unit tests in `test-friend-user.php` for `sanitize_username()` edge cases
- [ ] Manually test adding a Mastodon user with a non-ASCII display name

## Testing

https://playground.wordpress.net/#{%22steps%22:[{%22step%22:%22installPlugin%22,%22pluginData%22:{%22resource%22:%22git:directory%22,%22url%22:%22https://github.com/akirk/friends%22,%22ref%22:%22fix-cyrillic-username-handling%22,%22refType%22:%22branch%22},%22options%22:{%22activate%22:true}}]}