### PR TITLE
Fix mobile layout issues in admin bar and themes

### DIFF
--- a/.github/changelog/unreleased/fix-mobile-masterbar-friends-icon
+++ b/.github/changelog/unreleased/fix-mobile-masterbar-friends-icon
@@ -1,0 +1,3 @@
+Type: Fixed
+
+Mobile fixes: show the Friends icon in the admin bar on mobile; stack chips and search on separate rows in the Google Reader theme on narrow screens; remove duplicate compose box from the Twitter theme mobile panel.

--- a/.github/changelog/unreleased/fix-mobile-masterbar-friends-icon
+++ b/.github/changelog/unreleased/fix-mobile-masterbar-friends-icon
@@ -1,3 +1,3 @@
 Type: Fixed
 
-Mobile fixes: show the Friends icon in the admin bar on mobile; stack chips and search on separate rows in the Google Reader theme on narrow screens; remove duplicate compose box from the Twitter theme mobile panel.
+Mobile fixes: show the Friends icon in the admin bar on mobile and swap the generic group glyph for the Friends logo mark; stack chips and search on separate rows in the Google Reader theme on narrow screens; remove duplicate compose box from the Twitter theme mobile panel.

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -2700,6 +2700,9 @@ class Admin {
 					margin-top: 6px;
 					margin-left: 6px;
 				}
+				body.friends-page #wpadminbar li#wp-admin-bar-comments {
+					display: none;
+				}
 			}
 		</style>
 		<?php

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -2610,11 +2610,13 @@ class Admin {
 
 		$unread = $this->get_unread_badge();
 
+		$logo = '<svg class="friends-logo-mark" viewBox="-10 50 160 195" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false"><path fill="currentColor" d="M 132.29 90.93 C 119.28 54.95 70.12 63.99 38.89 88.85 C -7.90 126.11 11.81 177.74 25.75 200.93 C 40.32 225.15 60.67 237.50 74.87 225.14 C 83.57 217.57 86.99 209.19 77.64 194.01 C 74.25 188.51 76.44 170.04 85.94 165.64 C 94.55 161.65 94.95 149.38 83.17 149.73 C 75.25 149.97 53.78 148.25 61.03 144.89 C 67.56 141.86 143.08 120.75 132.29 90.93 Z"/></svg>';
+
 		$wp_menu->add_node(
 			array(
 				'id'     => 'friends-menu',
 				'parent' => '',
-				'title'  => '<span class="ab-icon dashicons dashicons-groups"></span> <span class="ab-label">' . esc_html( __( 'Friends', 'friends' ) ) . $unread . '</span>',
+				'title'  => '<span class="ab-icon">' . $logo . '</span> <span class="ab-label">' . esc_html( __( 'Friends', 'friends' ) ) . $unread . '</span>',
 				'href'   => $my_url . '/friends/',
 			)
 		);
@@ -2676,12 +2678,23 @@ class Admin {
 		}
 		?>
 		<style type="text/css" media="screen">
+			#wpadminbar #wp-admin-bar-friends-menu .ab-icon .friends-logo-mark {
+				width: 20px;
+				height: 20px;
+				vertical-align: middle;
+				margin-top: -2px;
+			}
 			@media screen and (max-width: 782px) {
 				#wpadminbar #wp-admin-bar-friends-menu, #wpadminbar #wp-admin-bar-friends-menu .ab-icon {
 					display: block !important;
 				}
 				#wpadminbar #wp-admin-bar-friends-menu .ab-label {
 					display: none !important;
