### PR TITLE
Fix ActivityPub replies to local comments not threading

### DIFF
--- a/.github/changelog/unreleased/654-from-description
+++ b/.github/changelog/unreleased/654-from-description
@@ -1,0 +1,3 @@
+Type: fixed
+
+Fix ActivityPub replies to local comments not arriving as threaded comments

--- a/.github/changelog/unreleased/fix-activitypub-threaded-comment-replies
+++ b/.github/changelog/unreleased/fix-activitypub-threaded-comment-replies
@@ -1,0 +1,3 @@
+Type: fixed
+
+Fix ActivityPub replies to local comments not arriving as threaded comments

--- a/feed-parsers/class-feed-parser-activitypub.php
+++ b/feed-parsers/class-feed-parser-activitypub.php
@@ -86,6 +86,9 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 		\add_action( 'mastodon_api_unreact', array( $this, 'mastodon_api_unreact' ), 10, 2 );
 		\add_action( 'friends_get_reaction_display_name', array( $this, 'get_reaction_display_name' ), 10, 2 );
 
+		\add_filter( 'url_to_postid', array( $this, 'fix_comment_url_to_postid' ) );
+		\add_filter( 'activitypub_is_post_disabled', array( $this, 'allow_comments_on_friends_posts' ), 10, 2 );
+		\add_filter( 'comment_reply_link', array( $this, 'fix_comment_reply_link' ), 10, 4 );
 		\add_filter( 'pre_comment_approved', array( $this, 'pre_comment_approved' ), 10, 2 );
 		\add_action( 'comment_post', array( $this, 'comment_post' ), 10, 3 );
 		\add_action( 'trashed_comment', array( $this, 'trashed_comment' ), 10, 2 );
@@ -2137,6 +2140,13 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 			if ( $reply_to_post_id ) {
 				// This is a reply to an existing Friends post - skip processing and let ActivityPub handle it as a comment.
 				return false;
+			}
+			// Check if this is a reply to a local comment (e.g. ?c=123 URLs).
+			if ( function_exists( '\Activitypub\url_to_commentid' ) ) {
+				$comment_id = \Activitypub\url_to_commentid( $in_reply_to );
+				if ( $comment_id ) {
+					return false;
+				}
 			}
 		}
 
