### PR TITLE
Fix performance regression from ActivityPub reply-exclusion filter

### DIFF
--- a/.github/changelog/unreleased/fix-remove-activitypub-reply-filter-performance
+++ b/.github/changelog/unreleased/fix-remove-activitypub-reply-filter-performance
@@ -1,0 +1,3 @@
+Type: fixed
+
+Remove ActivityPub reply-exclusion filter that causes a full table scan on the friends page query.

--- a/includes/class-frontend.php
+++ b/includes/class-frontend.php
@@ -2194,6 +2194,14 @@ class Frontend {
 
 		$this->is_friends_page = true;
 		$query->is_friends_page = true;
+
+		// Remove the ActivityPub reply-exclusion filter which does a NOT LIKE on post_content,
+		// causing a full table scan. Friends posts don't use the activitypub/reply block.
+		if ( class_exists( '\Activitypub\Blocks' ) ) {
+			remove_filter( 'posts_where', array( \Activitypub\Blocks::class, 'exclude_replies_where' ) );
+			remove_action( 'pre_get_posts', array( \Activitypub\Blocks::class, 'filter_query_loop_vars' ) );
+		}
+
 		$query->is_singular = false;
 		$query->is_single = false;
 		$query->is_category = false;


### PR DESCRIPTION
## Summary

- The ActivityPub plugin's `Blocks::filter_query_loop_vars()` (added in Automattic/wordpress-activitypub@b5af5618, PR Automattic/wordpress-activitypub#3036) hooks into `pre_get_posts` on all main non-singular queries and adds a `NOT LIKE '%<!-- wp:activitypub/reply%'` WHERE clause on `post_content`
- This causes a **full table scan** on every friends page load, adding ~4.7s to TTFB (6s → 1.4s after fix)
- Friends posts (`friend_post_cache`) don't use the `activitypub/reply` block, so the filter is unnecessary for the friends query
- Fix: remove the filter when setting up the friends page query

## Test plan

- [ ] Load `/friends/` and verify TTFB is under 2s (was ~6s before fix)
- [ ] Verify post content displays correctly (no missing posts)

<details><summary>Changelog</summary>

- [x] Automatically create a changelog entry from the details below

#### Type
- [x] Fixed

#### Message
Remove ActivityPub reply-exclusion filter that causes a full table scan on the friends page query.

</details>