+				}
+				#wpadminbar #wp-admin-bar-friends-menu .ab-icon .friends-logo-mark {
+					width: 24px;
+					height: 24px;
+					margin-top: 7px;
 				}
 			}
 		</style>

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -46,6 +46,7 @@ class Admin {
 		add_action( 'admin_bar_menu', array( $this, 'admin_bar_friends_menu' ), 39 );
 		add_action( 'admin_bar_menu', array( $this, 'admin_bar_new_content' ), 71 );
 		add_action( 'wp_head', array( $this, 'admin_bar_mobile' ) );
+		add_action( 'admin_head', array( $this, 'admin_bar_mobile' ) );
 		add_action( 'current_screen', array( $this, 'register_help' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_scripts' ), 39 );
 		add_action( 'gettext_with_context', array( $this->friends, 'translate_user_role' ), 10, 4 );
@@ -2676,10 +2677,10 @@ class Admin {
 		?>
 		<style type="text/css" media="screen">
 			@media screen and (max-width: 782px) {
-				#wpadminbar #wp-admin-bar-friends, #wpadminbar #wp-admin-bar-friends .ab-icon {
+				#wpadminbar #wp-admin-bar-friends-menu, #wpadminbar #wp-admin-bar-friends-menu .ab-icon {
 					display: block !important;
 				}
-				#wpadminbar #wp-admin-bar-friends .ab-label {
+				#wpadminbar #wp-admin-bar-friends-menu .ab-label {
 					display: none !important;
 				}
 			}

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -2610,13 +2610,11 @@ class Admin {
 
 		$unread = $this->get_unread_badge();
 
-		$logo = '<svg class="friends-logo-mark" viewBox="-10 50 160 195" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false"><path fill="currentColor" d="M 132.29 90.93 C 119.28 54.95 70.12 63.99 38.89 88.85 C -7.90 126.11 11.81 177.74 25.75 200.93 C 40.32 225.15 60.67 237.50 74.87 225.14 C 83.57 217.57 86.99 209.19 77.64 194.01 C 74.25 188.51 76.44 170.04 85.94 165.64 C 94.55 161.65 94.95 149.38 83.17 149.73 C 75.25 149.97 53.78 148.25 61.03 144.89 C 67.56 141.86 143.08 120.75 132.29 90.93 Z"/></svg>';
-
 		$wp_menu->add_node(
 			array(
 				'id'     => 'friends-menu',
 				'parent' => '',
-				'title'  => '<span class="ab-icon">' . $logo . '</span> <span class="ab-label">' . esc_html( __( 'Friends', 'friends' ) ) . $unread . '</span>',
+				'title'  => '<span class="ab-icon"></span> <span class="ab-label">' . esc_html( __( 'Friends', 'friends' ) ) . $unread . '</span>',
 				'href'   => $my_url . '/friends/',
 			)
 		);
@@ -2676,13 +2674,18 @@ class Admin {
 		if ( ! is_user_logged_in() ) {
 			return;
 		}
+		$logo_mask = "url(\"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='-10 53 154 187'%3E%3Cpath d='M 132.29 90.93 C 119.28 54.95 70.12 63.99 38.89 88.85 -7.9 126.11 11.81 177.74 25.75 200.93 40.32 225.15 60.67 237.5 74.87 225.14 83.57 217.57 86.99 209.19 77.64 194.01 74.25 188.51 76.44 170.04 85.94 165.64 94.55 161.65 94.95 149.38 83.17 149.73 75.25 149.97 53.78 148.25 61.03 144.89 67.56 141.86 143.08 120.75 132.29 90.93 Z'/%3E%3C/svg%3E\") center/contain no-repeat";
 		?>
 		<style type="text/css" media="screen">
-			#wpadminbar #wp-admin-bar-friends-menu .ab-icon .friends-logo-mark {
+			#wpadminbar #wp-admin-bar-friends-menu .ab-icon:before {
+				content: "";
+				float: left;
 				width: 20px;
 				height: 20px;
-				vertical-align: middle;
-				margin-top: -2px;
+				margin-top: 2px;
+				background-color: currentColor;
+				-webkit-mask: <?php echo $logo_mask; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>;
+				mask: <?php echo $logo_mask; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>;
 			}
 			@media screen and (max-width: 782px) {
 				#wpadminbar #wp-admin-bar-friends-menu, #wpadminbar #wp-admin-bar-friends-menu .ab-icon {
@@ -2691,9 +2694,9 @@ class Admin {
 				#wpadminbar #wp-admin-bar-friends-menu .ab-label {
 					display: none !important;
 				}
-				#wpadminbar #wp-admin-bar-friends-menu .ab-icon .friends-logo-mark {
-					width: 24px;
-					height: 24px;
+				#wpadminbar #wp-admin-bar-friends-menu .ab-icon:before {
+					width: 32px;
+					height: 32px;
 					margin-top: 7px;
 				}
 			}

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -2697,7 +2697,8 @@ class Admin {
 				#wpadminbar #wp-admin-bar-friends-menu .ab-icon:before {
 					width: 32px;
 					height: 32px;
-					margin-top: 7px;
+					margin-top: 6px;
+					margin-left: 6px;
 				}
 			}
 		</style>

--- a/templates/google-reader/google-reader.css
+++ b/templates/google-reader/google-reader.css
@@ -91,6 +91,13 @@
 	}
 }
 
+@media (max-width: 782px) {
+	.friends-page .off-canvas-sidebar,
+	.friends-page .off-canvas-content {
+		margin-top: 46px;
+	}
+}
+
 @media (max-width: 640px) {
 	.friends-page header.navbar {
 		flex-direction: column;

--- a/templates/google-reader/google-reader.css
+++ b/templates/google-reader/google-reader.css
@@ -91,6 +91,17 @@
 	}
 }
 