@@ -4210,6 +4220,67 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 	}
 
 	/**
+	 * Prevent comment URLs (?c=NNN) from resolving to the front page via url_to_postid().
+	 *
+	 * WordPress core's url_to_postid() strips query strings and matches the bare domain
+	 * to the static front page. This causes ActivityPub replies to comments to be attached
+	 * to the wrong post.
+	 *
+	 * @param string $url The URL to derive the post ID from.
+	 * @return string The URL, or empty string for comment URLs.
+	 */
+	public function fix_comment_url_to_postid( $url ) {
+		if ( preg_match( '#[?&]c=\d+#', $url ) ) {
+			return '';
+		}
+		return $url;
+	}
+
+	/**
+	 * Allow ActivityPub comments on friend_post_cache posts.
+	 *
+	 * The ActivityPub plugin's persist() rejects comments on post types that don't
+	 * support ActivityPub. Since friend_post_cache posts aggregate content from
+	 * ActivityPub sources, comments should be allowed.
+	 *
+	 * @param bool     $disabled Whether the post is disabled for ActivityPub.
+	 * @param \WP_Post $post     The post object.
+	 * @return bool Whether the post is disabled.
+	 */
+	public function allow_comments_on_friends_posts( $disabled, $post ) {
+		if ( Friends::CPT === $post->post_type ) {
+			return false;
+		}
+		return $disabled;
+	}
+
+	/**
+	 * Fix comment reply links on friend_post_cache posts to use the local Friends URL.
+	 *
+	 * WordPress core's get_comment_reply_link() uses get_permalink() which returns
+	 * the external URL for friend_post_cache posts.
+	 *
+	 * @param string      $link    The HTML markup for the comment reply link.
+	 * @param array       $args    The arguments.
+	 * @param \WP_Comment $comment The comment object.
+	 * @param \WP_Post    $post    The post object.
+	 * @return string The fixed HTML markup.
+	 */
+	public function fix_comment_reply_link( $link, $args, $comment, $post ) {
+		if ( Friends::CPT !== $post->post_type ) {
+			return $link;
+		}
+
+		$friend_user = User::get_post_author( $post );
+		if ( ! $friend_user ) {
+			return $link;
+		}
+
+		$local_url = $friend_user->get_local_friends_page_url( $post->ID );
+		return str_replace( get_permalink( $post->ID ), $local_url, $link );
+	}
+
+	/**
 	 * Approve incoming fediverse comments.
 	 *
 	 * @param      bool  $approved     Whether the comment is approved.
@@ -4289,12 +4360,12 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 	 * @return     array  The comments.
 	 */
 	public function get_remote_comments( $comments, $post_id, ?User $friend_user = null, ?User_Feed $user_feed = null ) {
-		if ( User_Feed::get_parser_for_post_id( $post_id ) !== self::SLUG ) {
+		$post = get_post( $post_id );
+		if ( ! $post || Friends::CPT !== $post->post_type ) {
 			return $comments;
 		}
 
-		$post = get_post( $post_id );
-		if ( Friends::CPT !== $post->post_type ) {
+		if ( ! self::post_supports_activitypub( $post_id ) ) {
 			return $comments;
 		}
 
@@ -4304,7 +4375,30 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 			'descendants' => array(),
 		);
 		$context = apply_filters( 'mastodon_api_status_context', $context, $post_id, $post->guid );
+
+		// Collect existing comment identifiers to avoid duplicates.
+		$existing_ids = array();
+		foreach ( $comments as $comment ) {
+			$existing_ids[ $comment->comment_ID ] = true;
+			$source_id = get_comment_meta( $comment->comment_ID, 'source_id', true );
+			if ( $source_id ) {
+				$existing_ids[ $source_id ] = true;
+			}
+			$source_url = get_comment_meta( $comment->comment_ID, 'source_url', true );
+			if ( $source_url ) {
+				$existing_ids[ $source_url ] = true;
+			}
+		}
+
 		foreach ( $context['descendants'] as $status ) {
+			// Skip if already present as a local comment.
+			if ( isset( $existing_ids[ $status->id ] ) || ( ! empty( $status->uri ) && isset( $existing_ids[ $status->uri ] ) ) ) {
+				continue;
+			}
+			// Check if the URI contains a local comment anchor (e.g. #comment-88153).
+			if ( ! empty( $status->uri ) && preg_match( '/#comment-(\d+)$/', $status->uri, $matches ) && isset( $existing_ids[ $matches[1] ] ) ) {
+				continue;
+			}
 
 			$comments[] = new \WP_Comment(
 				(object) array(
@@ -4319,7 +4413,6 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 					'comment_approved'     => 1,
 					'comment_type'         => 'activitypub',
 					'comment_parent'       => $status->in_reply_to_id,
-
 				)
 			);
 		}
@@ -4481,6 +4574,17 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 	}
 
 	public function append_comment_form( $content, $post_id, ?User $friend_user = null, ?User_Feed $user_feed = null ) {
+		$post = get_post( $post_id );
+
+		// Show a link to view the conversation at the source when the post is on a known AP host.
+		if ( $post && Friends::CPT === $post->post_type && self::post_supports_activitypub( $post_id ) ) {
+			$content .= sprintf(
+				'<p class="friends-fediverse-conversation"><a href="%s" target="_blank" rel="noopener noreferrer">%s</a></p>',
+				esc_url( $post->guid ),
+				esc_html__( 'View the full conversation at the source', 'friends' )
+			);
+		}
+
 		ob_start();
 		self::comment_form( $post_id );
 		$comment_form = ob_get_contents();

--- a/feed-parsers/class-feed-parser-activitypub.php
+++ b/feed-parsers/class-feed-parser-activitypub.php
@@ -54,6 +54,7 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 		\add_action( 'activitypub_inbox_update', array( $this, 'handle_received_update' ), 15, 2 );
 		\add_action( 'activitypub_handled_create', array( $this, 'activitypub_handled_create' ), 10, 4 );
 		\add_action( 'activitypub_interactions_follow_url', array( $this, 'activitypub_interactions_follow_url' ), 10, 2 );
+		\add_action( 'activitypub_handled_inbox_create', array( $this, 'prepare_activitypub_comment_reply' ), 5, 3 );
 		\add_filter( 'activitypub_comment_post_id', array( $this, 'activitypub_comment_post_id' ), 10, 3 );
 		\add_filter( 'activitypub_is_post_disabled', array( $this, 'disable_activitypub_for_cached_posts' ), 10, 2 );
 		\add_filter( 'activitypub_is_post_publicly_queryable', array( $this, 'activitypub_cached_post_publicly_queryable' ), 10, 2 );
@@ -88,6 +89,8 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 		\add_action( 'mastodon_api_unreact', array( $this, 'mastodon_api_unreact' ), 10, 2 );
 		\add_action( 'friends_get_reaction_display_name', array( $this, 'get_reaction_display_name' ), 10, 2 );
 
+		\add_filter( 'url_to_postid', array( $this, 'fix_comment_url_to_postid' ) );
+		\add_filter( 'comment_reply_link', array( $this, 'fix_comment_reply_link' ), 10, 4 );
 		\add_filter( 'pre_comment_approved', array( $this, 'pre_comment_approved' ), 10, 2 );
 		\add_action( 'comment_post', array( $this, 'comment_post' ), 10, 3 );
 		\add_action( 'trashed_comment', array( $this, 'trashed_comment' ), 10, 2 );
@@ -2488,6 +2491,10 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 				// This is a reply to an existing Friends post - skip processing and let ActivityPub handle it as a comment.
 				return false;
 			}
+			if ( function_exists( '\Activitypub\url_to_commentid' ) && \Activitypub\url_to_commentid( $in_reply_to ) ) {
+				// This is a reply to an existing local comment - skip processing and let ActivityPub handle it as a threaded comment.
+				return false;
+			}
 		}
 
 		if ( 'undo' === $type ) {
@@ -3720,6 +3727,32 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 	}
 
 	/**
+	 * Prepare ActivityPub's Create handler to persist a reply to a local comment.
+	 *
+	 * ActivityPub checks is_post_disabled() before inserting interaction comments.
+	 * Cached Friends posts normally stay disabled there to avoid post federation,
+	 * so mark the parent post when the incoming object targets a local comment.
+	 *
+	 * @param array $activity The activity object.
+	 */
+	public function prepare_activitypub_comment_reply( $activity ) {
+		if ( empty( $activity['object']['inReplyTo'] ) || ! function_exists( '\Activitypub\url_to_commentid' ) ) {
+			return;
+		}
+
+		$in_reply_to = $activity['object']['inReplyTo'];
+		if ( is_array( $in_reply_to ) ) {
+			$in_reply_to = reset( $in_reply_to );
+		}
+
+		$comment_id = \Activitypub\url_to_commentid( $in_reply_to );
+		$comment = $comment_id ? get_comment( $comment_id ) : null;
+		if ( $comment ) {
+			wp_cache_set( 'activitypub_comment_reply_post_' . $comment->comment_post_ID, true, 'friends' );
+		}
+	}
+
+	/**
 	 * Prevent the ActivityPub plugin from federating cached friend posts.
 	 *
 	 * Cached posts are remote content stored locally; they must never be
@@ -3735,9 +3768,67 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 	 */
 	public function disable_activitypub_for_cached_posts( $disabled, $post ) {
 		if ( $post instanceof \WP_Post && Friends::CPT === $post->post_type ) {
+			$cache_key = 'activitypub_comment_reply_post_' . $post->ID;
+			if (
+				doing_action( 'activitypub_handled_inbox_create' ) &&
+				wp_cache_get( $cache_key, 'friends' ) &&
+				self::post_supports_activitypub( $post->ID )
+			) {
+				return false;
+			}
 			return true;
 		}
 		return $disabled;
+	}
+
+	/**
+	 * Prevent comment URLs (?c=NNN) from resolving to the front page via url_to_postid().
+	 *
+	 * WordPress core strips query strings in url_to_postid(). For local comment URLs,
+	 * that can resolve to the site's front page before ActivityPub falls back to
+	 * url_to_commentid(), which breaks threaded replies.
+	 *
+	 * @param string $url The URL to derive the post ID from.
+	 * @return string The URL, or empty string for comment URLs.
+	 */
+	public function fix_comment_url_to_postid( $url ) {
+		if ( preg_match( '#[?&]c=\d+#', $url ) ) {
+			if ( function_exists( '\Activitypub\url_to_commentid' ) ) {
+				$comment_id = \Activitypub\url_to_commentid( $url );
+				$comment = $comment_id ? get_comment( $comment_id ) : null;
+				if ( $comment ) {
+					wp_cache_set( 'activitypub_comment_reply_post_' . $comment->comment_post_ID, true, 'friends' );
+				}
+			}
+			return '';
+		}
+
+		return $url;
+	}
+
+	/**
+	 * Fix comment reply links on friend_post_cache posts to use the local Friends URL.
+	 *
+	 * WordPress core's get_comment_reply_link() uses get_permalink(), which returns
+	 * the external source URL for cached Friends posts.
+	 *
+	 * @param string      $link    The HTML markup for the comment reply link.
+	 * @param array       $args    The arguments.
+	 * @param \WP_Comment $comment The comment object.
+	 * @param \WP_Post    $post    The post object.
+	 * @return string The fixed HTML markup.
+	 */
+	public function fix_comment_reply_link( $link, $args, $comment, $post ) {
+		if ( ! $post instanceof \WP_Post || Friends::CPT !== $post->post_type ) {
+			return $link;
+		}
+
+		$friend_user = User::get_post_author( $post );
+		if ( ! $friend_user ) {
+			return $link;
+		}
+
+		return str_replace( get_permalink( $post->ID ), $friend_user->get_local_friends_page_url( $post->ID ), $link );
 	}
 
 	/**
@@ -4695,12 +4786,12 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 	 * @return     array  The comments.
 	 */
 	public function get_remote_comments( $comments, $post_id, ?User $friend_user = null, ?User_Feed $user_feed = null ) {
-		if ( User_Feed::get_parser_for_post_id( $post_id ) !== self::SLUG ) {
+		$post = get_post( $post_id );
+		if ( ! $post || Friends::CPT !== $post->post_type ) {
 			return $comments;
 		}
 
-		$post = get_post( $post_id );
-		if ( Friends::CPT !== $post->post_type ) {
+		if ( ! self::post_supports_activitypub( $post_id ) ) {
 			return $comments;
 		}
 
@@ -4710,7 +4801,30 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 			'descendants' => array(),
 		);
 		$context = apply_filters( 'mastodon_api_status_context', $context, $post_id, $post->guid );
+
+		$existing_ids = array();
+		foreach ( $comments as $comment ) {
+			$existing_ids[ $comment->comment_ID ] = true;
+
+			$source_id = get_comment_meta( $comment->comment_ID, 'source_id', true );
+			if ( $source_id ) {
+				$existing_ids[ $source_id ] = true;
+			}
+
+			$source_url = get_comment_meta( $comment->comment_ID, 'source_url', true );
+			if ( $source_url ) {
+				$existing_ids[ $source_url ] = true;
+			}
+		}
+
 		foreach ( $context['descendants'] as $status ) {
+			if ( isset( $existing_ids[ $status->id ] ) || ( ! empty( $status->uri ) && isset( $existing_ids[ $status->uri ] ) ) ) {
+				continue;
+			}
+
+			if ( ! empty( $status->uri ) && preg_match( '/#comment-(\d+)$/', $status->uri, $matches ) && isset( $existing_ids[ $matches[1] ] ) ) {
+				continue;
+			}
 
 			$comments[] = new \WP_Comment(
 				(object) array(

--- a/tests/test-activitypub.php
+++ b/tests/test-activitypub.php
@@ -1022,6 +1022,219 @@ class ActivityPubTest extends Friends_TestCase_Cache_HTTP {
 		$this->assertSame( $unknown_actor, get_post_meta( $messages[0]->ID, 'friends_feed_url', true ) );
 	}
 
+	public function test_local_comment_urls_do_not_resolve_to_posts() {
+		$parser = Friends::get_instance()->feed->get_feed_parser( Feed_Parser_ActivityPub::SLUG );
+
+		$this->assertSame( '', $parser->fix_comment_url_to_postid( home_url( '/?c=123' ) ) );
+		$this->assertSame( '', $parser->fix_comment_url_to_postid( home_url( '/friends/?foo=bar&c=123' ) ) );
+		$this->assertSame( home_url( '/friends/?post=123' ), $parser->fix_comment_url_to_postid( home_url( '/friends/?post=123' ) ) );
+	}
+
+	public function test_incoming_reply_to_local_comment_is_deferred_to_activitypub_comments() {
+		$post_id = $this->friend->insert_post(
+			array(
+				'post_type'    => Friends::CPT,
+				'post_content' => 'Cached ActivityPub post.',
+				'post_status'  => 'publish',
+				'guid'         => 'https://mastodon.local/users/akirk/statuses/123456',
+				'meta_input'   => array(
+					Feed_Parser_ActivityPub::SLUG => array(
+						'attributedTo' => array(
+							'id' => $this->actor,
+						),
+					),
+				),
+			)
+		);
+		$comment_id = wp_insert_comment(
+			array(
+				'comment_post_ID'  => $post_id,
+				'comment_content'  => 'Local comment.',
+				'comment_type'     => 'comment',
+				'user_id'          => get_current_user_id(),
+				'comment_approved' => 1,
+			)
+		);
+
+		$parser = Friends::get_instance()->feed->get_feed_parser( Feed_Parser_ActivityPub::SLUG );
+		$result = $parser->handle_received_activity(
+			array(
+				'type'   => 'Create',
+				'id'     => $this->actor . '/statuses/reply/activity',
+				'actor'  => $this->actor,
+				'object' => array(
+					'type'         => 'Note',
+					'id'           => $this->actor . '/statuses/reply',
+					'attributedTo' => $this->actor,
+					'inReplyTo'    => home_url( '/?c=' . $comment_id ),
+					'content'      => 'Reply to the local comment.',
+					'url'          => $this->actor . '/statuses/reply',
+					'published'    => gmdate( \DATE_W3C, time() - 10 ),
+				),
+			),
+			get_current_user_id(),
+			'create'
+		);
+
+		$this->assertFalse( $result );
+	}
+
+	public function test_activitypub_can_persist_reply_to_local_comment_on_cached_post() {
+		if ( ! class_exists( '\Activitypub\Handler\Create' ) ) {
+			$this->markTestSkipped( 'The ActivityPub Create handler is not available.' );
+		}
+
+		$post_id = $this->friend->insert_post(
+			array(
+				'post_type'    => Friends::CPT,
+				'post_content' => 'Cached ActivityPub post.',
+				'post_status'  => 'publish',
+				'guid'         => 'https://mastodon.local/users/akirk/statuses/123456',
+				'meta_input'   => array(
+					Feed_Parser_ActivityPub::SLUG => array(
+						'attributedTo' => array(
+							'id' => $this->actor,
+						),
+					),
+				),
+			)
+		);
+		$comment_id = wp_insert_comment(
+			array(
+				'comment_post_ID'  => $post_id,
+				'comment_content'  => 'Local comment.',
+				'comment_type'     => 'comment',
+				'user_id'          => get_current_user_id(),
+				'comment_approved' => 1,
+			)
+		);
+		$reply_id = $this->actor . '/statuses/reply';
+		$this->assertSame( (int) $comment_id, (int) \Activitypub\url_to_commentid( home_url( '/?c=' . $comment_id ) ) );
+
+		$activity = array(
+			'type'   => 'Create',
+			'id'     => $reply_id . '/activity',
+			'actor'  => $this->actor,
+			'object' => array(
+				'type'         => 'Note',
+				'id'           => $reply_id,
+				'attributedTo' => $this->actor,
+				'inReplyTo'    => home_url( '/?c=' . $comment_id ),
+				'content'      => 'Reply to the local comment.',
+				'url'          => $reply_id,
+				'published'    => gmdate( \DATE_W3C, time() - 10 ),
+			),
+		);
+		$handler = function ( $activity, $user_ids, $activity_object ) {
+			\Activitypub\Handler\Create::create_interaction( $activity, $user_ids, $activity_object );
+		};
+		add_action( 'activitypub_handled_inbox_create', $handler, 10, 3 );
+		do_action( 'activitypub_handled_inbox_create', $activity, array( get_current_user_id() ), null );
+		remove_action( 'activitypub_handled_inbox_create', $handler, 10 );
+
+		$replies = get_comments(
+			array(
+				'post_id' => $post_id,
+				'parent'  => $comment_id,
+			)
+		);
+
+		$this->assertCount( 1, $replies );
+		$reply = reset( $replies );
+		$this->assertSame( (int) $post_id, (int) $reply->comment_post_ID );
+		$this->assertSame( (int) $comment_id, (int) $reply->comment_parent );
+	}
+
+	public function test_comment_reply_link_uses_local_friends_url() {
+		$remote_post_url = 'https://mastodon.local/users/akirk/statuses/123456';
+		$post_id = $this->friend->insert_post(
+			array(
+				'post_type'    => Friends::CPT,
+				'post_content' => 'Cached ActivityPub post.',
+				'post_status'  => 'publish',
+				'guid'         => $remote_post_url,
+			)
+		);
+		$comment_id = wp_insert_comment(
+			array(
+				'comment_post_ID'  => $post_id,
+				'comment_content'  => 'Local comment.',
+				'comment_type'     => 'comment',
+				'user_id'          => get_current_user_id(),
+				'comment_approved' => 1,
+			)
+		);
+
+		$parser = Friends::get_instance()->feed->get_feed_parser( Feed_Parser_ActivityPub::SLUG );
+		$link = $parser->fix_comment_reply_link(
+			'<a href="' . esc_url( $remote_post_url ) . '?replytocom=' . $comment_id . '#respond">Reply</a>',
+			array(),
+			get_comment( $comment_id ),
+			get_post( $post_id )
+		);
+
+		$this->assertStringContainsString( $this->friend->get_local_friends_page_url( $post_id ), $link );
+		$this->assertStringNotContainsString( $remote_post_url, $link );
+	}
+
+	public function test_get_remote_comments_skips_existing_local_comments() {
+		$post_id = $this->friend->insert_post(
+			array(
+				'post_type'    => Friends::CPT,
+				'post_content' => 'Cached ActivityPub post.',
+				'post_status'  => 'publish',
+				'guid'         => 'https://mastodon.local/users/akirk/statuses/123456',
+				'meta_input'   => array(
+					Feed_Parser_ActivityPub::SLUG => array(
+						'attributedTo' => array(
+							'id' => $this->actor,
+						),
+					),
+				),
+			)
+		);
+		$comment_id = wp_insert_comment(
+			array(
+				'comment_post_ID'  => $post_id,
+				'comment_content'  => 'Already stored locally.',
+				'comment_type'     => 'comment',
+				'user_id'          => get_current_user_id(),
+				'comment_approved' => 1,
+			)
+		);
+		add_comment_meta( $comment_id, 'source_id', 'remote-comment-1' );
+		$existing_comment = get_comment( $comment_id );
+
+		$filter = function ( $context ) {
+			$status = (object) array(
+				'id'             => 'remote-comment-1',
+				'uri'            => 'https://mastodon.local/users/akirk/statuses/remote-comment-1',
+				'account'        => (object) array(
+					'display_name' => 'Alex Kirk',
+					'url'          => $this->actor,
+					'acct'         => 'akirk@mastodon.local',
+				),
+				'content'        => 'Already stored locally.',
+				'created_at'     => new \DateTimeImmutable( '2026-01-01 00:00:00' ),
+				'in_reply_to_id' => null,
+			);
+
+			$context['descendants'] = array( $status );
+			return $context;
+		};
+		add_filter(
+			'mastodon_api_status_context',
+			$filter
+		);
+
+		$parser = Friends::get_instance()->feed->get_feed_parser( Feed_Parser_ActivityPub::SLUG );
+		$comments = $parser->get_remote_comments( array( $existing_comment ), $post_id );
+		remove_filter( 'mastodon_api_status_context', $filter );
+
+		$this->assertCount( 1, $comments );
+		$this->assertSame( (int) $comment_id, (int) $comments[0]->comment_ID );
+	}
+
 	public function test_comment_on_cached_post_federation() {
 		$remote_post_url = 'https://mastodon.local/users/akirk/statuses/123456';
 


### PR DESCRIPTION
## Summary

- Fix replies from the Fediverse to local WordPress comments, federated as `?c=NNN` URLs, so they arrive as threaded comments on the cached Friends post.
- Prevent local comment URLs from being misresolved by `url_to_postid()` before ActivityPub can fall back to `url_to_commentid()`.
- Let ActivityPub persist inbound interaction comments on ActivityPub-capable `friend_post_cache` posts only while handling the inbound Create activity, while keeping cached posts disabled for the normal ActivityPub post lifecycle.
- Defer Friends feed-item creation for replies to local comments so ActivityPub's comment handler can process them.
- Fix comment reply links on `friend_post_cache` posts to use the local Friends URL instead of the external source URL.
- Extend remote comment fetching to ActivityPub-capable cached posts and dedupe comments that are already stored locally.
- Add regression tests for the comment URL handling, ActivityPub comment persistence, Friends deferral, reply-link URL, and remote-comment deduplication.

## Test plan

- [x] `composer test -- --filter ActivityPubTest`
- [x] `composer check-cs`
- [ ] Comment on a friend's post that originates from an ActivityPub-capable source.
- [ ] Have someone reply to that comment from the Fediverse.
- [ ] Verify the reply arrives as a threaded comment on the correct Friends post, not as a standalone cached post.
- [ ] Verify the "Reply" link on comments uses the local Friends URL, not the external source URL.
- [ ] Verify remote comments load without duplicating locally stored comments.

[Test in WordPress Playground](https://akirk.github.io/playground-step-library/?redir=1&step[0]=setLandingPage&landingPage[0]=/friends/&step[1]=installPlugin&url[1]=github.com/akirk/friends/tree/fix/activitypub-threaded-comment-replies&step[2]=importFriendFeeds&opml[2]=https://alex.kirk.at%20Alex%20Kirk%20https://adamadam.blog%20Adam%20Zieliński)

<details><summary>Changelog</summary>

- [x] Automatically create a changelog entry from the details below

#### Type
- [x] Fixed

#### Message
Fix ActivityPub replies to local comments not arriving as threaded comments

</details>
