### PR TITLE
Fix welcome content padding

### DIFF
--- a/.github/changelog/unreleased/fix-welcome-padding
+++ b/.github/changelog/unreleased/fix-welcome-padding
@@ -1,0 +1,3 @@
+Type: fixed
+
+Add padding to the welcome content in the shipped frontend themes.

--- a/.github/changelog/unreleased/fix-welcome-padding
+++ b/.github/changelog/unreleased/fix-welcome-padding
@@ -1,3 +1,3 @@
 Type: fixed
 
-Add padding to the welcome content in the shipped frontend themes.
+Show and pad the welcome content in the shipped frontend themes.

--- a/friends.css
+++ b/friends.css
@@ -1684,6 +1684,10 @@ h2#page-title a.dashicons {
 	}
 
 	& section.posts {
+		& .friends-empty-state > .card-body {
+			padding: 1.25rem;
+		}
+
 		& .card {
 			& header.entry-header {
 				display: flex;

--- a/includes/class-blocks.php
+++ b/includes/class-blocks.php
@@ -193,6 +193,20 @@ class Blocks {
 		);
 
 		register_block_type(
+			'friends/welcome',
+			array(
+				'attributes'      => array(
+					'forceWelcome' => array(
+						'type'    => 'boolean',
+						'default' => false,
+					),
+				),
+				'render_callback' => array( $this, 'render_welcome_block' ),
+				'supports'        => $list_supports,
+			)
+		);
+
+		register_block_type(
 			'friends/post-content',
 			array(
 				'render_callback' => array( $this, 'render_post_content_block' ),
@@ -979,6 +993,30 @@ class Blocks {
 
 		$out .= '</div>';
 		return $out;
+	}
+
+	/**
+	 * Render the friends/welcome block.
+	 *
+	 * @param array $attributes Block attributes.
+	 * @return string The rendered block HTML.
+	 */
+	public function render_welcome_block( $attributes = array() ) {
+		$friends = Friends::get_instance();
+		$args    = array(
+			'friends'     => $friends,
+			'post_format' => $friends->frontend->post_format,
+		);
+
+		ob_start();
+		if ( empty( $attributes['forceWelcome'] ) && User_Query::all_associated_users()->get_total() > 0 ) {
+			Friends::template_loader()->get_template_part( 'frontend/no-posts', $args['post_format'], $args );
+		} else {
+			Friends::template_loader()->get_template_part( 'frontend/no-friends', $args['post_format'], $args );
+		}
+		$content = ob_get_clean();
+
+		return '<div ' . $this->get_wrapper_attributes( array( 'class' => 'wp-block-friends-welcome friends-empty-state' ) ) . '>' . $content . '</div>';
 	}
 
 	/**

--- a/includes/class-frontend.php
+++ b/includes/class-frontend.php
@@ -1602,7 +1602,11 @@ class Frontend {
 		if ( ! isset( $map[ $template_path ] ) ) {
 			return false;
 		}
-		$file = FRIENDS_PLUGIN_DIR . 'themes/friends/templates/' . $map[ $template_path ] . '.html';
+		$template = $map[ $template_path ];
+		if ( 'frontend/index' === $template_path && isset( $_GET['welcome'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$template = 'welcome';
+		}
+		$file = FRIENDS_PLUGIN_DIR . 'themes/friends/templates/' . $template . '.html';
 		if ( ! file_exists( $file ) ) {
 			return false;
 		}

--- a/templates/frontend/index.php
+++ b/templates/frontend/index.php
@@ -19,7 +19,7 @@ $show_welcome = isset( $args['show_welcome'] ) && $args['show_welcome'];
 	<?php
 	if ( $show_welcome || ! have_posts() ) {
 		?>
-		<div class="card columns col-12">
+		<div class="card columns col-12 friends-empty-state">
 			<div class="card-body">
 			<?php
 			if ( ! $show_welcome && $args['friends']->frontend->post_format ) {

--- a/templates/google-reader/frontend/index.php
+++ b/templates/google-reader/frontend/index.php
@@ -19,7 +19,7 @@ $show_welcome = isset( $args['show_welcome'] ) && $args['show_welcome'];
 	<?php
 	if ( $show_welcome || ! have_posts() ) {
 		?>
-		<div class="card columns col-12">
+		<div class="card columns col-12 friends-empty-state">
 			<div class="card-body">
 			<?php
 			if ( ! $show_welcome && $args['friends']->frontend->post_format ) {

--- a/templates/google-reader/google-reader.css
+++ b/templates/google-reader/google-reader.css
@@ -487,6 +487,26 @@
 	margin-top: 4px;
 }
 
+.friends-page .posts > .friends-empty-state > .card-body {
+	padding: 12px 0;
+}
+
+.friends-page .posts > .friends-empty-state h1 {
+	font-size: 22px;
+	line-height: 1.3;
+	margin-bottom: 10px;
+}
+
+.friends-page .posts > .friends-empty-state ul,
+.friends-page .posts > .friends-empty-state ol {
+	margin: 0 0 .8em;
+	padding-left: 1.25rem;
+}
+
+.friends-page .posts > .friends-empty-state li {
+	margin-bottom: .5em;
+}
+
 .friends-page .posts article.card {
 	border: none;
 	border-bottom: 1px solid light-dark(#e5e5e5, #3c4043);

--- a/templates/mastodon/frontend/index.php
+++ b/templates/mastodon/frontend/index.php
@@ -18,7 +18,7 @@ $show_welcome = isset( $args['show_welcome'] ) && $args['show_welcome'];
 	<?php
 	if ( $show_welcome || ! have_posts() ) {
 		?>
-		<div class="card columns col-12">
+		<div class="card columns col-12 friends-empty-state">
 			<div class="card-body">
 			<?php
 			if ( ! $show_welcome && $args['friends']->frontend->post_format ) {

--- a/templates/mastodon/mastodon.css
+++ b/templates/mastodon/mastodon.css
@@ -508,6 +508,31 @@ body.friends-page {
 	background: light-dark(#fff, #282c37);
 }
 
+.friends-page .posts > .friends-empty-state {
+	border-bottom: 1px solid light-dark(#c8d0db, #393f4f);
+	background: light-dark(#fff, #282c37);
+}
+
+.friends-page .posts > .friends-empty-state > .card-body {
+	padding: 20px 16px;
+}
+
+.friends-page .posts > .friends-empty-state h1 {
+	font-size: 22px;
+	line-height: 1.3;
+	margin-bottom: 12px;
+}
+
+.friends-page .posts > .friends-empty-state ul,
+.friends-page .posts > .friends-empty-state ol {
+	margin: 0 0 .8em;
+	padding-left: 1.25rem;
+}
+
+.friends-page .posts > .friends-empty-state li {
+	margin-bottom: .6em;
+}
+
 /* === Individual Status Card === */
 .friends-page .posts article.card {
 	position: relative;

--- a/templates/twitter/frontend/index.php
+++ b/templates/twitter/frontend/index.php
@@ -18,7 +18,7 @@ $show_welcome = isset( $args['show_welcome'] ) && $args['show_welcome'];
 	<?php
 	if ( $show_welcome || ! have_posts() ) {
 		?>
-		<div class="card columns col-12">
+		<div class="card columns col-12 friends-empty-state">
 			<div class="card-body">
 			<?php
 			if ( ! $show_welcome && $args['friends']->frontend->post_format ) {

--- a/templates/twitter/twitter.css
+++ b/templates/twitter/twitter.css
@@ -642,6 +642,31 @@ body.friends-page {
 	margin: 0;
 }
 
+.friends-page .posts > .friends-empty-state {
+	border-bottom: 1px solid light-dark(#eff3f4, #2f3336);
+	background: transparent;
+}
+
+.friends-page .posts > .friends-empty-state > .card-body {
+	padding: 16px;
+}
+
+.friends-page .posts > .friends-empty-state h1 {
+	font-size: 22px;
+	line-height: 1.3;
+	margin-bottom: 12px;
+}
+
+.friends-page .posts > .friends-empty-state ul,
+.friends-page .posts > .friends-empty-state ol {
+	margin: 0 0 .8em;
+	padding-left: 1.25rem;
+}
+
+.friends-page .posts > .friends-empty-state li {
+	margin-bottom: .6em;
+}
+
 /* === Individual Tweet Card === */
 .friends-page .posts article.card {
 	position: relative;

--- a/tests/test-block-theme.php
+++ b/tests/test-block-theme.php
@@ -60,6 +60,7 @@ class BlockThemeTest extends \WP_UnitTestCase {
 			'friends/search',
 			'friends/feed-title',
 			'friends/feed-chips',
+			'friends/welcome',
 			'friends/post-content',
 			'friends/post-permalink',
 			'friends/author-star',
@@ -90,6 +91,7 @@ class BlockThemeTest extends \WP_UnitTestCase {
 			'themes/friends/templates/friends-followers.html',
 			'themes/friends/templates/friends-subscriptions.html',
 			'themes/friends/templates/single-friend_post_cache.html',
+			'themes/friends/templates/welcome.html',
 		);
 
 		foreach ( $templates as $template ) {
@@ -174,6 +176,17 @@ class BlockThemeTest extends \WP_UnitTestCase {
 
 		$this->assertStringContainsString( 'wp-block-friends-feed-chips', $output );
 		$this->assertStringContainsString( 'chip', $output );
+	}
+
+	/**
+	 * Test the welcome block renders the empty state wrapper.
+	 */
+	public function test_render_welcome_block() {
+		$blocks = new Blocks();
+		$output = $blocks->render_welcome_block( array( 'forceWelcome' => true ) );
+
+		$this->assertStringContainsString( 'wp-block-friends-welcome', $output );
+		$this->assertStringContainsString( 'Welcome to the Friends Plugin!', $output );
 	}
 
 	/**
@@ -323,6 +336,8 @@ class BlockThemeTest extends \WP_UnitTestCase {
 		$this->assertStringContainsString( 'wp:post-title', $index );
 		$this->assertStringContainsString( 'wp:friends/post-content', $index );
 		$this->assertStringContainsString( 'wp:friends/post-permalink', $index );
+		$this->assertStringContainsString( 'wp:query-no-results', $index );
+		$this->assertStringContainsString( 'wp:friends/welcome', $index );
 		$this->assertStringContainsString( 'wp:query-pagination', $index );
 
 		// Footer should not be referenced.

--- a/themes/friends/templates/index.html
+++ b/themes/friends/templates/index.html
@@ -19,6 +19,9 @@
 <!-- wp:friends/post-comments /--></div>
 <!-- /wp:group -->
 <!-- /wp:post-template -->
+<!-- wp:query-no-results -->
+<!-- wp:friends/welcome {"style":{"spacing":{"padding":{"top":"20px","right":"20px","bottom":"20px","left":"20px"}}}} /-->
+<!-- /wp:query-no-results -->
 <!-- wp:query-pagination -->
 <!-- wp:query-pagination-previous /-->
 <!-- wp:query-pagination-numbers /-->

--- a/themes/friends/templates/welcome.html
+++ b/themes/friends/templates/welcome.html
@@ -1,0 +1,11 @@
+<!-- wp:columns {"style":{"spacing":{"padding":{"top":"40px"}}}} -->
+<div class="wp-block-columns" style="padding-top:40px"><!-- wp:column {"width":"25%"} -->
+<div class="wp-block-column" style="flex-basis:25%"><!-- wp:template-part {"slug":"sidebar","theme":"friends","tagName":"sidebar","area":"sidebar"} /--></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"width":"75%"} -->
+<div class="wp-block-column" style="flex-basis:75%"><!-- wp:template-part {"slug":"header","theme":"friends","tagName":"header","area":"header"} /-->
+
+<!-- wp:friends/welcome {"forceWelcome":true,"style":{"spacing":{"padding":{"top":"20px","right":"20px","bottom":"20px","left":"20px"}}}} /--></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->


### PR DESCRIPTION
## Summary
- Add a dedicated empty-state class for welcome/no-posts cards.
- Restore padding and list spacing for welcome content in the default, Mastodon, Twitter, and Google Reader themes.
- Add a dynamic welcome block plus block-theme query-no-results and /friends/?welcome handling.
- Add an unreleased changelog entry.

## Testing
- composer check-cs
- php -l templates/frontend/index.php
- php -l templates/mastodon/frontend/index.php
- php -l templates/twitter/frontend/index.php
- php -l templates/google-reader/frontend/index.php
- php -l includes/class-blocks.php
- php -l includes/class-frontend.php
- composer test -- --filter BlockThemeTest (fails: /tmp/wordpress-tests-lib/includes/functions.php is missing)