### PR TITLE
Promote the Friends browser extension

### DIFF
--- a/.github/changelog/unreleased/promote-browser-extension
+++ b/.github/changelog/unreleased/promote-browser-extension
@@ -1,0 +1,3 @@
+Type: changed
+
+Surface the Friends browser extension in more places so users can discover it: the Browser Extension submenu is now always visible under Friends, the settings page describes what the extension does and links to the Chrome and Firefox stores, and the Tools → Bookmarklets card and README mention it as well.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ You can...
 - Get full-post email notifications from your favorite blogs.
 - Save posts to a collection for later reference (via the Post Collection plugin).
 - Send posts to your eReader (via the Send to E-Reader plugin).
+- Subscribe to any site with one click using the [Friends browser extension](https://chromewebstore.google.com/detail/friends/ledbghpaplkpclndlommpbokndieflhl) (also available [for Firefox](https://addons.mozilla.org/en-US/firefox/addon/wpfriends/)).
 
 [![Friends Plugin Demo on Youtube](img/friends-plugin-youtube-thumbnail.png)](https://www.youtube.com/watch?v=4bz6GluXnsk)
 
@@ -60,6 +61,9 @@ That's exactly the point — with WordPress you own your data and decide where t
 
 ### What happens if I modify or delete a post?
 Cached posts are stored as the custom post type `friend_post_cache`. When you unfollow someone, their cached posts are removed with them.
+
+### Is there a browser extension?
+Yes — install it for [Chrome](https://chromewebstore.google.com/detail/friends/ledbghpaplkpclndlommpbokndieflhl) or [Firefox](https://addons.mozilla.org/en-US/firefox/addon/wpfriends/). It adds a toolbar button that lets you subscribe to the site you are currently visiting with one click. Pair it with the API key on the Friends → Browser Extension page to also expose quick actions from other Friends-aware plugins (saving to a collection, sending to your eReader, etc.).
 
 ## Screenshots
 

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -187,10 +187,8 @@ class Admin {
 			add_submenu_page( 'friends', $title, $title, $required_role, 'friends-logs', array( $this, 'render_friends_logs' ) );
 		}
 
-		if ( isset( $_GET['page'] ) && 'friends-browser-extension' === $_GET['page'] ) {
-			$title = __( 'Browser Extension', 'friends' );
-			add_submenu_page( 'friends', $title, $title, $required_role, 'friends-browser-extension', array( $this, 'render_browser_extension' ) );
-		}
+		$title = __( 'Browser Extension', 'friends' );
+		add_submenu_page( 'friends', $title, $title, $required_role, 'friends-browser-extension', array( $this, 'render_browser_extension' ) );
 
 		if ( isset( $_GET['page'] ) && 'unfriend' === $_GET['page'] ) {
 			$user = new User( intval( $_GET['user'] ) );
@@ -606,6 +604,11 @@ class Admin {
 		return apply_filters(
 			'friends_news_entries',
 			array(
+				array(
+					'version'  => '4.1',
+					'title'    => __( '4.1: Twitter Theme & Browser Extension', 'friends' ),
+					'template' => 'admin/news-4-1',
+				),
 				array(
 					'version'           => '4.0',
 					'title'             => __( '4.0: A Major Update', 'friends' ),
@@ -2778,8 +2781,10 @@ class Admin {
 			</p>
 			<h3><?php esc_html_e( 'Browser Extension', 'friends' ); ?></h3>
 
-			<p><?php esc_html_e( 'There is also the option to use a browser extension.', 'friends' ); ?></p>
+			<p><?php esc_html_e( 'For a smoother experience, install the Friends browser extension. It adds a toolbar button to subscribe to the current site with one click, plus quick actions provided by other Friends-aware plugins.', 'friends' ); ?></p>
 			<p>
+				<a href="https://chromewebstore.google.com/detail/friends/ledbghpaplkpclndlommpbokndieflhl"><?php esc_html_e( 'Chrome Extension', 'friends' ); ?></a>
+				&nbsp;·&nbsp;
 				<a href="https://addons.mozilla.org/en-US/firefox/addon/wpfriends/"><?php esc_html_e( 'Firefox Extension', 'friends' ); ?></a>
 			</p>
 		</div>

--- a/templates/admin/browser-extension.php
+++ b/templates/admin/browser-extension.php
@@ -2,11 +2,26 @@
 /**
  * This template contains the browser extension settings
  *
- * @version 1.0
+ * @version 1.1
  * @package Friends
  */
 
-?><form method="post">
+?>
+<div class="friends-browser-extension-promo card" style="max-width: 100%; padding: 1em 1.5em;">
+	<h2><?php esc_html_e( 'Friends Browser Extension', 'friends' ); ?></h2>
+	<p><?php esc_html_e( 'The browser extension lets you subscribe to any site you are visiting with one click — no more copy-pasting URLs into the Add Friend page.', 'friends' ); ?></p>
+	<p><?php esc_html_e( 'With your API key (below), the extension also exposes quick actions from your toolbar — for example, saving the current page to a collection or sending it to your eReader (if you have those companion plugins installed).', 'friends' ); ?></p>
+	<p>
+		<a class="button button-primary" href="https://chromewebstore.google.com/detail/friends/ledbghpaplkpclndlommpbokndieflhl" target="_blank" rel="noopener noreferrer">
+			<?php esc_html_e( 'Install for Chrome', 'friends' ); ?>
+		</a>
+		<a class="button button-primary" href="https://addons.mozilla.org/en-US/firefox/addon/wpfriends/" target="_blank" rel="noopener noreferrer">
+			<?php esc_html_e( 'Install for Firefox', 'friends' ); ?>
+		</a>
+	</p>
+</div>
+
+<form method="post">
 	<?php wp_nonce_field( 'friends-browser-extension' ); ?>
 	<table class="form-table">
 		<tbody>
@@ -19,7 +34,7 @@
 					<?php if ( ! empty( $args['browser-api-key'] ) ) : ?>
 						<button class="button button-destructive" name="revoke-api-key"><?php esc_html_e( 'Revoke', 'friends' ); ?></button>
 					<?php endif; ?>
-					<p class="description"><?php esc_html_e( 'With this API key, more features will be enabled in the browser extension.', 'friends' ); ?></p>
+					<p class="description"><?php esc_html_e( 'Paste this API key into the browser extension to enable additional features such as plugin-provided actions.', 'friends' ); ?></p>
 				</td>
 			</tr>
 		</tbody>

--- a/templates/admin/news-4-1.php
+++ b/templates/admin/news-4-1.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * This template contains the Friends 4.1 news entry.
+ *
+ * @package Friends
+ */
+
+?>
+<div class="friends-news-entry-body">
+	<h2><?php esc_html_e( 'Friends 4.1: Twitter Theme & Browser Extension', 'friends' ); ?></h2>
+
+	<div class="friends-news-changes">
+		<div class="friends-news-change">
+			<h4><?php esc_html_e( 'Twitter Theme', 'friends' ); ?></h4>
+			<p><?php esc_html_e( 'A Twitter-inspired frontend theme with a familiar three-column layout, an inline compose box, and a right-column widget area. Pick it from Friends → Settings → Theme.', 'friends' ); ?></p>
+		</div>
+
+		<div class="friends-news-change">
+			<h4><?php esc_html_e( 'Browser Extension', 'friends' ); ?></h4>
+			<p>
+				<?php esc_html_e( 'Subscribe to any site you are visiting with one click — install the Friends browser extension for Chrome or Firefox. Once installed, paste your API key from Friends → Browser Extension to also expose quick actions from companion plugins (Post Collection, Send to E-Reader, etc.) right from your toolbar.', 'friends' ); ?>
+			</p>
+			<p>
+				<a class="button button-primary" href="https://chromewebstore.google.com/detail/friends/ledbghpaplkpclndlommpbokndieflhl" target="_blank" rel="noopener noreferrer">
+					<?php esc_html_e( 'Install for Chrome', 'friends' ); ?>
+				</a>
+				<a class="button button-primary" href="https://addons.mozilla.org/en-US/firefox/addon/wpfriends/" target="_blank" rel="noopener noreferrer">
+					<?php esc_html_e( 'Install for Firefox', 'friends' ); ?>
+				</a>
+			</p>
+		</div>
+	</div>
+</div>


### PR DESCRIPTION
## Summary

The Browser Extension settings page was only hot-linked from the extension itself, so there was no way for users to discover the extension exists from inside WordPress. This PR adds discovery surfaces:

- **Friends menu** — the *Browser Extension* submenu is now always visible (was previously registered only when the URL already targeted it).
- **Browser Extension settings page** — leads with a description of what the extension does plus Install buttons for Chrome and Firefox, then the API key below. Now works for both audiences (people exploring before install, people landing from the extension after install).
- **Tools → Bookmarklets card** — adds the Chrome link alongside Firefox and expands the one-line description.
- **README.md** — feature bullet under "You can…" plus a new FAQ entry, so the extension shows up on wordpress.org/plugins/friends.
- **News page** — new 4.1 entry covering the Twitter theme (shipped in 4.0.6) and the browser extension.

## Test plan

- [ ] Visit Friends → Browser Extension and confirm the promo block, install buttons, and API key all render correctly.
- [ ] Confirm the *Browser Extension* item appears in the Friends submenu without needing to be on the page already.
- [ ] Visit Tools and confirm the bookmarklets card shows both Chrome and Firefox links.
- [ ] Visit Friends → Home (News) and confirm the new 4.1 entry appears at the top of the TOC with the Twitter theme and Browser Extension cards.
- [ ] Verify the install links open the correct Chrome Web Store and addons.mozilla.org pages.

<details><summary>Changelog</summary>

- [x] Automatically create a changelog entry from the details below

#### Type
- [x] Changed

#### Message
Surface the Friends browser extension in more places so users can discover it: the Browser Extension submenu is now always visible under Friends, the settings page describes what the extension does and links to the Chrome and Firefox stores, and the Tools → Bookmarklets card and README mention it as well.

</details>