### PR TITLE
Fix fatal error in follower notifications with ActivityPub 7.5.0+

### DIFF
--- a/.github/changelog/unreleased/fix-issue-660-wp-post-undefined-method
+++ b/.github/changelog/unreleased/fix-issue-660-wp-post-undefined-method
@@ -1,0 +1,3 @@
+Type: Fixed
+
+Avoid a fatal error in follower notifications when the ActivityPub plugin (7.5.0+) passes a WP_Post instead of a Follower model — the email handlers now resolve the Actor via Remote_Actors so new- and lost-follower emails work again, ending the inbox retry loop that this caused.

--- a/includes/class-notifications.php
+++ b/includes/class-notifications.php
@@ -349,10 +349,10 @@ class Notifications {
 	/**
 	 * Notify of a follower
 	 *
-	 * @param string                     $actor    The Actor URL.
-	 * @param array                      $activitypub_object   The Activity object.
-	 * @param int                        $user_id  The ID of the WordPress User.
-	 * @param Activitypub\Model\Follower $follower The Follower object.
+	 * @param string                               $actor              The Actor URL.
+	 * @param array                                $activitypub_object The Activity object.
+	 * @param int                                  $user_id            The ID of the WordPress User.
+	 * @param \WP_Post|\Activitypub\Activity\Actor $follower           The Actor post (since ActivityPub 7.5.0) or Actor object.
 	 *
 	 * @return void
 	 */
@@ -366,6 +366,15 @@ class Notifications {
 		}
 		if ( ! $user->user_email ) {
 			return;
+		}
+
+		$follower_post = null;
+		if ( $follower instanceof \WP_Post ) {
+			$follower_post = $follower;
+			$follower = \Activitypub\Collection\Remote_Actors::get_actor( $follower_post );
+			if ( is_wp_error( $follower ) ) {
+				return;
+			}
 		}
 
 		if ( ! apply_filters( 'notify_user_about_new_follower', true, $user, $actor, $activitypub_object, $follower ) ) {
@@ -384,6 +393,10 @@ class Notifications {
 			$following = false;
 		}
 
+		$icon_url = $follower_post
+			? \Activitypub\Collection\Remote_Actors::get_avatar_url( $follower_post->ID )
+			: \ActivityPub\object_to_uri( $follower->get_icon() );
+
 		// translators: %s is a user display name.
 		$email_title = sprintf( __( 'New Follower: %s', 'friends' ), $follower->get_name() . '@' . $server );
 
@@ -391,6 +404,7 @@ class Notifications {
 			'user'      => $user,
 			'url'       => $url,
 			'follower'  => $follower,
+			'icon_url'  => $icon_url,
 			'server'    => $server,
 			'following' => $following,
 		);
@@ -415,9 +429,9 @@ class Notifications {
 	/**
 	 * Notify of a lost follower
 	 *
-	 * @param Activitypub\Model\Follower $follower The Follower object.
-	 * @param int                        $user_id  The ID of the WordPress User.
-	 * @param string                     $actor    The Actor URL.
+	 * @param \WP_Post|\Activitypub\Activity\Actor $follower The Actor post (since ActivityPub 7.0.0) or Actor object.
+	 * @param int                                  $user_id  The ID of the WordPress User.
+	 * @param string|\Activitypub\Activity\Actor   $actor    The Actor URL or Actor object.
 	 *
 	 * @return void
 	 */
@@ -433,12 +447,33 @@ class Notifications {
 			return;
 		}
 
+		$follower_post = null;
+		$published = null;
+		if ( $follower instanceof \WP_Post ) {
+			$follower_post = $follower;
+			$published = $follower_post->post_date_gmt;
+			if ( $actor instanceof \Activitypub\Activity\Actor ) {
+				$follower = $actor;
+			} else {
+				$follower = \Activitypub\Collection\Remote_Actors::get_actor( $follower_post );
+				if ( is_wp_error( $follower ) ) {
+					return;
+				}
+			}
+		} else {
+			$published = $follower->get_published();
+		}
+
 		if ( ! apply_filters( 'notify_user_about_lost_follower', true, $user, $actor, $follower ) ) {
 			return;
 		}
 
 		$url = \ActivityPub\object_to_uri( $follower->get( 'id' ) );
 		$server = wp_parse_url( $url, PHP_URL_HOST );
+
+		$icon_url = $follower_post
+			? \Activitypub\Collection\Remote_Actors::get_avatar_url( $follower_post->ID )
+			: \ActivityPub\object_to_uri( $follower->get_icon() );
 
 		// translators: %s is a user display name.
 		$email_title = sprintf( __( 'Lost Follower: %s', 'friends' ), $follower->get_name() . '@' . $server );
@@ -447,11 +482,12 @@ class Notifications {
 			'user'     => $user,
 			'url'      => $url,
 			'follower' => $follower,
+			'icon_url' => $icon_url,
 			'server'   => $server,
-			'duration' => human_time_diff( strtotime( $follower->get_published() ) ) . ' (' . sprintf(
+			'duration' => human_time_diff( strtotime( $published ) ) . ' (' . sprintf(
 				// translators: %s is a time duration.
 				__( 'since %s', 'friends' ),
-				$follower->get_published()
+				$published
 			) . ')',
 
 		);

--- a/includes/class-notifications.php
+++ b/includes/class-notifications.php
@@ -368,6 +368,10 @@ class Notifications {
 			return;
 		}
 
+		if ( is_wp_error( $follower ) ) {
+			return;
+		}
+
 		$follower_post = null;
 		if ( $follower instanceof \WP_Post ) {
 			$follower_post = $follower;
@@ -429,7 +433,7 @@ class Notifications {
 	/**
 	 * Notify of a lost follower
 	 *
-	 * @param \WP_Post|\Activitypub\Activity\Actor $follower The Actor post (since ActivityPub 7.0.0) or Actor object.
+	 * @param \WP_Post|\Activitypub\Activity\Actor $follower The Actor post (since ActivityPub 7.5.0) or Actor object.
 	 * @param int                                  $user_id  The ID of the WordPress User.
 	 * @param string|\Activitypub\Activity\Actor   $actor    The Actor URL or Actor object.
 	 *

--- a/templates/email/lost-follower.php
+++ b/templates/email/lost-follower.php
@@ -24,7 +24,7 @@
 	<tr>
 		<td style="vertical-align: top">
 			<a href="<?php echo esc_url( $args['follower']->get_url() ); ?>" style="float: left; margin-right: 1em;">
-				<img src="<?php echo esc_url( $args['follower']->get_icon_url() ); /* phpcs:ignore PluginCheck.CodeAnalysis.ImageFunctions.NonEnqueuedImage */ ?>" alt="<?php echo esc_attr( $args['follower']->get_name() ); ?>" width="64" height="64">
+				<img src="<?php echo esc_url( $args['icon_url'] ); /* phpcs:ignore PluginCheck.CodeAnalysis.ImageFunctions.NonEnqueuedImage */ ?>" alt="<?php echo esc_attr( $args['follower']->get_name() ); ?>" width="64" height="64">
 			</a>
 		</td>
 		<td>

--- a/templates/email/new-follower.php
+++ b/templates/email/new-follower.php
@@ -24,7 +24,7 @@
 	<tr>
 		<td style="vertical-align: top">
 			<a href="<?php echo esc_url( $args['follower']->get_url() ); ?>" style="float: left; margin-right: 1em;">
-				<img src="<?php echo esc_url( $args['follower']->get_icon_url() ); /* phpcs:ignore PluginCheck.CodeAnalysis.ImageFunctions.NonEnqueuedImage */ ?>" alt="<?php echo esc_attr( $args['follower']->get_name() ); ?>" width="64" height="64">
+				<img src="<?php echo esc_url( $args['icon_url'] ); /* phpcs:ignore PluginCheck.CodeAnalysis.ImageFunctions.NonEnqueuedImage */ ?>" alt="<?php echo esc_attr( $args['follower']->get_name() ); ?>" width="64" height="64">
 			</a>
 		</td>
 		<td>


### PR DESCRIPTION
## Summary

Fixes #660 — `Call to undefined method WP_Post::get()` fatal in `class-notifications.php` when receiving a follow / unfollow from the Fediverse.

ActivityPub 7.5.0 changed the `activitypub_followers_post_follow` and `activitypub_followers_pre_remove_follower` hooks to pass a `WP_Post` for the follower rather than the (now deprecated) `Follower` model. The Friends notification handlers were still calling `Follower` methods on it (`get()`, `get_url()`, `get_name()`, …), throwing `E_ERROR`. The inbox endpoint then returned HTTP 500, so the sending Mastodon server retried the delivery several times — which is what caused the duplicate notification emails and the missing replies in the UI described in the report.

This PR:

- Detects when the follower argument is a `WP_Post` and resolves it to an `Activitypub\Activity\Actor` via `Remote_Actors::get_actor()`.
- Computes the avatar via `Remote_Actors::get_avatar_url()` (the `Actor` class has no `get_icon_url()`) and passes it to the email templates as a new `icon_url` arg.
- Reads the follow start date from the `WP_Post`'s `post_date_gmt` for the lost-follower duration calculation.
- Keeps backward compatibility with the old `Follower` model in case the hook is still called the old way.

The outgoing-reply duplication mentioned in the issue is a downstream symptom of the same retry loop and should also be resolved once the inbox stops 500ing.

## Test plan

- [ ] Have a Mastodon account follow a WordPress user with the Friends + ActivityPub plugins (≥ 7.5.0) installed — confirm a single new-follower email arrives and no fatal is logged.
- [ ] Have the Mastodon account reply to a post — confirm the reply arrives once and shows up in the Friends UI / WP comments.
- [ ] Have the Mastodon account unfollow — confirm a single lost-follower email arrives with the correct duration.
- [ ] Smoke-test outgoing reply from Friends UI — appears once locally, not three times.

[Test in WordPress Playground](https://akirk.github.io/playground-step-library/?redir=1&step[0]=setLandingPage&landingPage[0]=/friends/&step[1]=installPlugin&url[1]=github.com/akirk/friends/tree/fix/issue-660-wp-post-undefined-method&step[2]=importFriendFeeds&opml[2]=https://alex.kirk.at%20Alex%20Kirk%20https://adamadam.blog%20Adam%20Zieliński)