+@media (max-width: 640px) {
+	.friends-page header.navbar {
+		flex-direction: column;
+		align-items: stretch;
+		gap: 6px;
+	}
+	.friends-page .navbar-section.search {
+		margin-left: 0;
+	}
+}
+
 /* === Sidebar === */
 .friends-page .friends-brand {
 	padding: 14px 16px 10px;

--- a/templates/twitter/frontend/header.php
+++ b/templates/twitter/frontend/header.php
@@ -59,16 +59,6 @@ $twitter_current_user = wp_get_current_user();
 				<i class="dashicons dashicons-arrow-down-alt2"></i>
 			</summary>
 			<div class="twitter-mobile-panel-content">
-				<form method="post" action="<?php echo esc_url( admin_url( 'admin-ajax.php' ) ); ?>" class="twitter-compose-form friends-post-inline">
-					<?php wp_nonce_field( 'friends_publish' ); ?>
-					<input type="hidden" name="action" value="friends_publish" />
-					<input type="hidden" name="format" value="<?php echo esc_attr( get_option( 'friends_compose_post_format', 'status' ) ); ?>" />
-					<textarea name="content" rows="3" placeholder="<?php echo esc_attr( sprintf( /* translators: %s is the user's display name */ __( "What's on your mind, %s?", 'friends' ), $twitter_current_user->display_name ) ); ?>"></textarea>
-					<div class="twitter-compose-footer">
-						<a href="<?php echo esc_url( admin_url( 'admin.php?page=friends-settings#compose' ) ); ?>" class="twitter-compose-settings" title="<?php esc_attr_e( 'Compose settings', 'friends' ); ?>"><span class="dashicons dashicons-admin-generic"></span></a>
-						<button type="submit" class="twitter-compose-submit"><?php esc_html_e( 'Post', 'friends' ); ?></button>
-					</div>
-				</form>
 				<form class="twitter-search-form form-autocomplete" action="<?php echo esc_url( home_url( '/friends/' ) ); ?>">
 					<div class="form-autocomplete-input twitter-search-wrap">
 						<input class="twitter-search-input master-search" type="text" name="s" placeholder="<?php /* phpcs:ignore WordPress.WP.I18n.MissingArgDomain */ esc_attr_e( 'Search or paste URL' ); ?>" value="<?php echo esc_attr( $_search ); ?>" autocomplete="off" data-nonce="<?php echo esc_attr( wp_create_nonce( 'friends-autocomplete' ) ); ?>" />

--- a/templates/twitter/twitter.css
+++ b/templates/twitter/twitter.css
@@ -167,6 +167,26 @@ body.friends-page {
 	}
 }
 
+@media (max-width: 782px) {
+	body.friends-page {
+		padding-top: 46px;
+	}
+	.twitter-left-col {
+		top: 46px;
+		height: calc(100vh - 46px);
+	}
+	.twitter-center-col {
+		min-height: calc(100vh - 46px);
+	}
+	.twitter-right-col {
+		top: 46px;
+		height: calc(100vh - 46px);
+	}
+	.twitter-col-title-row {
+		top: 46px;
+	}
+}
+
 @media (max-width: 500px) {
 	body.friends-page {
 		display: block;
@@ -182,10 +202,10 @@ body.friends-page {
 	.twitter-right-col {
 		display: none;
 		position: fixed;
-		top: 32px;
+		top: 46px;
 		right: 0;
 		width: 300px;
-		height: calc(100vh - 32px);
+		height: calc(100vh - 46px);
 		z-index: 20;
 		background: light-dark(#fff, #000);
 		box-shadow: -4px 0 16px rgba(0,0,0,.2);


### PR DESCRIPTION
## Summary
- **Admin bar**: the Friends icon was hidden on mobile because the mobile-only CSS targeted `#wp-admin-bar-friends`, but the node is registered with id `friends-menu`, so the selector never matched and WP's default mobile rules (hiding `.ab-icon`/`.ab-label`) won. The same style was also only emitted on `wp_head`, so wp-admin screens didn't get it at all. Fixed both.
- **Google Reader theme**: on narrow screens the search field kept its full width and squeezed the chips section so tight that each chip wrapped to its own line. Added a `@media (max-width: 640px)` block that stacks the two navbar sections vertically and zeroes the search section's left margin.
- **Twitter theme**: the collapsible mobile panel unfolded a "What's on your mind" compose form, but the center column already renders an always-visible "What's happening?" inline compose box. Removed the duplicated compose form from the mobile panel, leaving just the search form there (which still serves a purpose because the right column — which owns search on desktop — is hidden at ≤1000px).

## Test plan
- [ ] On a mobile-width viewport (≤782px), confirm the Friends icon appears in the admin bar on both the frontend and in wp-admin.
- [ ] In the Google Reader theme, resize to ≤640px and confirm chips sit on one or more horizontal rows above a full-width search field instead of stacking into a single column.
- [ ] In the Twitter theme, resize to ≤1000px and confirm the collapsible user panel only exposes the search field, while the inline "What's happening?" compose box remains in the center column.

<details><summary>Changelog</summary>

- [x] Automatically create a changelog entry from the details below

#### Type
- [x] Fixed

#### Message
Mobile fixes: show the Friends icon in the admin bar on mobile; stack chips and search on separate rows in the Google Reader theme on narrow screens; remove duplicate compose box from the Twitter theme mobile panel.

</details>