### PR TITLE
Twitter theme: add second widget area in right column

### DIFF
--- a/.github/changelog/unreleased/twitter-theme-second-sidebar
+++ b/.github/changelog/unreleased/twitter-theme-second-sidebar
@@ -1,0 +1,3 @@
+Type: Added
+
+Twitter theme: add a second widget area ("Friends Sidebar 2") shown in the right column.

--- a/includes/class-frontend.php
+++ b/includes/class-frontend.php
@@ -258,6 +258,17 @@ class Frontend {
 				'after_title'   => '</h5>',
 			)
 		);
+		register_sidebar(
+			array(
+				'name'          => __( 'Friends Sidebar 2 (Twitter theme)', 'friends' ),
+				'id'            => 'friends-sidebar-2',
+				'description'   => __( 'Shown in the right column of the Twitter theme.', 'friends' ),
+				'before_widget' => '<div class="friends-widget">',
+				'after_widget'  => '</div>',
+				'before_title'  => '<h5>',
+				'after_title'   => '</h5>',
+			)
+		);
 
 		if ( Friends::on_frontend() ) {
 			add_action( 'customize_register', '__return_true' );

--- a/templates/twitter/frontend/footer.php
+++ b/templates/twitter/frontend/footer.php
@@ -24,8 +24,11 @@
 			</div>
 			<ul class="menu" style="display: none"></ul>
 		</form>
+		<div class="twitter-right-widgets">
+			<?php dynamic_sidebar( 'friends-sidebar-2' ); ?>
+		</div>
 		<div class="twitter-right-customize">
-			<a href="<?php echo esc_url( add_query_arg( 'url', home_url( '/friends/' ), admin_url( 'customize.php?autofocus[section]=sidebar-widgets-friends-sidebar' ) ) ); ?>"><?php esc_html_e( 'customize sidebar', 'friends' ); ?></a>
+			<a href="<?php echo esc_url( add_query_arg( 'url', home_url( '/friends/' ), admin_url( 'customize.php?autofocus[section]=sidebar-widgets-friends-sidebar-2' ) ) ); ?>"><?php esc_html_e( 'customize sidebar', 'friends' ); ?></a>
 		</div>
 	</aside>
 

--- a/templates/twitter/twitter.css
+++ b/templates/twitter/twitter.css
@@ -501,10 +501,7 @@ body.friends-page {
 }
 
 .twitter-right-widgets {
-	background: light-dark(#f7f9fa, #16181c);
-	border-radius: 16px;
 	margin-bottom: 12px;
-	overflow: hidden;
 }
 
 .twitter-right-widgets:empty {

--- a/templates/twitter/twitter.css
+++ b/templates/twitter/twitter.css
@@ -500,6 +500,23 @@ body.friends-page {
 	color: light-dark(#536471, #71767b);
 }
 
+.twitter-right-widgets {
+	background: light-dark(#f7f9fa, #16181c);
+	border-radius: 16px;
+	margin-bottom: 12px;
+	overflow: hidden;
+}
+
+.twitter-right-widgets:empty {
+	display: none;
+}
+
+.twitter-right-widgets .friends-widget + .friends-widget {
+	border-top: 1px solid light-dark(#eff3f4, #2f3336);
+	margin-top: 4px;
+	padding-top: 4px;
+}
+
 .twitter-right-customize {
 	padding: 8px 0;
 	font-size: 12px;


### PR DESCRIPTION
## Summary

- Registers a new "Friends Sidebar 2" widget area (`friends-sidebar-2`) alongside the existing `friends-sidebar`.
- Renders it in the Twitter theme's right column between the search box and the customize link, styled as a Twitter-style rounded card that hides when empty.
- Points the right column's "customize sidebar" link at the new widget area (the left column still links to `friends-sidebar`).

Gives users a place to drop widgets (trends, follow suggestions, etc.) in the previously-empty right column of the Twitter theme.

## Test plan

- [ ] Switch to the Twitter theme on the Friends page.
- [ ] Open Appearance → Widgets (or the Customizer) and confirm "Friends Sidebar 2 (Twitter theme)" is listed.
- [ ] Add a widget to it and verify it appears in the right column, styled in the rounded card container.
- [ ] With no widgets added, confirm the container is hidden (no empty card).
- [ ] Click "customize sidebar" in the right column — verify the customizer opens focused on the new widget area.
- [ ] Confirm the left column's "customize sidebar" still points at the original `friends-sidebar`.

[Test in WordPress Playground](https://akirk.github.io/playground-step-library/?redir=1&step[0]=setLandingPage&landingPage[0]=/friends/&step[1]=installPlugin&url[1]=github.com/akirk/friends/tree/twitter-theme-second-sidebar&step[2]=importFriendFeeds&opml[2]=https://alex.kirk.at%20Alex%20Kirk%20https://adamadam.blog%20Adam%20Zieliński)