### PR TITLE
Fix loading indicator propeller effect in themes

### DIFF
--- a/.github/changelog/unreleased/fix-theme-loading-propeller
+++ b/.github/changelog/unreleased/fix-theme-loading-propeller
@@ -1,0 +1,3 @@
+Type: Fixed
+
+Fix loading indicator in Google Reader, Mastodon, and Twitter themes spinning the host element's text like a propeller; use a rotating pseudo-element instead.

--- a/templates/google-reader/google-reader.css
+++ b/templates/google-reader/google-reader.css
@@ -928,9 +928,25 @@
 
 /* === Loading indicator === */
 .friends-page .loading {
-	display: inline-block;
+	color: transparent !important;
+	pointer-events: none;
+	position: relative;
+	min-height: 16px;
+	min-width: 16px;
+	animation: none;
+	border: 0;
+}
+
+.friends-page .loading::after {
+	content: "";
+	display: block;
+	position: absolute;
+	top: 50%;
+	left: 50%;
 	width: 16px;
 	height: 16px;
+	margin-top: -8px;
+	margin-left: -8px;
 	border: 2px solid light-dark(#d4d4d4, #3c4043);
 	border-top-color: #4d90fe;
 	border-radius: 50%;

--- a/templates/mastodon/mastodon.css
+++ b/templates/mastodon/mastodon.css
@@ -1749,9 +1749,25 @@ body.friends-page {
 
 /* === Loading === */
 .friends-page .loading {
-	display: inline-block;
+	color: transparent !important;
+	pointer-events: none;
+	position: relative;
+	min-height: 20px;
+	min-width: 20px;
+	animation: none;
+	border: 0;
+}
+
+.friends-page .loading::after {
+	content: "";
+	display: block;
+	position: absolute;
+	top: 50%;
+	left: 50%;
 	width: 20px;
 	height: 20px;
+	margin-top: -10px;
+	margin-left: -10px;
 	border: 2px solid light-dark(#d4dde8, #393f4f);
 	border-top-color: light-dark(#563acc, #6364ff);
 	border-radius: 50%;

--- a/templates/twitter/twitter.css
+++ b/templates/twitter/twitter.css
@@ -1897,9 +1897,25 @@ body.friends-page {
 
 /* === Loading === */
 .friends-page .loading {
-	display: inline-block;
+	color: transparent !important;
+	pointer-events: none;
+	position: relative;
+	min-height: 20px;
+	min-width: 20px;
+	animation: none;
+	border: 0;
+}
+
+.friends-page .loading::after {
+	content: "";
+	display: block;
+	position: absolute;
+	top: 50%;
+	left: 50%;
 	width: 20px;
 	height: 20px;
+	margin-top: -10px;
+	margin-left: -10px;
 	border: 2px solid light-dark(#eff3f4, #2f3336);
 	border-top-color: #1d9bf0;
 	border-radius: 50%;


### PR DESCRIPTION
## Summary
- In the Google Reader, Mastodon, and Twitter themes, the `.friends-page .loading` rule was applied directly to the host element and rotated the whole element — spinning button text/emoji like a propeller (e.g. on reaction buttons).
- Aligned each theme with the default theme's pattern: the host gets `color: transparent` and no animation; a `::after` pseudo-element carries the border and rotation. Each theme keeps its own colors and size.

## Test plan
- [ ] In each of Google Reader, Mastodon, and Twitter themes, click a reaction on a friend post and confirm the spinner shows without the emoji/count text visibly rotating.
- [ ] Reblog from a themed post and confirm loading feedback is a clean spinner, not spinning text.
- [ ] Verify standalone `<i class=\"loading\"></i>` indicators (comments loading, pagination) still render a visible spinner.
- [Test in WordPress Playground](https://akirk.github.io/playground-step-library/?redir=1&step[0]=setLandingPage&landingPage[0]=/friends/&step[1]=installPlugin&url[1]=github.com/akirk/friends/tree/fix/theme-loading-propeller&step[2]=importFriendFeeds&opml[2]=https://alex.kirk.at%20Alex%20Kirk%20https://adamadam.blog%20Adam%20Zieliński)