### PR TITLE
Add generic browser extension action dispatch

### DIFF
--- a/.github/changelog/unreleased/main
+++ b/.github/changelog/unreleased/main
@@ -1,0 +1,3 @@
+Type: changed
+
+Add generic inline browser extension action dispatching so companion plugins can provide authenticated in-popup actions through Friends filters.

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -2430,7 +2430,12 @@ class Admin {
 	}
 
 
-	public static function check_browser_api_key( $key ) {
+	public static function get_browser_api_key_user( $key ) {
+		$key = (string) $key;
+		if ( ! $key ) {
+			return false;
+		}
+
 		$parts = explode( '-', $key, 3 );
 		if ( 3 !== count( $parts ) ) {
 			return false;
@@ -2441,12 +2446,21 @@ class Admin {
 			return false;
 		}
 
-		$desired_key = self::get_browser_api_key( $user_id );
-		if ( ! $desired_key ) {
+		$desired_key = get_user_option( 'friends_browser_api_key', $user_id );
+		if ( ! $desired_key || ! hash_equals( (string) $desired_key, (string) $key ) ) {
 			return false;
 		}
 
-		return $key === $desired_key;
+		$user = get_user_by( 'ID', $user_id );
+		if ( ! $user ) {
+			return false;
+		}
+
+		return $user;
+	}
+
+	public static function check_browser_api_key( $key ) {
+		return false !== self::get_browser_api_key_user( $key );
 	}
 
 	public static function revoke_browser_api_key( $user_id = false ) {

--- a/includes/class-rest.php
+++ b/includes/class-rest.php
@@ -119,6 +119,26 @@ class REST {
 				),
 			)
 		);
+
+		register_rest_route(
+			self::PREFIX,
+			'extension/action',
+			array(
+				'methods'             => 'POST',
+				'callback'            => array( $this, 'rest_extension_action' ),
+				'permission_callback' => array( $this, 'browser_extension_action_permission_callback' ),
+				'args'                => array(
+					'action' => array(
+						'type'     => 'string',
+						'required' => true,
+					),
+					'key'    => array(
+						'type'     => 'string',
+						'required' => true,
+					),
+				),
+			)
+		);
 	}
 
 	/**
@@ -279,8 +299,9 @@ class REST {
 		);
 
 		if ( 'POST' === $request->get_method() && $request->get_param( 'key' ) ) {
-			if ( Admin::check_browser_api_key( $request->get_param( 'key' ) ) ) {
-				$current_user = wp_get_current_user();
+			$current_user = self::get_browser_extension_user( $request->get_param( 'key' ) );
+			if ( ! is_wp_error( $current_user ) ) {
+				$context = $this->get_browser_extension_request_context( $request, $current_user );
 
 				/**
 				 * Allows plugins to register actions for the Friends browser extension.
@@ -290,24 +311,33 @@ class REST {
 				 * - `url` (string, required) — target URL; may contain `{current_url}` which the extension substitutes with the current page URL (URL-encoded).
 				 * - `method` (string, optional) — if `"POST"`, the extension submits a form instead of opening a link.
 				 * - `fields` (object, optional) — for POST actions, key/value pairs of form fields; values may contain `{current_url}` (raw) and `{page_html}` placeholders.
+				 * - `run` (string, optional) — if `"inline"`, the extension handles the response in place instead of opening a new tab.
+				 * - `inputs` (array, optional) — user-editable fields for inline actions.
 				 * - `category` (string, optional) — groups actions under a named header; actions without a category appear under the default "Actions" header.
 				 *
 				 * Example:
 				 * ```php
-				 * add_filter( 'friends_browser_extension_actions', function ( $actions, $current_user ) {
+				 * add_filter( 'friends_browser_extension_actions', function ( $actions, $current_user, $context ) {
 				 *     $actions[] = array(
 				 *         'name' => 'Save to Collection',
 				 *         'url'  => home_url( '/collect/?url={current_url}' ),
 				 *     );
 				 *     return $actions;
-				 * }, 10, 2 );
+				 * }, 10, 3 );
 				 * ```
 				 *
 				 * @param array    $actions      The array of actions.
 				 * @param \WP_User $current_user The current user.
+				 * @param array    $context      Browser extension request context: key, version, user, and request.
 				 * @return array The modified array of actions.
 				 */
-				$actions = apply_filters( 'friends_browser_extension_actions', array(), $current_user );
+				$previous_user_id = get_current_user_id();
+				wp_set_current_user( $current_user->ID );
+				try {
+					$actions = apply_filters( 'friends_browser_extension_actions', array(), $current_user, $context );
+				} finally {
+					wp_set_current_user( $previous_user_id );
+				}
 
 				$return['actions'] = array_values(
 					array_filter(
@@ -329,6 +359,191 @@ class REST {
 		return $return;
 	}
 
+	/**
+	 * Validate a browser extension inline action request.
+	 *
+	 * @param \WP_REST_Request $request The REST request.
+	 * @return true|\WP_Error True if the request is allowed, otherwise an error.
+	 */
+	public function browser_extension_action_permission_callback( $request ) {
+		$current_user = self::get_browser_extension_user( $request->get_param( 'key' ) );
+		if ( is_wp_error( $current_user ) ) {
+			return new \WP_Error(
+				$current_user->get_error_code(),
+				$current_user->get_error_message(),
+				array( 'status' => 401 )
+			);
+		}
+
+		$attributes                                      = $request->get_attributes();
+		$attributes['friends_browser_extension_user']    = $current_user;
+		$attributes['friends_browser_extension_context'] = $this->get_browser_extension_request_context( $request, $current_user );
+		$request->set_attributes( $attributes );
+
+		return true;
+	}
+
+	/**
+	 * Handle a browser extension inline action.
+	 *
+	 * @param \WP_REST_Request $request The REST request.
+	 * @return \WP_REST_Response The REST response.
+	 */
+	public function rest_extension_action( $request ) {
+		$url_params = $request->get_url_params();
+		$action     = isset( $url_params['action'] ) ? $url_params['action'] : $request->get_param( 'action' );
+		$action     = sanitize_key( (string) wp_unslash( $action ) );
+		if ( ! $action ) {
+			return self::browser_extension_action_error(
+				new \WP_Error( 'friends_missing_browser_extension_action', __( 'No browser extension action was provided.', 'friends' ) ),
+				400
+			);
+		}
+
+		$attributes   = $request->get_attributes();
+		$current_user = isset( $attributes['friends_browser_extension_user'] ) ? $attributes['friends_browser_extension_user'] : self::get_browser_extension_user( $request->get_param( 'key' ) );
+		if ( is_wp_error( $current_user ) ) {
+			return self::browser_extension_action_error( $current_user, 401 );
+		}
+
+		$context           = isset( $attributes['friends_browser_extension_context'] ) ? $attributes['friends_browser_extension_context'] : $this->get_browser_extension_request_context( $request, $current_user );
+		$context['action'] = $action;
+
+		$previous_user_id = get_current_user_id();
+		wp_set_current_user( $current_user->ID );
+
+		try {
+			/**
+			 * Handles a browser extension inline action.
+			 *
+			 * Return a \WP_REST_Response, \WP_Error, array, or scalar value. Returning null means the action
+			 * was not handled.
+			 *
+			 * @param mixed            $response     The action response.
+			 * @param string           $action       The browser extension action name.
+			 * @param \WP_REST_Request $request      The REST request.
+			 * @param \WP_User         $current_user The user authenticated by the browser extension key.
+			 * @param array            $context      Browser extension request context.
+			 */
+			$response = apply_filters( 'friends_browser_extension_action', null, $action, $request, $current_user, $context );
+
+			/**
+			 * Handles a specific browser extension inline action.
+			 *
+			 * The dynamic portion of the hook name, `$action`, is the sanitized action name from the
+			 * request's `action` parameter.
+			 *
+			 * @param mixed            $response     The action response.
+			 * @param \WP_REST_Request $request      The REST request.
+			 * @param \WP_User         $current_user The user authenticated by the browser extension key.
+			 * @param array            $context      Browser extension request context.
+			 */
+			$response = apply_filters( "friends_browser_extension_action_{$action}", $response, $request, $current_user, $context );
+		} finally {
+			wp_set_current_user( $previous_user_id );
+		}
+
+		if ( null === $response ) {
+			return self::browser_extension_action_error(
+				new \WP_Error( 'friends_unknown_browser_extension_action', __( 'Unknown browser extension action.', 'friends' ) ),
+				404
+			);
+		}
+
+		return self::prepare_browser_extension_action_response( $response );
+	}
+
+	/**
+	 * Get the user authenticated by a browser extension key.
+	 *
+	 * @param string $key The browser extension API key.
+	 * @return \WP_User|\WP_Error The authenticated user or an error.
+	 */
+	private static function get_browser_extension_user( $key ) {
+		$key = sanitize_text_field( (string) wp_unslash( $key ) );
+		if ( ! $key ) {
+			return new \WP_Error( 'friends_invalid_browser_extension_key', __( 'Invalid API key', 'friends' ) );
+		}
+
+		$user = Admin::get_browser_api_key_user( $key );
+		if ( ! $user ) {
+			return new \WP_Error( 'friends_invalid_browser_extension_key', __( 'Invalid API key', 'friends' ) );
+		}
+
+		return $user;
+	}
+
+	/**
+	 * Build browser extension request context for plugin filters.
+	 *
+	 * @param \WP_REST_Request $request      The REST request.
+	 * @param \WP_User         $current_user The user authenticated by the browser extension key.
+	 * @return array Browser extension request context.
+	 */
+	private function get_browser_extension_request_context( $request, $current_user ) {
+		$key     = sanitize_text_field( (string) wp_unslash( $request->get_param( 'key' ) ) );
+		$version = sanitize_text_field( (string) wp_unslash( $request->get_param( 'version' ) ) );
+
+		if ( ! $version ) {
+			$version = sanitize_text_field( (string) wp_unslash( $request->get_param( 'extension_version' ) ) );
+		}
+
+		return array(
+			'key'                   => $key,
+			'browser_extension_key' => $key,
+			'version'               => $version,
+			'extension_version'     => $version,
+			'user'                  => $current_user,
+			'request'               => $request,
+		);
+	}
+
+	/**
+	 * Prepare a browser extension action response.
+	 *
+	 * @param mixed $response The handler response.
+	 * @return \WP_REST_Response The REST response.
+	 */
+	private static function prepare_browser_extension_action_response( $response ) {
+		if ( is_wp_error( $response ) ) {
+			return self::browser_extension_action_error( $response, 400 );
+		}
+
+		if ( $response instanceof \WP_REST_Response ) {
+			return $response;
+		}
+
+		if ( true === $response ) {
+			$response = array(
+				'success' => true,
+			);
+		}
+
+		return rest_ensure_response( $response );
+	}
+
+	/**
+	 * Format a browser extension action error response.
+	 *
+	 * @param \WP_Error $error  The error.
+	 * @param int       $status The default HTTP status.
+	 * @return \WP_REST_Response The REST response.
+	 */
+	private static function browser_extension_action_error( \WP_Error $error, $status ) {
+		$error_data = $error->get_error_data();
+		if ( is_array( $error_data ) && ! empty( $error_data['status'] ) ) {
+			$status = absint( $error_data['status'] );
+		}
+
+		return new \WP_REST_Response(
+			array(
+				'success' => false,
+				'code'    => $error->get_error_code(),
+				'message' => $error->get_error_message(),
+			),
+			$status
+		);
+	}
 
 	/**
 	 * Discover the REST URL for a friend site

--- a/tests/test-rest.php
+++ b/tests/test-rest.php
@@ -135,4 +135,135 @@ class RestTest extends Friends_TestCase_Cache_HTTP {
 		}
 	}
 
+	/**
+	 * Check that browser extension action filters receive the authenticated user and context.
+	 */
+	public function test_extension_actions_receive_user_and_context() {
+		$user_id = self::factory()->user->create(
+			array(
+				'role'         => 'administrator',
+				'display_name' => 'Extension User',
+			)
+		);
+		$key     = Admin::get_browser_api_key( $user_id );
+
+		wp_set_current_user( 0 );
+
+		$received = array();
+		$callback = function ( $actions, $current_user, $context ) use ( &$received ) {
+			$received = array(
+				'user_id'             => $current_user->ID,
+				'current_user_id'     => get_current_user_id(),
+				'key'                 => $context['key'],
+				'extension_version'   => $context['extension_version'],
+			);
+
+			$actions[] = array(
+				'name' => 'Inline Action',
+				'url'  => rest_url( REST::PREFIX . '/extension/action' ),
+				'run'  => 'inline',
+			);
+
+			return $actions;
+		};
+
+		add_filter( 'friends_browser_extension_actions', $callback, 10, 3 );
+
+		$request = new \WP_REST_Request( 'POST', '/' . REST::PREFIX . '/extension' );
+		$request->set_param( 'key', $key );
+		$request->set_param( 'version', '1.6.0' );
+
+		$response = $this->server->dispatch( $request );
+		remove_filter( 'friends_browser_extension_actions', $callback, 10 );
+
+		$data = $response->get_data();
+
+		$this->assertSame( $user_id, $received['user_id'] );
+		$this->assertSame( $user_id, $received['current_user_id'] );
+		$this->assertSame( $key, $received['key'] );
+		$this->assertSame( '1.6.0', $received['extension_version'] );
+		$this->assertCount( 1, $data['actions'] );
+		$this->assertSame( 'inline', $data['actions'][0]['run'] );
+		$this->assertSame( 0, get_current_user_id() );
+	}
+
+	/**
+	 * Check that inline browser extension actions are dispatched through a filter.
+	 */
+	public function test_extension_action_dispatches_to_filter() {
+		$user_id = self::factory()->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
+		$key     = Admin::get_browser_api_key( $user_id );
+
+		wp_set_current_user( 0 );
+
+		$received = array();
+		$callback = function ( $response, $action, $request, $current_user, $context ) use ( &$received ) {
+			$received = array(
+				'action'          => $action,
+				'current_user_id' => get_current_user_id(),
+				'filter_user_id'  => $current_user->ID,
+				'context_version' => $context['version'],
+			);
+
+			return array(
+				'success' => true,
+				'message' => 'Saved.',
+				'url'     => $request->get_param( 'url' ),
+			);
+		};
+
+		add_filter( 'friends_browser_extension_action', $callback, 10, 5 );
+
+		$request = new \WP_REST_Request( 'POST', '/' . REST::PREFIX . '/extension/action' );
+		$request->set_param( 'action', 'save' );
+		$request->set_param( 'key', $key );
+		$request->set_param( 'version', '1.6.0' );
+		$request->set_param( 'url', 'https://example.org/post' );
+
+		$response = $this->server->dispatch( $request );
+		remove_filter( 'friends_browser_extension_action', $callback, 10 );
+
+		$data = $response->get_data();
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertTrue( $data['success'] );
+		$this->assertSame( 'Saved.', $data['message'] );
+		$this->assertSame( 'https://example.org/post', $data['url'] );
+		$this->assertSame( 'save', $received['action'] );
+		$this->assertSame( $user_id, $received['current_user_id'] );
+		$this->assertSame( $user_id, $received['filter_user_id'] );
+		$this->assertSame( '1.6.0', $received['context_version'] );
+		$this->assertSame( 0, get_current_user_id() );
+	}
+
+	/**
+	 * Check that inline browser extension actions reject invalid API keys.
+	 */
+	public function test_extension_action_rejects_invalid_key() {
+		$called   = false;
+		$callback = function () use ( &$called ) {
+			$called = true;
+			return true;
+		};
+
+		add_filter( 'friends_browser_extension_action_save', $callback );
+
+		$request = new \WP_REST_Request( 'POST', '/' . REST::PREFIX . '/extension/action' );
+		$request->set_param( 'action', 'save' );
+		$request->set_param( 'key', 'invalid' );
+
+		$response = $this->server->dispatch( $request );
+		remove_filter( 'friends_browser_extension_action_save', $callback );
+
+		$data = $response->get_data();
+
+		$this->assertSame( 401, $response->get_status() );
+		$this->assertSame( 'friends_invalid_browser_extension_key', $data['code'] );
+		$this->assertFalse( $called );
+	}
+
 }


### PR DESCRIPTION
Summary:
- add a generic Friends browser extension inline action dispatcher
- pass browser extension key/version context to `friends_browser_extension_actions`
- authenticate action requests with the existing browser API key and run handlers as that user

Verification:
- php -l includes/class-rest.php
- php -l tests/test-rest.php
- composer check-cs
- git diff --check

Note:
- PHPUnit could not run locally because `/tmp/wordpress-tests-lib/includes/functions.php` is missing.
