### PR TITLE
Mastodon theme: fix search, add cmd-k, style messages

### DIFF
--- a/.github/changelog/unreleased/651-from-description
+++ b/.github/changelog/unreleased/651-from-description
@@ -1,0 +1,3 @@
+Type: fixed
+
+Fix Mastodon theme search autocomplete styling and prevent User_Query from returning non-subscription WordPress users.

--- a/includes/class-user-query.php
+++ b/includes/class-user-query.php
@@ -167,7 +167,7 @@ class User_Query extends \WP_User_Query {
 				'order'   => 'ASC',
 				'orderby' => 'display_name',
 			);
-			$starred_friends_subscriptions[ $cache_key ] = new self( array( 'number' => 0 ) );
+			$starred_friends_subscriptions[ $cache_key ] = new self( array( 'include' => array( 0 ) ) );
 			$starred_friends_subscriptions[ $cache_key ]->add_virtual_subscriptions( $meta );
 			$starred_friends_subscriptions[ $cache_key ]->sort( $sort['orderby'], $sort['order'] );
 		}
@@ -266,7 +266,7 @@ class User_Query extends \WP_User_Query {
 			'order'   => 'ASC',
 			'orderby' => 'display_name',
 		);
-		$search = new self( array( 'number' => 0 ) );
+		$search = new self( array( 'include' => array( 0 ) ) );
 		$search->add_virtual_subscriptions( $query );
 		$search->sort( $sort['orderby'], $sort['order'] );
 		return $search;
@@ -282,7 +282,7 @@ class User_Query extends \WP_User_Query {
 				'order'   => 'ASC',
 				'orderby' => 'display_name',
 			);
-			$all_subscriptions[ get_current_blog_id() ] = new self( array( 'number' => 0 ) );
+			$all_subscriptions[ get_current_blog_id() ] = new self( array( 'include' => array( 0 ) ) );
 			$all_subscriptions[ get_current_blog_id() ]->add_virtual_subscriptions();
 			$all_subscriptions[ get_current_blog_id() ]->sort( $sort['orderby'], $sort['order'] );
 		}

--- a/templates/mastodon/mastodon.css
+++ b/templates/mastodon/mastodon.css
@@ -362,6 +362,16 @@ body.friends-page {
 	align-items: center;
 }
 
