### PR TITLE
Fix conversation accounts for migrated users

### DIFF
--- a/.github/changelog/unreleased/655-from-description
+++ b/.github/changelog/unreleased/655-from-description
@@ -1,0 +1,3 @@
+Type: fixed
+
+Fix conversation accounts for migrated users by falling back to friends_feed_url meta when post_author is 0.

--- a/includes/class-messages.php
+++ b/includes/class-messages.php
@@ -618,8 +618,14 @@ class Messages {
 		$conversation->unread = $unread;
 		$conversation->last_status = apply_filters( 'mastodon_api_status', null, $last_status->ID );
 		$conversation->accounts = array();
-		// TODO: include virtual users.
-		$conversation->accounts[] = apply_filters( 'mastodon_api_account', null, $message->post_author );
+		$account_id = $message->post_author;
+		if ( ! $account_id ) {
+			$account_id = get_post_meta( $message->ID, 'friends_feed_url', true );
+		}
+		$account = apply_filters( 'mastodon_api_account', null, $account_id );
+		if ( $account ) {
+			$conversation->accounts[] = $account;
+		}
 
 		return $conversation;
 	}


### PR DESCRIPTION
## Summary
- When WP users were migrated to Friend terms, their `post_author` became 0 on existing conversation posts
- The Mastodon API conversation endpoint returned empty `accounts` arrays for these conversations
- This caused Tusky (and potentially other clients) to crash with `IndexOutOfBoundsException` when rendering conversations
- Fix: fall back to `friends_feed_url` post meta to resolve the account when `post_author` is 0

## Test plan
- [ ] Check `/api/v1/conversations` returns non-empty `accounts` for all conversations
- [ ] Verify conversations from remote users (previously migrated) show the correct account

<details><summary>Changelog</summary>

- [x] Automatically create a changelog entry from the details below

#### Type
- [x] Fixed

#### Message
Fix conversation accounts for migrated users by falling back to friends_feed_url meta when post_author is 0.

</details>

[Test in WordPress Playground](https://akirk.github.io/playground-step-library/?redir=1&step[0]=setLandingPage&landingPage[0]=/friends/&step[1]=installPlugin&url[1]=github.com/akirk/friends/tree/fix/conversation-accounts-for-migrated-users&step[2]=importFriendFeeds&opml[2]=https://alex.kirk.at%20Alex%20Kirk%20https://adamadam.blog%20Adam%20Zieliński)