### PR TITLE
Document category field for browser extension actions

### DIFF
--- a/.github/changelog/unreleased/664-from-description
+++ b/.github/changelog/unreleased/664-from-description
@@ -1,0 +1,3 @@
+Type: changed
+
+Document that a category can be specified.

--- a/includes/class-rest.php
+++ b/includes/class-rest.php
@@ -290,6 +290,7 @@ class REST {
 				 * - `url` (string, required) — target URL; may contain `{current_url}` which the extension substitutes with the current page URL (URL-encoded).
 				 * - `method` (string, optional) — if `"POST"`, the extension submits a form instead of opening a link.
 				 * - `fields` (object, optional) — for POST actions, key/value pairs of form fields; values may contain `{current_url}` (raw) and `{page_html}` placeholders.
+				 * - `category` (string, optional) — groups actions under a named header; actions without a category appear under the default "Actions" header.
 				 *
 				 * Example:
 				 * ```php


### PR DESCRIPTION
## Summary

- Adds `category` to the `friends_browser_extension_actions` filter docblock as an optional field
- Actions without a category appear under the default "Actions" header in the extension popup

## Test plan

- [ ] Verify that a plugin providing an action with a `category` field has it grouped under that header in the extension popup
- [ ] Verify that actions without `category` still appear under the default "Actions" header
- [ ] 
### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- A GitHub workflow will create and push the entry into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

- [x] Automatically create a changelog entry from the details below.

<details>

<summary>Add category support for browser extension</summary>

#### Type

<!-- Choose only one -->

- [ ] Added - for new features
- [x] Changed - for changes in existing functionality
- [ ] Fixed - for any bug fixes
- [ ] Removed - for now removed features

#### Message

Document that a category can be specified.

</details>
