### PR TITLE
Add search field to Followers, Following, and Mutual pages

### DIFF
--- a/.github/changelog/unreleased/add-search-followers-following-mutual
+++ b/.github/changelog/unreleased/add-search-followers-following-mutual
@@ -1,0 +1,3 @@
+Type: Added
+
+Add a search field to the Followers, Following, and Mutual pages.

--- a/friends.css
+++ b/friends.css
@@ -1827,6 +1827,41 @@ h2#page-title a.dashicons {
 	}
 
 	& section.followers, & section.subscriptions {
+		& .friends-search {
+			display: flex;
+			flex-wrap: wrap;
+			align-items: center;
+			gap: .5em;
+			margin: 0 0 1em;
+		}
+
+		& .friends-search-label {
+			display: inline-flex;
+			align-items: center;
+			gap: .4em;
+			flex: 1 1 240px;
+			min-width: 0;
+		}
+
+		& .friends-search-input {
+			flex: 1 1 auto;
+			min-width: 0;
+			box-sizing: border-box;
+			padding: .35em .6em;
+			font-size: inherit;
+			line-height: 1.3;
+			border: 1px solid #ccc;
+			border-radius: 3px;
+			background: #fff;
+		}
+
+		& .friends-search-input:focus {
+			outline: 2px solid #2271b1;
+			outline-offset: -1px;
+		}
+
+		& .friends-search-clear { font-size: .9em; }
+
 		& ul { padding-left: 0; }
 
 		& ul li {

--- a/includes/class-blocks.php
+++ b/includes/class-blocks.php
@@ -556,28 +556,26 @@ class Blocks {
 				?>
 			</a>
 			</p>
-			<form method="get" action="<?php echo esc_url( $base_url ); ?>" class="followers-search">
-				<p>
-					<label>
-						<?php esc_html_e( 'Search:', 'friends' ); ?>
-						<input type="search" name="q" value="<?php echo esc_attr( $search_term ); ?>" placeholder="<?php esc_attr_e( 'Name, handle, or description', 'friends' ); ?>" />
-					</label>
-					<button type="submit" class="button"><?php esc_html_e( 'Search', 'friends' ); ?></button>
-					<?php if ( 'all' !== $filter ) : ?>
-						<input type="hidden" name="filter" value="<?php echo esc_attr( $filter ); ?>" />
-					<?php endif; ?>
-					<?php if ( 'newest' !== $sort ) : ?>
-						<input type="hidden" name="sort" value="<?php echo esc_attr( $sort ); ?>" />
-					<?php endif; ?>
-					<?php
-					if ( '' !== $search_term ) :
-						$clear_args = $link_args;
-						unset( $clear_args['q'] );
-						$clear_url = $clear_args ? add_query_arg( $clear_args, $base_url ) : $base_url;
-						?>
-						<a href="<?php echo esc_url( $clear_url ); ?>"><?php esc_html_e( 'Clear', 'friends' ); ?></a>
-					<?php endif; ?>
-				</p>
+			<form method="get" action="<?php echo esc_url( $base_url ); ?>" class="friends-search" role="search">
+				<label class="friends-search-label">
+					<?php esc_html_e( 'Search:', 'friends' ); ?>
+					<input type="search" name="q" value="<?php echo esc_attr( $search_term ); ?>" placeholder="<?php esc_attr_e( 'Name, handle, or description', 'friends' ); ?>" class="friends-search-input" />
+				</label>
+				<button type="submit" class="button friends-search-submit"><?php esc_html_e( 'Search', 'friends' ); ?></button>
+				<?php if ( 'all' !== $filter ) : ?>
+					<input type="hidden" name="filter" value="<?php echo esc_attr( $filter ); ?>" />
+				<?php endif; ?>
+				<?php if ( 'newest' !== $sort ) : ?>
+					<input type="hidden" name="sort" value="<?php echo esc_attr( $sort ); ?>" />
+				<?php endif; ?>
+				<?php
+				if ( '' !== $search_term ) :
+					$clear_args = $link_args;
+					unset( $clear_args['q'] );
+					$clear_url = $clear_args ? add_query_arg( $clear_args, $base_url ) : $base_url;
+					?>
+					<a href="<?php echo esc_url( $clear_url ); ?>" class="friends-search-clear"><?php esc_html_e( 'Clear', 'friends' ); ?></a>
+				<?php endif; ?>
 			</form>
 			<?php if ( '' !== $search_term ) : ?>
 			<p>

--- a/includes/class-blocks.php
+++ b/includes/class-blocks.php
@@ -380,6 +380,8 @@ class Blocks {
 			$sort = 'newest';
 		}
 
+		$search_term = isset( $_GET['q'] ) ? trim( wp_unslash( $_GET['q'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended,WordPress.Security.ValidatedSanitizedInput.MissingUnslash,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+
 		$followers_list_page = 'users.php?page=activitypub-followers-list';
 		if ( $blog_followers ) {
 			$followers_list_page = 'options-general.php?page=activitypub&tab=followers';
@@ -387,6 +389,31 @@ class Blocks {
 
 		$follower_data     = \ActivityPub\Collection\Followers::query( $user_id );
 		$total             = $follower_data['total'];
+
+		// Apply search filter first so downstream work operates on the smaller set.
+		if ( '' !== $search_term ) {
+			$search_term_lc                  = function_exists( 'mb_strtolower' ) ? mb_strtolower( $search_term ) : strtolower( $search_term );
+			$follower_data['followers'] = array_values(
+				array_filter(
+					$follower_data['followers'],
+					function ( $f ) use ( $search_term_lc ) {
+						$haystack = '';
+						if ( isset( $f->post_title ) ) {
+							$haystack .= $f->post_title . ' ';
+						}
+						if ( isset( $f->guid ) ) {
+							$haystack .= $f->guid . ' ';
+						}
+						if ( isset( $f->post_content ) ) {
+							$haystack .= wp_strip_all_tags( $f->post_content );
+						}
+						$haystack = function_exists( 'mb_strtolower' ) ? mb_strtolower( $haystack ) : strtolower( $haystack );
+						return false !== strpos( $haystack, $search_term_lc );
+					}
+				)
+			);
+		}
+
 		// Classify followers only when a filter is active.
 		if ( 'all' !== $filter ) {
 			$following_ids     = array();
@@ -491,6 +518,9 @@ class Blocks {
 		if ( 'newest' !== $sort ) {
 			$link_args['sort'] = $sort;
 		}
+		if ( '' !== $search_term ) {
+			$link_args['q'] = $search_term;
+		}
 
 		ob_start();
 		?>
@@ -526,6 +556,43 @@ class Blocks {
 				?>
 			</a>
 			</p>
+			<form method="get" action="<?php echo esc_url( $base_url ); ?>" class="followers-search">
+				<p>
+					<label>
+						<?php esc_html_e( 'Search:', 'friends' ); ?>
+						<input type="search" name="q" value="<?php echo esc_attr( $search_term ); ?>" placeholder="<?php esc_attr_e( 'Name, handle, or description', 'friends' ); ?>" />
+					</label>
+					<button type="submit" class="button"><?php esc_html_e( 'Search', 'friends' ); ?></button>
+					<?php if ( 'all' !== $filter ) : ?>
+						<input type="hidden" name="filter" value="<?php echo esc_attr( $filter ); ?>" />
+					<?php endif; ?>
+					<?php if ( 'newest' !== $sort ) : ?>
+						<input type="hidden" name="sort" value="<?php echo esc_attr( $sort ); ?>" />
+					<?php endif; ?>
+					<?php
+					if ( '' !== $search_term ) :
+						$clear_args = $link_args;
+						unset( $clear_args['q'] );
+						$clear_url = $clear_args ? add_query_arg( $clear_args, $base_url ) : $base_url;
+						?>
+						<a href="<?php echo esc_url( $clear_url ); ?>"><?php esc_html_e( 'Clear', 'friends' ); ?></a>
+					<?php endif; ?>
+				</p>
+			</form>
+			<?php if ( '' !== $search_term ) : ?>
+			<p>
+				<?php
+				echo esc_html(
+					sprintf(
+						// translators: %1$s is the number of matches, %2$s is the search term.
+						_n( '%1$s match for "%2$s"', '%1$s matches for "%2$s"', count( $filtered_followers ), 'friends' ),
+						number_format_i18n( count( $filtered_followers ) ),
+						$search_term
+					)
+				);
+				?>
+			</p>
+			<?php endif; ?>
 			<p>
 				<?php esc_html_e( 'Filter:', 'friends' ); ?>
 				<?php

--- a/templates/frontend/followers.php
+++ b/templates/frontend/followers.php
@@ -30,6 +30,8 @@ if ( ! in_array( $sort, array( 'newest', 'oldest', 'name' ), true ) ) {
 	$sort = 'newest';
 }
 
+$search_term = isset( $_GET['q'] ) ? trim( wp_unslash( $_GET['q'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended,WordPress.Security.ValidatedSanitizedInput.MissingUnslash,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+
 $args['no-bottom-margin'] = true;
 
 Friends\Friends::template_loader()->get_template_part( 'frontend/header', null, $args );
@@ -44,6 +46,30 @@ if ( $blog_followers ) {
 	if ( class_exists( '\ActivityPub\Collection\Followers' ) ) {
 		$follower_data = \ActivityPub\Collection\Followers::query( $args['user_id'] );
 		$total         = $follower_data['total'];
+
+		// Apply search filter first so downstream work operates on the smaller set.
+		if ( '' !== $search_term ) {
+			$search_term_lc                    = function_exists( 'mb_strtolower' ) ? mb_strtolower( $search_term ) : strtolower( $search_term );
+			$follower_data['followers'] = array_values(
+				array_filter(
+					$follower_data['followers'],
+					function ( $f ) use ( $search_term_lc ) {
+						$haystack = '';
+						if ( isset( $f->post_title ) ) {
+							$haystack .= $f->post_title . ' ';
+						}
+						if ( isset( $f->guid ) ) {
+							$haystack .= $f->guid . ' ';
+						}
+						if ( isset( $f->post_content ) ) {
+							$haystack .= wp_strip_all_tags( $f->post_content );
+						}
+						$haystack = function_exists( 'mb_strtolower' ) ? mb_strtolower( $haystack ) : strtolower( $haystack );
+						return false !== strpos( $haystack, $search_term_lc );
+					}
+				)
+			);
+		}
 
 		// Classify followers only when a filter is active.
 		if ( 'all' !== $filter ) {
@@ -150,6 +176,9 @@ if ( $blog_followers ) {
 		if ( 'newest' !== $sort ) {
 			$link_args['sort'] = $sort;
 		}
+		if ( '' !== $search_term ) {
+			$link_args['q'] = $search_term;
+		}
 		?>
 		<p>
 		<?php
@@ -180,6 +209,43 @@ if ( $blog_followers ) {
 		echo '</a>';
 		?>
 		</p>
+		<form method="get" action="<?php echo esc_url( $base_url ); ?>" class="followers-search">
+			<p>
+				<label>
+					<?php esc_html_e( 'Search:', 'friends' ); ?>
+					<input type="search" name="q" value="<?php echo esc_attr( $search_term ); ?>" placeholder="<?php esc_attr_e( 'Name, handle, or description', 'friends' ); ?>" />
+				</label>
+				<button type="submit" class="button"><?php esc_html_e( 'Search', 'friends' ); ?></button>
+				<?php if ( 'all' !== $filter ) : ?>
+					<input type="hidden" name="filter" value="<?php echo esc_attr( $filter ); ?>" />
+				<?php endif; ?>
+				<?php if ( 'newest' !== $sort ) : ?>
+					<input type="hidden" name="sort" value="<?php echo esc_attr( $sort ); ?>" />
+				<?php endif; ?>
+				<?php
+				if ( '' !== $search_term ) :
+					$clear_args = $link_args;
+					unset( $clear_args['q'] );
+					$clear_url = $clear_args ? add_query_arg( $clear_args, $base_url ) : $base_url;
+					?>
+					<a href="<?php echo esc_url( $clear_url ); ?>"><?php esc_html_e( 'Clear', 'friends' ); ?></a>
+				<?php endif; ?>
+			</p>
+		</form>
+		<?php if ( '' !== $search_term ) : ?>
+		<p>
+			<?php
+			echo esc_html(
+				sprintf(
+					// translators: %1$s is the number of matches, %2$s is the search term.
+					_n( '%1$s match for "%2$s"', '%1$s matches for "%2$s"', count( $filtered_followers ), 'friends' ),
+					number_format_i18n( count( $filtered_followers ) ),
+					$search_term
+				)
+			);
+			?>
+		</p>
+		<?php endif; ?>
 		<p>
 			<?php esc_html_e( 'Filter:', 'friends' ); ?>
 			<?php

--- a/templates/frontend/followers.php
+++ b/templates/frontend/followers.php
@@ -209,28 +209,26 @@ if ( $blog_followers ) {
 		echo '</a>';
 		?>
 		</p>
-		<form method="get" action="<?php echo esc_url( $base_url ); ?>" class="followers-search">
-			<p>
-				<label>
-					<?php esc_html_e( 'Search:', 'friends' ); ?>
-					<input type="search" name="q" value="<?php echo esc_attr( $search_term ); ?>" placeholder="<?php esc_attr_e( 'Name, handle, or description', 'friends' ); ?>" />
-				</label>
-				<button type="submit" class="button"><?php esc_html_e( 'Search', 'friends' ); ?></button>
-				<?php if ( 'all' !== $filter ) : ?>
-					<input type="hidden" name="filter" value="<?php echo esc_attr( $filter ); ?>" />
-				<?php endif; ?>
-				<?php if ( 'newest' !== $sort ) : ?>
-					<input type="hidden" name="sort" value="<?php echo esc_attr( $sort ); ?>" />
-				<?php endif; ?>
-				<?php
-				if ( '' !== $search_term ) :
-					$clear_args = $link_args;
-					unset( $clear_args['q'] );
-					$clear_url = $clear_args ? add_query_arg( $clear_args, $base_url ) : $base_url;
-					?>
-					<a href="<?php echo esc_url( $clear_url ); ?>"><?php esc_html_e( 'Clear', 'friends' ); ?></a>
-				<?php endif; ?>
-			</p>
+		<form method="get" action="<?php echo esc_url( $base_url ); ?>" class="friends-search" role="search">
+			<label class="friends-search-label">
+				<?php esc_html_e( 'Search:', 'friends' ); ?>
+				<input type="search" name="q" value="<?php echo esc_attr( $search_term ); ?>" placeholder="<?php esc_attr_e( 'Name, handle, or description', 'friends' ); ?>" class="friends-search-input" />
+			</label>
+			<button type="submit" class="button friends-search-submit"><?php esc_html_e( 'Search', 'friends' ); ?></button>
+			<?php if ( 'all' !== $filter ) : ?>
+				<input type="hidden" name="filter" value="<?php echo esc_attr( $filter ); ?>" />
+			<?php endif; ?>
+			<?php if ( 'newest' !== $sort ) : ?>
+				<input type="hidden" name="sort" value="<?php echo esc_attr( $sort ); ?>" />
+			<?php endif; ?>
+			<?php
+			if ( '' !== $search_term ) :
+				$clear_args = $link_args;
+				unset( $clear_args['q'] );
+				$clear_url = $clear_args ? add_query_arg( $clear_args, $base_url ) : $base_url;
+				?>
+				<a href="<?php echo esc_url( $clear_url ); ?>" class="friends-search-clear"><?php esc_html_e( 'Clear', 'friends' ); ?></a>
+			<?php endif; ?>
 		</form>
 		<?php if ( '' !== $search_term ) : ?>
 		<p>

--- a/templates/frontend/subscriptions.php
+++ b/templates/frontend/subscriptions.php
@@ -182,28 +182,26 @@ Friends\Friends::template_loader()->get_template_part( 'frontend/header', null, 
 	);
 	?>
 	</p>
-	<form method="get" action="<?php echo esc_url( $base_url ); ?>" class="subscriptions-search">
-		<p>
-			<label>
-				<?php esc_html_e( 'Search:', 'friends' ); ?>
-				<input type="search" name="q" value="<?php echo esc_attr( $search_term ); ?>" placeholder="<?php esc_attr_e( 'Name, handle, or description', 'friends' ); ?>" />
-			</label>
-			<button type="submit" class="button"><?php esc_html_e( 'Search', 'friends' ); ?></button>
-			<?php if ( 'all' !== $filter ) : ?>
-				<input type="hidden" name="filter" value="<?php echo esc_attr( $filter ); ?>" />
-			<?php endif; ?>
-			<?php if ( 'name' !== $sort ) : ?>
-				<input type="hidden" name="sort" value="<?php echo esc_attr( $sort ); ?>" />
-			<?php endif; ?>
-			<?php
-			if ( '' !== $search_term ) :
-				$clear_args = $link_args;
-				unset( $clear_args['q'] );
-				$clear_url = $clear_args ? add_query_arg( $clear_args, $base_url ) : $base_url;
-				?>
-				<a href="<?php echo esc_url( $clear_url ); ?>"><?php esc_html_e( 'Clear', 'friends' ); ?></a>
-			<?php endif; ?>
-		</p>
+	<form method="get" action="<?php echo esc_url( $base_url ); ?>" class="friends-search" role="search">
+		<label class="friends-search-label">
+			<?php esc_html_e( 'Search:', 'friends' ); ?>
+			<input type="search" name="q" value="<?php echo esc_attr( $search_term ); ?>" placeholder="<?php esc_attr_e( 'Name, handle, or description', 'friends' ); ?>" class="friends-search-input" />
+		</label>
+		<button type="submit" class="button friends-search-submit"><?php esc_html_e( 'Search', 'friends' ); ?></button>
+		<?php if ( 'all' !== $filter ) : ?>
+			<input type="hidden" name="filter" value="<?php echo esc_attr( $filter ); ?>" />
+		<?php endif; ?>
+		<?php if ( 'name' !== $sort ) : ?>
+			<input type="hidden" name="sort" value="<?php echo esc_attr( $sort ); ?>" />
+		<?php endif; ?>
+		<?php
+		if ( '' !== $search_term ) :
+			$clear_args = $link_args;
+			unset( $clear_args['q'] );
+			$clear_url = $clear_args ? add_query_arg( $clear_args, $base_url ) : $base_url;
+			?>
+			<a href="<?php echo esc_url( $clear_url ); ?>" class="friends-search-clear"><?php esc_html_e( 'Clear', 'friends' ); ?></a>
+		<?php endif; ?>
 	</form>
 	<?php if ( '' !== $search_term ) : ?>
 	<p>

--- a/templates/frontend/subscriptions.php
+++ b/templates/frontend/subscriptions.php
@@ -32,6 +32,8 @@ if ( ! in_array( $sort, array( 'name', 'newest', 'oldest', 'posts' ), true ) ) {
 	$sort = 'name';
 }
 
+$search_term = isset( $_GET['q'] ) ? trim( wp_unslash( $_GET['q'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended,WordPress.Security.ValidatedSanitizedInput.MissingUnslash,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+
 Friends\Friends::template_loader()->get_template_part( 'frontend/header', null, $args );
 
 ?>
@@ -62,6 +64,31 @@ Friends\Friends::template_loader()->get_template_part( 'frontend/header', null, 
 		);
 	} else {
 		$filtered = $all_subscriptions;
+	}
+
+	// Search (applied after category filter so the top-of-page totals stay accurate).
+	if ( '' !== $search_term ) {
+		$search_term_lc = function_exists( 'mb_strtolower' ) ? mb_strtolower( $search_term ) : strtolower( $search_term );
+		$filtered  = array_filter(
+			$filtered,
+			function ( $s ) use ( $search_term_lc ) {
+				$haystack = '';
+				if ( isset( $s->display_name ) ) {
+					$haystack .= $s->display_name . ' ';
+				}
+				if ( isset( $s->user_login ) ) {
+					$haystack .= $s->user_login . ' ';
+				}
+				if ( isset( $s->user_url ) ) {
+					$haystack .= $s->user_url . ' ';
+				}
+				if ( isset( $s->description ) ) {
+					$haystack .= wp_strip_all_tags( $s->description );
+				}
+				$haystack = function_exists( 'mb_strtolower' ) ? mb_strtolower( $haystack ) : strtolower( $haystack );
+				return false !== strpos( $haystack, $search_term_lc );
+			}
+		);
 	}
 
 	// Sort.
@@ -132,6 +159,9 @@ Friends\Friends::template_loader()->get_template_part( 'frontend/header', null, 
 	if ( 'name' !== $sort ) {
 		$link_args['sort'] = $sort;
 	}
+	if ( '' !== $search_term ) {
+		$link_args['q'] = $search_term;
+	}
 	?>
 	<p>
 	<?php
@@ -152,6 +182,43 @@ Friends\Friends::template_loader()->get_template_part( 'frontend/header', null, 
 	);
 	?>
 	</p>
+	<form method="get" action="<?php echo esc_url( $base_url ); ?>" class="subscriptions-search">
+		<p>
+			<label>
+				<?php esc_html_e( 'Search:', 'friends' ); ?>
+				<input type="search" name="q" value="<?php echo esc_attr( $search_term ); ?>" placeholder="<?php esc_attr_e( 'Name, handle, or description', 'friends' ); ?>" />
+			</label>
+			<button type="submit" class="button"><?php esc_html_e( 'Search', 'friends' ); ?></button>
+			<?php if ( 'all' !== $filter ) : ?>
+				<input type="hidden" name="filter" value="<?php echo esc_attr( $filter ); ?>" />
+			<?php endif; ?>
+			<?php if ( 'name' !== $sort ) : ?>
+				<input type="hidden" name="sort" value="<?php echo esc_attr( $sort ); ?>" />
+			<?php endif; ?>
+			<?php
+			if ( '' !== $search_term ) :
+				$clear_args = $link_args;
+				unset( $clear_args['q'] );
+				$clear_url = $clear_args ? add_query_arg( $clear_args, $base_url ) : $base_url;
+				?>
+				<a href="<?php echo esc_url( $clear_url ); ?>"><?php esc_html_e( 'Clear', 'friends' ); ?></a>
+			<?php endif; ?>
+		</p>
+	</form>
+	<?php if ( '' !== $search_term ) : ?>
+	<p>
+		<?php
+		echo esc_html(
+			sprintf(
+				// translators: %1$s is the number of matches, %2$s is the search term.
+				_n( '%1$s match for "%2$s"', '%1$s matches for "%2$s"', count( $filtered ), 'friends' ),
+				number_format_i18n( count( $filtered ) ),
+				$search_term
+			)
+		);
+		?>
+	</p>
+	<?php endif; ?>
 	<p>
 		<?php esc_html_e( 'Filter:', 'friends' ); ?>
 		<?php

--- a/templates/google-reader/google-reader.css
+++ b/templates/google-reader/google-reader.css
@@ -358,6 +358,72 @@
 	padding-left: 0;
 }
 
+/* Search form */
+.friends-page section.followers .friends-search,
+.friends-page section.subscriptions .friends-search {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 6px;
+	margin: 0 0 10px;
+	font-size: 13px;
+	color: #333;
+}
+
+.friends-page section.followers .friends-search-label,
+.friends-page section.subscriptions .friends-search-label {
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+	flex: 1 1 240px;
+	min-width: 0;
+}
+
+.friends-page section.followers .friends-search-input,
+.friends-page section.subscriptions .friends-search-input {
+	flex: 1 1 auto;
+	min-width: 0;
+	box-sizing: border-box;
+	padding: 4px 8px;
+	font-size: 13px;
+	line-height: 1.3;
+	color: #222;
+	background: #fff;
+	border: 1px solid #bbb;
+	border-radius: 2px;
+}
+
+.friends-page section.followers .friends-search-input:focus,
+.friends-page section.subscriptions .friends-search-input:focus {
+	outline: none;
+	border-color: #4d90fe;
+	box-shadow: 0 0 0 1px #4d90fe;
+}
+
+.friends-page section.followers .friends-search-submit,
+.friends-page section.subscriptions .friends-search-submit {
+	padding: 4px 12px;
+	font-size: 13px;
+	line-height: 1.3;
+	background: linear-gradient(#f5f5f5, #f1f1f1);
+	color: #222;
+	border: 1px solid #bbb;
+	border-radius: 2px;
+	cursor: pointer;
+}
+
+.friends-page section.followers .friends-search-submit:hover,
+.friends-page section.subscriptions .friends-search-submit:hover {
+	background: linear-gradient(#f8f8f8, #f1f1f1);
+	border-color: #999;
+}
+
+.friends-page section.followers .friends-search-clear,
+.friends-page section.subscriptions .friends-search-clear {
+	color: #15c;
+	font-size: 12px;
+}
+
 .friends-page section.subscriptions .subscription-item {
 	padding: 8px 0;
 	border-bottom: 1px solid #e8e8e8;

--- a/templates/mastodon/mastodon.css
+++ b/templates/mastodon/mastodon.css
@@ -1669,6 +1669,65 @@ body.friends-page {
 	margin-bottom: 8px;
 }
 
+/* --- Search form --- */
+.friends-page section.followers .friends-search,
+.friends-page section.subscriptions .friends-search {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 8px;
+	margin: 0 0 12px;
+	font-size: 14px;
+	color: light-dark(#606984, #9baec8);
+}
+
+.friends-page section.followers .friends-search-label,
+.friends-page section.subscriptions .friends-search-label {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	flex: 1 1 240px;
+	min-width: 0;
+}
+
+.friends-page section.followers .friends-search-input,
+.friends-page section.subscriptions .friends-search-input {
+	flex: 1 1 auto;
+	min-width: 0;
+	box-sizing: border-box;
+	padding: 6px 10px;
+	font-size: 14px;
+	line-height: 1.3;
+	color: light-dark(#282c37, #dadada);
+	background: light-dark(#fff, #282c37);
+	border: 1px solid light-dark(#d4dde8, #393f4f);
+	border-radius: 4px;
+}
+
+.friends-page section.followers .friends-search-input:focus,
+.friends-page section.subscriptions .friends-search-input:focus {
+	outline: none;
+	border-color: light-dark(#563acc, #6364ff);
+}
+
+.friends-page section.followers .friends-search-submit,
+.friends-page section.subscriptions .friends-search-submit {
+	padding: 6px 14px;
+	font-size: 14px;
+	line-height: 1.3;
+	background: light-dark(#563acc, #6364ff);
+	color: #fff;
+	border: 0;
+	border-radius: 4px;
+	cursor: pointer;
+}
+
+.friends-page section.followers .friends-search-clear,
+.friends-page section.subscriptions .friends-search-clear {
+	color: light-dark(#563acc, #c4bbff);
+	font-size: 13px;
+}
+
 .friends-page section.followers > p a,
 .friends-page section.subscriptions > p a {
 	color: light-dark(#563acc, #c4bbff);

--- a/templates/twitter/twitter.css
+++ b/templates/twitter/twitter.css
@@ -1820,6 +1820,72 @@ body.friends-page {
 	color: light-dark(#0f1419, #e7e9ea);
 }
 
+/* Search form */
+.friends-page section.followers .friends-search,
+.friends-page section.subscriptions .friends-search {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 8px;
+	margin: 0 0 12px;
+	font-size: 15px;
+	color: light-dark(#536471, #71767b);
+}
+
+.friends-page section.followers .friends-search-label,
+.friends-page section.subscriptions .friends-search-label {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	flex: 1 1 240px;
+	min-width: 0;
+}
+
+.friends-page section.followers .friends-search-input,
+.friends-page section.subscriptions .friends-search-input {
+	flex: 1 1 auto;
+	min-width: 0;
+	box-sizing: border-box;
+	padding: 8px 14px;
+	font-size: 15px;
+	line-height: 1.3;
+	color: light-dark(#0f1419, #e7e9ea);
+	background: light-dark(#fff, #16181c);
+	border: 1px solid light-dark(#eff3f4, #2f3336);
+	border-radius: 9999px;
+}
+
+.friends-page section.followers .friends-search-input:focus,
+.friends-page section.subscriptions .friends-search-input:focus {
+	outline: none;
+	border-color: #1d9bf0;
+	box-shadow: 0 0 0 1px #1d9bf0;
+}
+
+.friends-page section.followers .friends-search-submit,
+.friends-page section.subscriptions .friends-search-submit {
+	padding: 8px 18px;
+	font-size: 15px;
+	font-weight: 700;
+	line-height: 1.3;
+	background: #1d9bf0;
+	color: #fff;
+	border: 0;
+	border-radius: 9999px;
+	cursor: pointer;
+}
+
+.friends-page section.followers .friends-search-submit:hover,
+.friends-page section.subscriptions .friends-search-submit:hover {
+	background: #1a8cd8;
+}
+
+.friends-page section.followers .friends-search-clear,
+.friends-page section.subscriptions .friends-search-clear {
+	color: #1d9bf0;
+	font-size: 14px;
+}
+
 /* === Pagination === */
 .friends-page .navigation {
 	padding: 16px;


### PR DESCRIPTION
## Summary
- Adds a `?q=` search field to `/friends/followers/`, `/friends/following/`, and `/friends/mutual/` with the same UI pattern.
- Followers (and Mutual, which reuses the followers template): searches display name, handle/URL, and summary.
- Following: searches display name, user_login, user_url, and description.
- Search runs in-memory after the category filter so the top-of-page totals stay accurate; pagination and filter/sort selections are preserved when searching. Block-theme renderer in `includes/class-blocks.php` mirrors the same behavior.

## Test plan
- [ ] `/friends/followers/?q=alice` narrows the list to matching followers and shows a match count.
- [ ] `/friends/following/?q=alice` narrows subscriptions to matching people/feeds.
- [ ] `/friends/mutual/?q=alice` narrows mutuals (uses followers template with `filter=following`).
- [ ] Filter and sort selections stay active when typing into the search field and submitting.
- [ ] The "Clear" link returns to the current filter/sort without the search term.
- [ ] Pagination links for searched results include the `q` parameter.
- [ ] `composer check-cs` passes.

[Test in WordPress Playground](https://akirk.github.io/playground-step-library/?redir=1&step[0]=setLandingPage&landingPage[0]=/friends/&step[1]=installPlugin&url[1]=github.com/akirk/friends/tree/feat/search-followers-following-mutual&step[2]=importFriendFeeds&opml[2]=https://alex.kirk.at%20Alex%20Kirk%20https://adamadam.blog%20Adam%20Zieliński)