### PR TITLE
Add collapsible mobile panel for compose and search in Mastodon theme

### DIFF
--- a/.github/changelog/unreleased/650-from-description
+++ b/.github/changelog/unreleased/650-from-description
@@ -1,0 +1,3 @@
+Type: added
+
+Add collapsible mobile panel for compose and search in Mastodon theme.

--- a/templates/mastodon/frontend/footer.php
+++ b/templates/mastodon/frontend/footer.php
@@ -16,16 +16,6 @@
 				<h2><?php esc_html_e( 'Friends', 'friends' ); ?></h2>
 			</a>
 		</div>
-		<form class="mastodon-sidebar-search form-autocomplete" action="<?php echo esc_url( home_url( '/friends/' ) ); ?>">
-			<div class="form-autocomplete-input mastodon-search-wrap">
-					<?php
-					$_sidebar_search = isset( $_GET['s'] ) ? sanitize_text_field( wp_unslash( $_GET['s'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-					?>
-				<input class="mastodon-search-input master-search" type="text" name="s" placeholder="<?php /* phpcs:ignore WordPress.WP.I18n.MissingArgDomain */ esc_attr_e( 'Search or paste URL' ); ?>" value="<?php echo esc_attr( $_sidebar_search ); ?>" autocomplete="off" data-nonce="<?php echo esc_attr( wp_create_nonce( 'friends-autocomplete' ) ); ?>" />
-				<i class="form-icon"></i>
-			</div>
-			<ul class="menu" style="display: none"></ul>
-		</form>
 		<nav class="mastodon-right-nav">
 			<?php dynamic_sidebar( 'friends-sidebar' ); ?>
 		</nav>

--- a/templates/mastodon/frontend/header.php
+++ b/templates/mastodon/frontend/header.php
@@ -65,6 +65,32 @@ $mastodon_current_user = wp_get_current_user();
 
 	<!-- Center column: timeline (left open, footer closes it) -->
 	<div class="mastodon-center-col">
+		<details class="mastodon-mobile-panel">
+			<summary class="mastodon-mobile-panel-toggle">
+				<?php echo get_avatar( $mastodon_current_user->ID, 32, '', '', array( 'class' => 'mastodon-avatar' ) ); ?>
+				<span><?php echo esc_html( $mastodon_current_user->display_name ); ?></span>
+				<i class="dashicons dashicons-arrow-down-alt2"></i>
+			</summary>
+			<div class="mastodon-mobile-panel-content">
+				<form method="post" action="<?php echo esc_url( admin_url( 'admin-ajax.php' ) ); ?>" class="mastodon-compose-form friends-post-inline">
+					<?php wp_nonce_field( 'friends_publish' ); ?>
+					<input type="hidden" name="action" value="friends_publish" />
+					<input type="hidden" name="format" value="<?php echo esc_attr( get_option( 'friends_compose_post_format', 'status' ) ); ?>" />
+					<textarea name="content" rows="3" placeholder="<?php echo esc_attr( sprintf( /* translators: %s is the user's display name */ __( "What's on your mind, %s?", 'friends' ), $mastodon_current_user->display_name ) ); ?>"></textarea>
+					<div class="mastodon-compose-footer">
+						<a href="<?php echo esc_url( admin_url( 'admin.php?page=friends-settings#compose' ) ); ?>" class="mastodon-compose-settings" title="<?php esc_attr_e( 'Compose settings', 'friends' ); ?>"><span class="dashicons dashicons-admin-generic"></span></a>
+						<button type="submit" class="mastodon-compose-submit"><?php esc_html_e( 'Post', 'friends' ); ?></button>
+					</div>
+				</form>
+				<form class="mastodon-search-form form-autocomplete" action="<?php echo esc_url( home_url( '/friends/' ) ); ?>">
+					<div class="form-autocomplete-input mastodon-search-wrap">
+						<input class="mastodon-search-input master-search" type="text" name="s" placeholder="<?php /* phpcs:ignore WordPress.WP.I18n.MissingArgDomain */ esc_attr_e( 'Search or paste URL' ); ?>" value="<?php echo esc_attr( $_search ); ?>" autocomplete="off" data-nonce="<?php echo esc_attr( wp_create_nonce( 'friends-autocomplete' ) ); ?>" />
+						<i class="form-icon"></i>
+					</div>
+					<ul class="menu" style="display: none"></ul>
+				</form>
+			</div>
+		</details>
 		<div class="mastodon-col-header<?php echo is_single() ? ' is-single' : ''; ?>">
 			<div class="mastodon-col-title-row">
 				<?php

--- a/templates/mastodon/mastodon.css
+++ b/templates/mastodon/mastodon.css
@@ -92,17 +92,62 @@ body.friends-page {
 /* Mobile overlay */
 .mastodon-overlay { display: none; }
 
-/* Search inside right sidebar (shown when left col is hidden) */
-.mastodon-sidebar-search {
+/* Mobile panel: collapsible compose + search (replaces left col on small screens) */
+.mastodon-mobile-panel {
 	display: none;
-	padding: 16px 16px 8px;
+	border-bottom: 1px solid light-dark(#d4dde8, #393f4f);
+}
+
+.mastodon-mobile-panel-toggle {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 10px 16px;
+	cursor: pointer;
+	color: light-dark(#282c37, #dadada);
+	font-weight: 600;
+	font-size: 14px;
+	list-style: none;
+}
+
+.mastodon-mobile-panel-toggle::-webkit-details-marker { display: none; }
+.mastodon-mobile-panel-toggle::marker { display: none; content: ""; }
+
+.mastodon-mobile-panel-toggle img {
+	width: 32px;
+	height: 32px;
+	border-radius: 4px;
+}
+
+.mastodon-mobile-panel-toggle span {
+	flex: 1;
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.mastodon-mobile-panel-toggle .dashicons {
+	font-size: 18px;
+	width: 18px;
+	height: 18px;
+	transition: transform .2s;
+	color: light-dark(#606984, #9baec8);
+}
+
+.mastodon-mobile-panel[open] > .mastodon-mobile-panel-toggle .dashicons {
+	transform: rotate(180deg);
+}
+
+.mastodon-mobile-panel-content {
+	padding: 0 16px 12px;
 }
 
 @media (max-width: 1100px) {
 	.mastodon-left-col {
 		display: none;
 	}
-	.mastodon-sidebar-search {
+	.mastodon-mobile-panel {
 		display: block;
 	}
 }


### PR DESCRIPTION
## Summary
- Replace the duplicate search in the right sidebar with a collapsible `<details>` panel at the top of the center column on screens <=1100px
- The panel shows the user's avatar and name; tapping expands to reveal compose box and search
- Uses pure HTML `<details>`/`<summary>` — no JavaScript required

<details><summary>Changelog</summary>

- [x] Automatically create a changelog entry from the details below

#### Type
- [x] Added

#### Message
Add collapsible mobile panel for compose and search in Mastodon theme.

</details>