+.mastodon-search-wrap .form-icon {
+	position: absolute;
+	right: 10px;
+	top: 50%;
+	transform: translateY(-50%);
+	width: .8rem;
+	height: .8rem;
+	pointer-events: none;
+}
+
 .mastodon-search-input {
 	width: 100%;
 	background: light-dark(#eaedf1, #313543);
@@ -1065,9 +1075,56 @@ body.friends-page {
 	border: 1px solid light-dark(#d4dde8, #393f4f);
 	border-radius: 8px;
 	z-index: 100;
-	max-height: 300px;
-	overflow-y: auto;
 	box-shadow: 0 8px 24px rgba(0,0,0,.2);
+	overflow: hidden;
+	padding: 0;
+}
+
+.friends-page .form-autocomplete .menu .menu-item {
+	padding: 0;
+	margin: 0;
+}
+
+.friends-page .form-autocomplete .menu .menu-item + .menu-item {
+	margin-top: 0;
+}
+
+.friends-page .form-autocomplete .menu .menu-item > a {
+	display: block !important;
+	white-space: normal;
+	margin: 0;
+	padding: 8px 12px;
+	border-radius: 0;
+	color: light-dark(#282c37, #dadada);
+	font-size: 14px;
+	font-weight: normal;
+	line-height: 1.4;
+}
+
+.friends-page .form-autocomplete .menu .menu-item > a:hover,
+.friends-page .form-autocomplete .menu .menu-item > a:focus,
+.friends-page .form-autocomplete .menu .menu-item > a:active {
+	background: light-dark(rgba(86,58,204,.06), rgba(99,100,255,.1));
+	color: light-dark(#282c37, #dadada);
+	outline: none;
+}
+
+.friends-page .form-autocomplete .menu .menu-item > a > .ab-icon {
+	margin-right: 6px;
+	vertical-align: middle;
+}
+
+.friends-page .form-autocomplete .menu .menu-item > a small {
+	margin-left: .3em;
+	color: light-dark(#606984, #9baec8);
+}
+
+.friends-page .form-autocomplete .menu .menu-item > a mark {
+	background: light-dark(rgba(86,58,204,.15), rgba(99,100,255,.25));
+	color: inherit;
+	border: none;
+	border-radius: 2px;
+	padding: 0 1px;
 }
 
 /* === Dropdown Menus === */
@@ -1186,6 +1243,146 @@ body.friends-page {
 
 .friends-page #friends-send-new-message {
 	padding: 16px !important;
+}
+
+/* Mastodon theme: messages */
+.friends-page .card.mt-2.p-2:has(.friend-message) {
+	background: transparent;
+	border: none;
+	box-shadow: none;
+	padding: 0 !important;
+	margin: 0;
+}
+
+.friends-page .card.mt-2.p-2:has(.friend-message) > strong {
+	display: block;
+	padding: 12px 16px;
+	font-size: 15px;
+	color: light-dark(#282c37, #dadada);
+	border-bottom: 1px solid light-dark(#d4dde8, #393f4f);
+}
+
+.friends-page .friend-message {
+	border-bottom: 1px solid light-dark(#d4dde8, #393f4f);
+}
+
+.friends-page a.display-message {
+	display: block;
+	padding: 12px 16px;
+	color: light-dark(#282c37, #dadada);
+	font-size: 14px;
+	transition: background .15s;
+}
+
+.friends-page a.display-message:hover {
+	background: light-dark(#f2f5f7, #313543);
+	text-decoration: none;
+}
+
+.friends-page a.display-message.unread {
+	font-weight: 700;
+	border-left: 3px solid light-dark(#563acc, #6364ff);
+	padding-left: 13px;
+}
+
+.friends-page .friend-message .conversation {
+	background: light-dark(#f2f5f7, #1e2028);
+	border-top: 1px solid light-dark(#d4dde8, #393f4f);
+}
+
+.friends-page .friend-message .conversation .messages {
+	max-height: 50vh;
+	overflow-y: auto;
+	padding: 8px 0;
+}
+
+.friends-page .friend-message .conversation .message {
+	padding: 10px 16px;
+	font-size: 14px;
+	color: light-dark(#606984, #9baec8);
+}
+
+.friends-page .friend-message .conversation .message .author {
+	font-weight: 600;
+	color: light-dark(#282c37, #dadada);
+}
+
+.friends-page .friend-message .conversation .message .time {
+	font-size: 12px;
+}
+
+.friends-page .friend-message .conversation .message blockquote {
+	margin: 6px 0 0;
+	padding: 10px 14px;
+	background: light-dark(#fff, #282c37);
+	border-radius: 8px;
+	border: 1px solid light-dark(#d4dde8, #393f4f);
+	border-left: none;
+	color: light-dark(#282c37, #dadada);
+	font-size: 15px;
+}
+
+.friends-page .friend-message .conversation .message blockquote p:last-child {
+	margin-bottom: 0;
+}
+
+.friends-page .friend-message .conversation .form-horizontal {
+	padding: 12px 16px;
+	border-top: 1px solid light-dark(#d4dde8, #393f4f);
+}
+
+.friends-page .friend-message .conversation .form-horizontal .form-input {
+	background: light-dark(#fff, #282c37);
+	border: 1px solid light-dark(#d4dde8, #393f4f);
+	border-radius: 8px;
+	padding: 8px 12px;
+	font-size: 14px;
+	font-family: inherit;
+	color: light-dark(#282c37, #dadada);
+	width: 100%;
+}
+
+.friends-page .friend-message .conversation .form-horizontal .form-input:focus {
+	border-color: light-dark(#563acc, #6364ff);
+	outline: none;
+}
+
+.friends-page .friend-message .conversation .form-horizontal textarea.form-input {
+	min-height: 60px;
+	resize: vertical;
+}
+
+.friends-page .friend-message .conversation .form-horizontal .btn {
+	background: light-dark(#563acc, #6364ff);
+	color: #fff;
+	border: none;
+	border-radius: 100px;
+	padding: 6px 18px;
+	font-size: 14px;
+	font-weight: 600;
+	cursor: pointer;
+	font-family: inherit;
+}
+
+.friends-page .friend-message .conversation .form-horizontal .btn:hover {
+	background: light-dark(#4a30b0, #7475ff);
+}
+
+.friends-page .friend-message .conversation .form-horizontal .btn.delete-conversation {
+	background: transparent;
+	color: light-dark(#df405a, #e87c8e);
+	font-size: 12px;
+	padding: 4px 8px;
+}
+
+.friends-page .friend-message .conversation .form-horizontal .form-group {
+	margin-bottom: 8px;
+}
+
+.friends-page .friend-message .conversation .form-horizontal .form-label {
+	font-size: 13px;
+	color: light-dark(#606984, #9baec8);
+	font-weight: 600;
 }
 
 /* Mastodon theme: header image as banner on the title row */

--- a/templates/mastodon/mastodon.js
+++ b/templates/mastodon/mastodon.js
@@ -9,6 +9,7 @@
  *   o/enter       - Toggle open/close current item
  *   s             - Toggle star reaction
  *   v             - Open original in new tab
+ *   cmd-k/ctrl-k  - Focus search
  *   ?             - Show keyboard shortcuts help
  */
 ( function( $ ) {
@@ -158,6 +159,19 @@
 
 	// Keyboard shortcuts.
 	$( document ).on( 'keydown', function( e ) {
+		// cmd-k / ctrl-k: focus search input (works in any context).
+		if ( ( e.metaKey || e.ctrlKey ) && 75 === e.keyCode ) {
+			e.preventDefault();
+			$( '.mastodon-search-input' ).first().focus();
+			return false;
+		}
+
+		// Escape: blur search input.
+		if ( 27 === e.keyCode && $( e.target ).is( '.mastodon-search-input' ) ) {
+			$( e.target ).blur();
+			return false;
+		}
+
 		if ( $( e.target ).is( 'input, textarea, select, [contenteditable]' ) ) {
 			return;
 		}
@@ -262,6 +276,7 @@
 						'<tr><td style="padding:2px 12px 2px 0"><b>o / enter</b></td><td>Open / close item</td></tr>' +
 						'<tr><td style="padding:2px 12px 2px 0"><b>s</b></td><td>Toggle \u2b50 reaction</td></tr>' +
 						'<tr><td style="padding:2px 12px 2px 0"><b>v</b></td><td>Open original in new tab</td></tr>' +
+						'<tr><td style="padding:2px 12px 2px 0"><b>\u2318K / Ctrl-K</b></td><td>Search</td></tr>' +
 						'<tr><td style="padding:2px 12px 2px 0"><b>?</b></td><td>Show this help</td></tr>' +
 						'</table>' +
 						'<p style="margin:12px 0 0;color:light-dark(#606984,#4a4e69);font-size:11px">Press any key to close</p>' +


### PR DESCRIPTION
## Summary
- **Fix search returning all WP users**: `User_Query::search()`, `all_subscriptions()`, and `starred_friends_subscriptions()` were using `new self(array('number' => 0))` which ran a `WP_User_Query` with no role filter, returning all WordPress users alongside virtual subscriptions. Changed to `array('include' => array(0))` to suppress the parent query.
- **Add cmd-k/ctrl-k shortcut** to focus the search input in the Mastodon theme, matching the main theme behavior. Escape blurs it. Added to the `?` help overlay.
- **Fix search autocomplete styling**: Override spectre CSS `display: flex` and `gap: 10px` on `.menu-item a` that broke inline `<mark>` highlighting (text appeared spaced out). Fix hover/focus artifacts from spectre's padding/margin/background rules. Fix search input resizing during loading spinner.
- **Style messages for Mastodon theme**: Conversation list, message bubbles, reply form, and unread indicators now match the Mastodon visual language.

<details><summary>Changelog</summary>

- [x] Automatically create a changelog entry from the details below

#### Type
- [x] Fixed

#### Message
Fix Mastodon theme search autocomplete styling and prevent User_Query from returning non-subscription WordPress users.

</details>

## Test plan
- [ ] Search for a subscription in the Mastodon theme — only subscriptions should appear, no admin users
- [ ] Press cmd-k (Mac) or ctrl-k — search input should focus
- [ ] Press Escape while search is focused — should blur
- [ ] Type a query — autocomplete results should show names with highlighted matches inline (no extra spacing)
- [ ] Arrow-down through results — focus highlight should be subtle purple, no blue outlines
- [ ] Search input should not resize while loading spinner is active
- [ ] Visit a friend's page with messages — messages should be styled in the Mastodon theme