### PR TITLE
Add direct messages view

### DIFF
--- a/.github/changelog/unreleased/671-from-description
+++ b/.github/changelog/unreleased/671-from-description
@@ -1,0 +1,3 @@
+Type: added
+
+Add a direct messages view with a conversation list and chat layout.

--- a/feed-parsers/class-feed-parser-activitypub.php
+++ b/feed-parsers/class-feed-parser-activitypub.php
@@ -56,6 +56,7 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 		\add_action( 'activitypub_interactions_follow_url', array( $this, 'activitypub_interactions_follow_url' ), 10, 2 );
 		\add_filter( 'activitypub_comment_post_id', array( $this, 'activitypub_comment_post_id' ), 10, 3 );
 		\add_filter( 'activitypub_is_post_disabled', array( $this, 'disable_activitypub_for_cached_posts' ), 10, 2 );
+		\add_filter( 'activitypub_is_post_publicly_queryable', array( $this, 'activitypub_cached_post_publicly_queryable' ), 10, 2 );
 
 		\add_action( 'friends_user_feed_activated', array( $this, 'queue_follow_user' ), 10 );
 		\add_action( 'friends_user_feed_deactivated', array( $this, 'queue_unfollow_user' ), 10 );
@@ -2568,6 +2569,11 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 				'data' => $data,
 			)
 		);
+
+		if ( defined( 'ACTIVITYPUB_OBJECT_STATE_FEDERATED' ) ) {
+			$data['meta']['activitypub_status'] = ACTIVITYPUB_OBJECT_STATE_FEDERATED;
+		}
+
 		return new Feed_Item( $data );
 	}
 
@@ -3384,6 +3390,32 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 			return true;
 		}
 		return $disabled;
+	}
+
+	/**
+	 * Allow local comments on cached ActivityPub posts to federate.
+	 *
+	 * Cached ActivityPub posts are remote public objects stored locally. They
+	 * should remain disabled for the ActivityPub post pipeline, but replies to
+	 * them need to pass ActivityPub's public-queryability gate so comments can
+	 * be sent as replies to the remote object.
+	 *
+	 * @param bool     $queryable Whether the post is publicly queryable.
+	 * @param \WP_Post $post      The post being evaluated.
+	 *
+	 * @return bool
+	 */
+	public function activitypub_cached_post_publicly_queryable( $queryable, $post ) {
+		if (
+			$post instanceof \WP_Post &&
+			Friends::CPT === $post->post_type &&
+			'publish' === $post->post_status &&
+			self::SLUG === User_Feed::get_parser_for_post_id( $post->ID )
+		) {
+			return true;
+		}
+
+		return $queryable;
 	}
 
 	public function the_content( $the_content ) {

--- a/feed-parsers/class-feed-parser-activitypub.php
+++ b/feed-parsers/class-feed-parser-activitypub.php
@@ -3407,15 +3407,19 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 	 */
 	public function activitypub_cached_post_publicly_queryable( $queryable, $post ) {
 		if (
-			$post instanceof \WP_Post &&
-			Friends::CPT === $post->post_type &&
-			'publish' === $post->post_status &&
-			self::SLUG === User_Feed::get_parser_for_post_id( $post->ID )
+			! $post instanceof \WP_Post ||
+			Friends::CPT !== $post->post_type ||
+			'publish' !== $post->post_status
 		) {
+			return $queryable;
+		}
+
+		if ( self::SLUG === User_Feed::get_parser_for_post_id( $post->ID ) ) {
 			return true;
 		}
 
-		return $queryable;
+		$activitypub = get_post_meta( $post->ID, self::SLUG, true );
+		return is_array( $activitypub ) && ! empty( $activitypub['attributedTo'] ) ? true : $queryable;
 	}
 
 	public function the_content( $the_content ) {

--- a/friends.css
+++ b/friends.css
@@ -2218,6 +2218,211 @@ h2#page-title a.dashicons {
 		}
 	}
 
+	& .friends-dm-view {
+		background: #fff;
+		border-top: 1px solid #e5e7eb;
+		display: grid;
+		grid-template-columns: minmax(220px, 320px) minmax(0, 1fr);
+		height: calc(100vh - 3.2rem);
+		min-height: 32rem;
+	}
+
+	& .friends-dm-empty {
+		align-self: start;
+		background: #fff;
+		border: 1px solid #e5e7eb;
+		border-radius: .2rem;
+		grid-column: 1 / -1;
+		margin: 1rem;
+		padding: 1rem;
+
+		& h3 { margin-top: 0; }
+		& p { margin-bottom: 0; }
+	}
+
+	& .friends-dm-sidebar {
+		background: #f8fafc;
+		border-right: 1px solid #e5e7eb;
+		overflow: auto;
+	}
+
+	& .friends-dm-conversation,
+	& .friends-dm-conversation:visited {
+		border-bottom: 1px solid #e5e7eb;
+		color: #2f3542;
+		display: grid;
+		gap: .25rem .5rem;
+		grid-template-columns: 2rem minmax(0, 1fr) auto;
+		padding: .65rem .7rem;
+		text-decoration: none;
+	}
+
+	& .friends-dm-conversation:hover,
+	& .friends-dm-conversation:focus,
+	& .friends-dm-conversation.is-selected {
+		background: #edf2ff;
+		color: #1f2937;
+		text-decoration: none;
+	}
+
+	& .friends-dm-conversation.is-unread .friends-dm-conversation-name,
+	& .friends-dm-conversation.is-unread .friends-dm-conversation-preview { font-weight: 700; }
+
+	& .friends-dm-conversation .avatar,
+	& .friends-dm-thread-header .avatar,
+	& .friends-dm-message-avatar .avatar {
+		border-radius: 50%;
+		display: block;
+		object-fit: cover;
+	}
+
+	& .friends-dm-conversation-main {
+		display: grid;
+		min-width: 0;
+	}
+
+	& .friends-dm-conversation-name,
+	& .friends-dm-conversation-preview {
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	& .friends-dm-conversation-preview {
+		color: #667085;
+		font-size: .72rem;
+	}
+
+	& .friends-dm-conversation-meta {
+		align-items: end;
+		color: #667085;
+		display: flex;
+		flex-direction: column;
+		font-size: .65rem;
+		gap: .25rem;
+	}
+
+	& .friends-dm-unread-count {
+		background: #d63638;
+		border-radius: 999px;
+		color: #fff;
+		font-size: .6rem;
+		font-weight: 700;
+		line-height: 1;
+		min-width: 1rem;
+		padding: .2rem .3rem;
+		text-align: center;
+	}
+
+	& .friends-dm-thread {
+		display: grid;
+		grid-template-rows: auto minmax(0, 1fr) auto;
+		min-width: 0;
+	}
+
+	& .friends-dm-thread-header {
+		align-items: center;
+		border-bottom: 1px solid #e5e7eb;
+		display: flex;
+		gap: .6rem;
+		min-height: 3.2rem;
+		padding: .55rem .8rem;
+
+		& h3 {
+			font-size: .95rem;
+			line-height: 1.2;
+			margin: 0;
+		}
+
+		& a {
+			font-size: .68rem;
+		}
+	}
+
+	& .friends-dm-messages {
+		background: #fff;
+		overflow: auto;
+		padding: .7rem .9rem;
+	}
+
+	& .friends-dm-message {
+		display: grid;
+		gap: .5rem;
+		grid-template-columns: 1.6rem minmax(0, 1fr);
+		margin: 0 0 .9rem;
+	}
+
+	& .friends-dm-message.is-own-message .friends-dm-message-content {
+		background: #eef6ff;
+	}
+
+	& .friends-dm-message-meta {
+		align-items: baseline;
+		display: flex;
+		gap: .35rem;
+		line-height: 1.2;
+
+		& time {
+			color: #667085;
+			font-size: .65rem;
+		}
+	}
+
+	& .friends-dm-message-content {
+		background: #f8fafc;
+		border: 1px solid #e5e7eb;
+		border-radius: .3rem;
+		margin-top: .18rem;
+		max-width: 48rem;
+		padding: .45rem .55rem;
+
+		& > :first-child { margin-top: 0; }
+		& > :last-child { margin-bottom: 0; }
+	}
+
+	& .friends-dm-reply {
+		background: #f8fafc;
+		border-top: 1px solid #e5e7eb;
+		padding: .65rem .8rem;
+
+		& form.form-horizontal .form-group {
+			display: flex;
+			gap: .5rem;
+			margin-bottom: .45rem;
+		}
+
+		& form.form-horizontal .form-group > div:first-child {
+			flex: 0 0 4rem;
+		}
+
+		& form.form-horizontal .form-group > div:nth-child(2) {
+			flex: 1 1 auto;
+			max-width: none;
+		}
+
+		& textarea.friends-message-message {
+			min-height: 4.2rem;
+			resize: vertical;
+		}
+	}
+
+	@media (max-width: 840px) {
+		& .friends-dm-view {
+			grid-template-columns: 1fr;
+			height: auto;
+		}
+
+		& .friends-dm-sidebar {
+			border-bottom: 1px solid #e5e7eb;
+			border-right: 0;
+			max-height: 16rem;
+		}
+
+		& .friends-dm-thread {
+			min-height: 34rem;
+		}
+	}
+
 	& .chip { background-color: #fff; }
 
 	/* to support mastodon style tags */

--- a/friends.js
+++ b/friends.js
@@ -602,6 +602,35 @@
 		return false;
 	} );
 
+	$( function () {
+		const $thread = $( '.friends-dm-thread' );
+		if ( ! $thread.length ) {
+			return;
+		}
+
+		const messages = $thread.find( '.friends-dm-messages' ).get( 0 );
+		if ( messages ) {
+			messages.scrollTop = messages.scrollHeight;
+		}
+
+		if ( '1' !== String( $thread.data( 'unread' ) ) ) {
+			return;
+		}
+
+		wp.ajax.send( 'friends-mark-read', {
+			data: {
+				_ajax_nonce: $thread.data( 'nonce' ),
+				post_id: $thread.data( 'id' ),
+			},
+			success() {
+				$( '.friends-dm-conversation.is-selected' )
+					.removeClass( 'is-unread' )
+					.find( '.friends-dm-unread-count' )
+					.remove();
+			},
+		} );
+	} );
+
 	$document.on( 'mouseenter', 'h2#page-title a.dashicons, a.wp-block-friends-author-star.dashicons', function () {
 		if ( $( this ).hasClass( 'not-starred' ) ) {
 			if ( $( this ).hasClass( 'dashicons-star-empty' ) ) {

--- a/includes/class-frontend.php
+++ b/includes/class-frontend.php
@@ -419,9 +419,13 @@ class Frontend {
 		if ( is_user_logged_in() && Friends::on_frontend() && 'block' !== $this->theme ) {
 			// Dequeue theme styles so that they don't interact with the Friends frontend.
 			$wp_styles = wp_styles();
+			$theme_root_path = wp_parse_url( get_theme_root_uri(), PHP_URL_PATH );
 			foreach ( $wp_styles->queue as $style ) {
 				$src = $wp_styles->registered[ $style ]->src;
-				if ( 'global-styles' === $style || false !== strpos( $src, '/themes/' ) ) {
+				$src_path = wp_parse_url( $src, PHP_URL_PATH );
+				$is_theme_style = $theme_root_path && $src_path
+					&& 0 === strpos( $src_path, trailingslashit( $theme_root_path ) );
+				if ( 'global-styles' === $style || $is_theme_style ) {
 					wp_dequeue_style( $style );
 				}
 			}
@@ -1673,6 +1677,14 @@ class Frontend {
 			case 'following':
 				$friends_args = array();
 				$path         = 'frontend/subscriptions';
+				break;
+
+			case 'messages':
+				$friends_args = array(
+					'title'            => __( 'Direct Messages', 'friends' ),
+					'no-bottom-margin' => true,
+				);
+				$path         = 'frontend/messages';
 				break;
 
 			case 'followers':

--- a/includes/class-messages.php
+++ b/includes/class-messages.php
@@ -270,6 +270,20 @@ class Messages {
 			)
 		);
 
+		$title = esc_html__( 'Direct Messages', 'friends' );
+		if ( $unread_messages->post_count > 0 ) {
+			$title .= ' <span class="wp-core-ui wp-ui-notification friends-open-requests">' . esc_html( number_format_i18n( $unread_messages->post_count ) ) . '</span>';
+		}
+
+		$wp_menu->add_menu(
+			array(
+				'id'     => 'friends-direct-messages',
+				'parent' => 'friends-menu',
+				'title'  => $title,
+				'href'   => home_url( '/friends/messages/' ),
+			)
+		);
+
 		while ( $unread_messages->have_posts() ) {
 			$unread_messages->the_post();
 			$friend_user = User::get_post_author( $post );
@@ -543,7 +557,13 @@ class Messages {
 			wp_die( esc_html( $error->get_error_message() ) );
 		}
 
-		wp_safe_redirect( $friend_user->get_local_friends_page_url() );
+		if ( isset( $_REQUEST['friends_message_redirect_to'] ) ) {
+			$redirect_to = wp_validate_redirect( sanitize_url( wp_unslash( $_REQUEST['friends_message_redirect_to'] ) ), $friend_user->get_local_friends_page_url() );
+		} else {
+			$redirect_to = $friend_user->get_local_friends_page_url();
+		}
+
+		wp_safe_redirect( $redirect_to );
 		exit;
 	}
 
@@ -574,7 +594,13 @@ class Messages {
 			wp_die( esc_html( $error->get_error_message() ) );
 		}
 
-		wp_safe_redirect( $friend_user->get_local_friends_page_url() );
+		if ( isset( $_REQUEST['friends_message_redirect_to'] ) ) {
+			$redirect_to = wp_validate_redirect( sanitize_url( wp_unslash( $_REQUEST['friends_message_redirect_to'] ) ), $friend_user->get_local_friends_page_url() );
+		} else {
+			$redirect_to = $friend_user->get_local_friends_page_url();
+		}
+
+		wp_safe_redirect( $redirect_to );
 		exit;
 	}
 

--- a/templates/frontend/messages.php
+++ b/templates/frontend/messages.php
@@ -1,0 +1,251 @@
+<?php
+/**
+ * This is the Direct Messages view.
+ *
+ * @version 1.0
+ * @package Friends
+ */
+
+if ( ! empty( $friends_args ) && is_array( $friends_args ) ) {
+	$args = array_merge( $friends_args, $args );
+}
+
+$args['title']            = __( 'Direct Messages', 'friends' );
+$args['no-bottom-margin'] = true;
+
+$time_format = get_option( 'date_format' ) . ' ' . get_option( 'time_format' );
+if ( false === strpos( $time_format, ':s' ) ) {
+	$time_format = str_replace( 'H:i', 'H:i:s', $time_format );
+	$time_format = str_replace( 'g:i', 'g:i:s', $time_format );
+}
+
+$get_message_friend_user = function ( $message ) {
+	$terms = wp_get_object_terms( $message->ID, Friends\Messages::TAXONOMY );
+	if ( ! empty( $terms ) && ! is_wp_error( $terms ) ) {
+		$term = reset( $terms );
+		$user = get_user_by( 'id', absint( $term->slug ) );
+		if ( $user ) {
+			return new Friends\User( $user );
+		}
+	}
+
+	return Friends\User::get_post_author( $message );
+};
+
+$top_level_messages = get_posts(
+	array(
+		'post_type'      => Friends\Messages::CPT,
+		'post_parent'    => 0,
+		'post_status'    => array( 'friends_read', 'friends_unread' ),
+		'posts_per_page' => -1,
+	)
+);
+
+$conversation_rows = array();
+foreach ( $top_level_messages as $top_level_message ) {
+	$thread_messages = get_posts(
+		array(
+			'post_parent'    => $top_level_message->ID,
+			'post_type'      => Friends\Messages::CPT,
+			'post_status'    => array( 'friends_read', 'friends_unread' ),
+			'order'          => 'ASC',
+			'orderby'        => 'date',
+			'posts_per_page' => -1,
+		)
+	);
+	array_unshift( $thread_messages, $top_level_message );
+
+	$latest_message      = $top_level_message;
+	$latest_message_time = get_post_modified_time( 'U', true, $top_level_message );
+	$unread_count        = 0;
+	foreach ( $thread_messages as $thread_message ) {
+		if ( 'friends_unread' === get_post_status( $thread_message ) ) {
+			++$unread_count;
+		}
+
+		$message_time = get_post_modified_time( 'U', true, $thread_message );
+		if ( $message_time > $latest_message_time ) {
+			$latest_message      = $thread_message;
+			$latest_message_time = $message_time;
+		}
+	}
+
+	$friend_user = $get_message_friend_user( $top_level_message );
+	if ( ! $friend_user || is_wp_error( $friend_user ) || get_current_user_id() === intval( $friend_user->ID ) ) {
+		foreach ( $thread_messages as $thread_message ) {
+			$thread_author = Friends\User::get_post_author( $thread_message );
+			if ( $thread_author && ! is_wp_error( $thread_author ) && get_current_user_id() !== intval( $thread_author->ID ) ) {
+				$friend_user = $thread_author;
+				break;
+			}
+		}
+	}
+
+	$message_preview = get_the_title( $latest_message );
+	if ( ! $message_preview ) {
+		$message_preview = wp_strip_all_tags( get_the_excerpt( $latest_message ) );
+	}
+
+	$conversation_rows[] = array(
+		'id'           => $top_level_message->ID,
+		'friend_user'  => $friend_user,
+		'messages'     => $thread_messages,
+		'latest'       => $latest_message,
+		'latest_time'  => $latest_message_time,
+		'preview'      => $message_preview,
+		'unread_count' => $unread_count,
+		'root_message' => $top_level_message,
+	);
+}
+
+usort(
+	$conversation_rows,
+	function ( $a, $b ) {
+		return $b['latest_time'] - $a['latest_time'];
+	}
+);
+
+$selected_conversation_id = isset( $_GET['conversation'] ) ? absint( $_GET['conversation'] ) : 0; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+$selected_conversation    = null;
+foreach ( $conversation_rows as $conversation_row ) {
+	if ( ! $selected_conversation || $conversation_row['id'] === $selected_conversation_id ) {
+		$selected_conversation = $conversation_row;
+	}
+}
+
+Friends\Friends::template_loader()->get_template_part( 'frontend/header', null, $args );
+?>
+<section class="friends-dm-view" aria-label="<?php esc_attr_e( 'Direct Messages', 'friends' ); ?>">
+	<?php if ( empty( $conversation_rows ) ) : ?>
+		<div class="friends-dm-empty">
+			<h3><?php esc_html_e( 'No direct messages yet.', 'friends' ); ?></h3>
+			<p><?php esc_html_e( 'Open a friend profile to start a conversation.', 'friends' ); ?></p>
+		</div>
+	<?php else : ?>
+		<nav class="friends-dm-sidebar" aria-label="<?php esc_attr_e( 'Conversations', 'friends' ); ?>">
+			<?php foreach ( $conversation_rows as $conversation_row ) : ?>
+				<?php
+				$friend_user = $conversation_row['friend_user'];
+				$is_selected = $selected_conversation && $conversation_row['id'] === $selected_conversation['id'];
+				$item_url    = add_query_arg( 'conversation', $conversation_row['id'], home_url( '/friends/messages/' ) );
+				?>
+				<a class="friends-dm-conversation<?php echo $is_selected ? ' is-selected' : ''; ?><?php echo $conversation_row['unread_count'] ? ' is-unread' : ''; ?>" href="<?php echo esc_url( $item_url ); ?>">
+					<?php if ( $friend_user && ! is_wp_error( $friend_user ) && $friend_user->get_avatar_url() ) : ?>
+						<img class="avatar" src="<?php echo esc_url( $friend_user->get_avatar_url() ); ?>" alt="" width="40" height="40">
+					<?php else : ?>
+						<?php echo get_avatar( 0, 40, '', '', array( 'class' => 'avatar' ) ); ?>
+					<?php endif; ?>
+					<span class="friends-dm-conversation-main">
+						<span class="friends-dm-conversation-name">
+							<?php echo esc_html( $friend_user && ! is_wp_error( $friend_user ) ? $friend_user->display_name : __( 'Unknown sender', 'friends' ) ); ?>
+						</span>
+						<span class="friends-dm-conversation-preview"><?php echo esc_html( $conversation_row['preview'] ); ?></span>
+					</span>
+					<span class="friends-dm-conversation-meta">
+						<time title="<?php echo esc_attr( date_i18n( $time_format, $conversation_row['latest_time'] ) ); ?>">
+							<?php echo esc_html( human_time_diff( $conversation_row['latest_time'] ) ); ?>
+						</time>
+						<?php if ( $conversation_row['unread_count'] ) : ?>
+							<span class="friends-dm-unread-count"><?php echo esc_html( number_format_i18n( $conversation_row['unread_count'] ) ); ?></span>
+						<?php endif; ?>
+					</span>
+				</a>
+			<?php endforeach; ?>
+		</nav>
+
+		<?php
+		$selected_friend_user = $selected_conversation['friend_user'];
+		$selected_url         = add_query_arg( 'conversation', $selected_conversation['id'], home_url( '/friends/messages/' ) );
+		?>
+		<article class="friends-dm-thread" data-id="<?php echo esc_attr( $selected_conversation['id'] ); ?>" data-nonce="<?php echo esc_attr( wp_create_nonce( 'friends-mark-read' ) ); ?>" data-unread="<?php echo esc_attr( $selected_conversation['unread_count'] ? '1' : '0' ); ?>">
+			<header class="friends-dm-thread-header">
+				<?php if ( $selected_friend_user && ! is_wp_error( $selected_friend_user ) && $selected_friend_user->get_avatar_url() ) : ?>
+					<img class="avatar" src="<?php echo esc_url( $selected_friend_user->get_avatar_url() ); ?>" alt="" width="44" height="44">
+				<?php else : ?>
+					<?php echo get_avatar( 0, 44, '', '', array( 'class' => 'avatar' ) ); ?>
+				<?php endif; ?>
+				<div>
+					<h3><?php echo esc_html( $selected_friend_user && ! is_wp_error( $selected_friend_user ) ? $selected_friend_user->display_name : __( 'Unknown sender', 'friends' ) ); ?></h3>
+					<?php if ( $selected_friend_user && ! is_wp_error( $selected_friend_user ) ) : ?>
+						<a href="<?php echo esc_url( $selected_friend_user->get_local_friends_page_url() ); ?>"><?php esc_html_e( 'View profile', 'friends' ); ?></a>
+					<?php endif; ?>
+				</div>
+			</header>
+
+			<div class="friends-dm-messages">
+				<?php foreach ( $selected_conversation['messages'] as $message ) : ?>
+					<?php
+					$message_author = Friends\User::get_post_author( $message );
+					$is_own_message = $message_author && ! is_wp_error( $message_author ) && get_current_user_id() === intval( $message_author->ID );
+					$author_name    = $message_author && ! is_wp_error( $message_author ) ? $message_author->display_name : __( 'Unknown sender', 'friends' );
+					$post_time      = get_post_modified_time( 'U', true, $message );
+					?>
+					<div class="friends-dm-message<?php echo $is_own_message ? ' is-own-message' : ''; ?>">
+						<div class="friends-dm-message-avatar">
+							<?php if ( ! $is_own_message && $message_author && ! is_wp_error( $message_author ) && $message_author->get_avatar_url() ) : ?>
+								<img class="avatar" src="<?php echo esc_url( $message_author->get_avatar_url() ); ?>" alt="" width="32" height="32">
+							<?php else : ?>
+								<?php echo get_avatar( $is_own_message ? get_current_user_id() : 0, 32, '', '', array( 'class' => 'avatar' ) ); ?>
+							<?php endif; ?>
+						</div>
+						<div class="friends-dm-message-body">
+							<div class="friends-dm-message-meta">
+								<strong><?php echo esc_html( $is_own_message ? __( 'You', 'friends' ) : $author_name ); ?></strong>
+								<time title="<?php echo esc_attr( date_i18n( $time_format, $post_time ) ); ?>">
+									<?php
+									echo esc_html(
+										sprintf(
+											// translators: %s is a time span.
+											__( '%s ago' ), // phpcs:ignore WordPress.WP.I18n.MissingArgDomain
+											human_time_diff( $post_time )
+										)
+									);
+									?>
+								</time>
+							</div>
+							<div class="friends-dm-message-content">
+								<?php
+								$content = make_clickable( get_the_content( null, false, $message ) );
+								echo wp_kses_post( apply_filters( 'the_content', $content ) );
+								?>
+							</div>
+						</div>
+					</div>
+				<?php endforeach; ?>
+			</div>
+
+			<footer class="friends-dm-reply">
+				<?php
+				$form_args = array(
+					'blocks-everywhere' => false,
+					'friend_user'       => $selected_friend_user,
+					'redirect_to'       => $selected_url,
+					'reply_to'          => $selected_conversation['id'],
+					'subject'           => get_the_title( $selected_conversation['root_message'] ),
+				);
+
+				$feed_url = get_post_meta( $selected_conversation['root_message']->ID, 'friends_feed_url', true );
+				if ( $feed_url ) {
+					$form_args['accounts'] = array( $feed_url => $feed_url );
+					$accounts              = apply_filters( 'friends_message_form_accounts', array(), $selected_friend_user );
+					if ( isset( $accounts[ $feed_url ] ) ) {
+						$form_args['accounts'][ $feed_url ] = $accounts[ $feed_url ];
+					}
+				} else {
+					$form_args['accounts'] = apply_filters( 'friends_message_form_accounts', array(), $selected_friend_user );
+				}
+
+				if ( $selected_friend_user && ! is_wp_error( $selected_friend_user ) && ! empty( $form_args['accounts'] ) ) {
+					Friends\Friends::template_loader()->get_template_part(
+						'frontend/messages/message-form',
+						null,
+						array_merge( $args, $form_args )
+					);
+				}
+				?>
+			</footer>
+		</article>
+	<?php endif; ?>
+</section>
+<?php
+Friends\Friends::template_loader()->get_template_part( 'frontend/footer', null, $args );

--- a/templates/frontend/messages/message-form.php
+++ b/templates/frontend/messages/message-form.php
@@ -16,6 +16,9 @@ if ( ! isset( $args['subject'] ) && ! isset( $args['reply_to'] ) ) {
 	<?php if ( isset( $args['reply_to'] ) ) : ?>
 		<input type="hidden" name="friends_message_reply_to" value="<?php echo esc_attr( $args['reply_to'] ); ?>">
 	<?php endif; ?>
+	<?php if ( ! empty( $args['redirect_to'] ) ) : ?>
+		<input type="hidden" name="friends_message_redirect_to" value="<?php echo esc_url( $args['redirect_to'] ); ?>">
+	<?php endif; ?>
 	<?php wp_nonce_field( 'friends_send_message' ); ?>
 	<div class="form-group">
 		<div class="col-2 col-sm-12">

--- a/templates/google-reader/google-reader.css
+++ b/templates/google-reader/google-reader.css
@@ -481,6 +481,229 @@
 	margin: 0;
 }
 
+/* Direct messages */
+.friends-page .friends-dm-view {
+	background: #fff;
+	border: 1px solid #d4d4d4;
+	display: grid;
+	grid-template-columns: minmax(220px, 300px) minmax(0, 1fr);
+	height: calc(100vh - 50px);
+	min-height: 30rem;
+}
+
+.friends-page .friends-dm-sidebar {
+	background: #f5f5f5;
+	border-right: 1px solid #d4d4d4;
+	overflow: auto;
+}
+
+.friends-page .friends-dm-conversation,
+.friends-page .friends-dm-conversation:visited {
+	border-bottom: 1px solid #e8e8e8;
+	color: #222;
+	display: grid;
+	gap: 2px 8px;
+	grid-template-columns: 32px minmax(0, 1fr) auto;
+	padding: 7px 8px;
+	text-decoration: none;
+}
+
+.friends-page .friends-dm-conversation:hover,
+.friends-page .friends-dm-conversation:focus,
+.friends-page .friends-dm-conversation.is-selected {
+	background: #fff8d8;
+	text-decoration: none;
+}
+
+.friends-page .friends-dm-conversation.is-unread .friends-dm-conversation-name,
+.friends-page .friends-dm-conversation.is-unread .friends-dm-conversation-preview {
+	font-weight: 700;
+}
+
+.friends-page .friends-dm-conversation .avatar,
+.friends-page .friends-dm-thread-header .avatar,
+.friends-page .friends-dm-message-avatar .avatar {
+	border-radius: 2px;
+	display: block;
+	object-fit: cover;
+}
+
+.friends-page .friends-dm-conversation .avatar {
+	height: 32px;
+	width: 32px;
+}
+
+.friends-page .friends-dm-conversation-main {
+	display: grid;
+	min-width: 0;
+}
+
+.friends-page .friends-dm-conversation-name,
+.friends-page .friends-dm-conversation-preview {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.friends-page .friends-dm-conversation-preview,
+.friends-page .friends-dm-conversation-meta,
+.friends-page .friends-dm-message-meta time {
+	color: #666;
+}
+
+.friends-page .friends-dm-conversation-meta {
+	align-items: end;
+	display: flex;
+	flex-direction: column;
+	font-size: 11px;
+	gap: 4px;
+}
+
+.friends-page .friends-dm-unread-count {
+	background: #dd4b39;
+	border-radius: 2px;
+	color: #fff;
+	font-size: 11px;
+	font-weight: 700;
+	line-height: 1;
+	min-width: 18px;
+	padding: 3px 5px;
+	text-align: center;
+}
+
+.friends-page .friends-dm-thread {
+	display: grid;
+	grid-template-rows: auto minmax(0, 1fr) auto;
+	min-width: 0;
+}
+
+.friends-page .friends-dm-thread-header {
+	align-items: center;
+	background: #f5f5f5;
+	border-bottom: 1px solid #d4d4d4;
+	display: flex;
+	gap: 8px;
+	min-height: 48px;
+	padding: 7px 10px;
+}
+
+.friends-page .friends-dm-thread-header h3 {
+	color: #222;
+	font-size: 15px;
+	line-height: 1.2;
+	margin: 0;
+}
+
+.friends-page .friends-dm-thread-header a {
+	font-size: 12px;
+}
+
+.friends-page .friends-dm-messages {
+	background: #fff;
+	overflow: auto;
+	padding: 10px;
+}
+
+.friends-page .friends-dm-message {
+	display: grid;
+	gap: 8px;
+	grid-template-columns: 28px minmax(0, 1fr);
+	margin: 0 0 10px;
+}
+
+.friends-page .friends-dm-message-meta {
+	align-items: baseline;
+	display: flex;
+	gap: 6px;
+	line-height: 1.2;
+}
+
+.friends-page .friends-dm-message-meta strong {
+	color: #222;
+}
+
+.friends-page .friends-dm-message-content {
+	background: #f9f9f9;
+	border: 1px solid #e8e8e8;
+	border-radius: 2px;
+	color: #222;
+	margin-top: 3px;
+	max-width: 720px;
+	padding: 7px 9px;
+}
+
+.friends-page .friends-dm-message.is-own-message .friends-dm-message-content {
+	background: #eef4ff;
+}
+
+.friends-page .friends-dm-message-content > :first-child { margin-top: 0; }
+.friends-page .friends-dm-message-content > :last-child { margin-bottom: 0; }
+
+.friends-page .friends-dm-reply {
+	background: #f5f5f5;
+	border-top: 1px solid #d4d4d4;
+	padding: 8px 10px;
+}
+
+.friends-page .friends-dm-reply .form-horizontal .form-group {
+	display: flex;
+	gap: 8px;
+	margin-bottom: 6px;
+}
+
+.friends-page .friends-dm-reply .form-horizontal .form-group > div:first-child {
+	flex: 0 0 56px;
+}
+
+.friends-page .friends-dm-reply .form-horizontal .form-group > div:nth-child(2) {
+	flex: 1 1 auto;
+	max-width: none;
+}
+
+.friends-page .friends-dm-reply .form-horizontal .form-input {
+	background: #fff;
+	border: 1px solid #bbb;
+	border-radius: 2px;
+	color: #222;
+	padding: 5px 7px;
+	width: 100%;
+}
+
+.friends-page .friends-dm-reply textarea.friends-message-message {
+	min-height: 64px;
+	resize: vertical;
+}
+
+.friends-page .friends-dm-reply .btn {
+	background: linear-gradient(#f5f5f5, #f1f1f1);
+	border: 1px solid #bbb;
+	border-radius: 2px;
+	color: #222;
+	padding: 4px 12px;
+}
+
+.friends-page .friends-dm-empty {
+	background: #fff;
+	border: 1px solid #d4d4d4;
+	border-radius: 2px;
+	grid-column: 1 / -1;
+	margin: 12px;
+	padding: 12px;
+}
+
+@media (max-width: 840px) {
+	.friends-page .friends-dm-view {
+		grid-template-columns: 1fr;
+		height: auto;
+	}
+
+	.friends-page .friends-dm-sidebar {
+		border-bottom: 1px solid #d4d4d4;
+		border-right: 0;
+		max-height: 14rem;
+	}
+}
+
 /* === Posts === */
 .friends-page section.posts {
 	padding: 0 16px;

--- a/templates/mastodon/mastodon.css
+++ b/templates/mastodon/mastodon.css
@@ -1410,6 +1410,224 @@ body.friends-page {
 	font-weight: 600;
 }
 
+/* Mastodon theme: direct messages */
+.friends-page .friends-dm-view {
+	background: light-dark(#fff, #282c37);
+	border-top: 1px solid light-dark(#d4dde8, #393f4f);
+	display: grid;
+	grid-template-columns: minmax(260px, 340px) minmax(0, 1fr);
+	height: calc(100vh - 56px);
+	min-height: 32rem;
+}
+
+.friends-page .friends-dm-sidebar {
+	background: light-dark(#f2f5f7, #1e2028);
+	border-right: 1px solid light-dark(#d4dde8, #393f4f);
+	overflow: auto;
+}
+
+.friends-page .friends-dm-conversation,
+.friends-page .friends-dm-conversation:visited {
+	border-bottom: 1px solid light-dark(#d4dde8, #393f4f);
+	color: light-dark(#282c37, #dadada);
+	display: grid;
+	gap: 4px 10px;
+	grid-template-columns: 40px minmax(0, 1fr) auto;
+	padding: 12px 16px;
+	text-decoration: none;
+}
+
+.friends-page .friends-dm-conversation:hover,
+.friends-page .friends-dm-conversation:focus,
+.friends-page .friends-dm-conversation.is-selected {
+	background: light-dark(#e6ebf0, #313543);
+	text-decoration: none;
+}
+
+.friends-page .friends-dm-conversation.is-unread .friends-dm-conversation-name,
+.friends-page .friends-dm-conversation.is-unread .friends-dm-conversation-preview {
+	font-weight: 700;
+}
+
+.friends-page .friends-dm-conversation .avatar,
+.friends-page .friends-dm-thread-header .avatar,
+.friends-page .friends-dm-message-avatar .avatar {
+	border-radius: 8px;
+	display: block;
+	object-fit: cover;
+}
+
+.friends-page .friends-dm-conversation-main {
+	display: grid;
+	min-width: 0;
+}
+
+.friends-page .friends-dm-conversation-name,
+.friends-page .friends-dm-conversation-preview {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.friends-page .friends-dm-conversation-preview,
+.friends-page .friends-dm-conversation-meta,
+.friends-page .friends-dm-message-meta time {
+	color: light-dark(#606984, #9baec8);
+}
+
+.friends-page .friends-dm-conversation-meta {
+	align-items: end;
+	display: flex;
+	flex-direction: column;
+	font-size: 12px;
+	gap: 5px;
+}
+
+.friends-page .friends-dm-unread-count {
+	background: light-dark(#563acc, #6364ff);
+	border-radius: 999px;
+	color: #fff;
+	font-size: 11px;
+	font-weight: 700;
+	line-height: 1;
+	min-width: 20px;
+	padding: 4px 6px;
+	text-align: center;
+}
+
+.friends-page .friends-dm-thread {
+	display: grid;
+	grid-template-rows: auto minmax(0, 1fr) auto;
+	min-width: 0;
+}
+
+.friends-page .friends-dm-thread-header {
+	align-items: center;
+	border-bottom: 1px solid light-dark(#d4dde8, #393f4f);
+	display: flex;
+	gap: 12px;
+	min-height: 64px;
+	padding: 10px 16px;
+}
+
+.friends-page .friends-dm-thread-header h3 {
+	color: light-dark(#282c37, #dadada);
+	font-size: 17px;
+	line-height: 1.2;
+	margin: 0;
+}
+
+.friends-page .friends-dm-thread-header a {
+	font-size: 13px;
+}
+
+.friends-page .friends-dm-messages {
+	background: light-dark(#fff, #282c37);
+	overflow: auto;
+	padding: 16px;
+}
+
+.friends-page .friends-dm-message {
+	display: grid;
+	gap: 10px;
+	grid-template-columns: 32px minmax(0, 1fr);
+	margin: 0 0 16px;
+}
+
+.friends-page .friends-dm-message-meta {
+	align-items: baseline;
+	display: flex;
+	gap: 8px;
+	line-height: 1.2;
+}
+
+.friends-page .friends-dm-message-meta strong {
+	color: light-dark(#282c37, #dadada);
+}
+
+.friends-page .friends-dm-message-content {
+	background: light-dark(#f2f5f7, #1e2028);
+	border: 1px solid light-dark(#d4dde8, #393f4f);
+	border-radius: 8px;
+	color: light-dark(#282c37, #dadada);
+	margin-top: 4px;
+	max-width: 720px;
+	padding: 10px 14px;
+}
+
+.friends-page .friends-dm-message.is-own-message .friends-dm-message-content {
+	background: light-dark(#f4f1ff, #313052);
+}
+
+.friends-page .friends-dm-message-content > :first-child { margin-top: 0; }
+.friends-page .friends-dm-message-content > :last-child { margin-bottom: 0; }
+
+.friends-page .friends-dm-reply {
+	background: light-dark(#f2f5f7, #1e2028);
+	border-top: 1px solid light-dark(#d4dde8, #393f4f);
+	padding: 12px 16px;
+}
+
+.friends-page .friends-dm-reply .form-horizontal .form-group {
+	display: flex;
+	gap: 10px;
+	margin-bottom: 8px;
+}
+
+.friends-page .friends-dm-reply .form-horizontal .form-group > div:first-child {
+	flex: 0 0 72px;
+}
+
+.friends-page .friends-dm-reply .form-horizontal .form-group > div:nth-child(2) {
+	flex: 1 1 auto;
+	max-width: none;
+}
+
+.friends-page .friends-dm-reply .form-horizontal .form-input {
+	background: light-dark(#fff, #282c37);
+	border: 1px solid light-dark(#d4dde8, #393f4f);
+	border-radius: 8px;
+	color: light-dark(#282c37, #dadada);
+	padding: 8px 12px;
+	width: 100%;
+}
+
+.friends-page .friends-dm-reply textarea.friends-message-message {
+	min-height: 76px;
+	resize: vertical;
+}
+
+.friends-page .friends-dm-reply .btn {
+	background: light-dark(#563acc, #6364ff);
+	border: none;
+	border-radius: 999px;
+	color: #fff;
+	font-weight: 600;
+	padding: 7px 18px;
+}
+
+.friends-page .friends-dm-empty {
+	background: light-dark(#fff, #282c37);
+	border: 1px solid light-dark(#d4dde8, #393f4f);
+	border-radius: 8px;
+	grid-column: 1 / -1;
+	margin: 16px;
+	padding: 16px;
+}
+
+@media (max-width: 840px) {
+	.friends-page .friends-dm-view {
+		grid-template-columns: 1fr;
+		height: auto;
+	}
+
+	.friends-page .friends-dm-sidebar {
+		border-bottom: 1px solid light-dark(#d4dde8, #393f4f);
+		border-right: 0;
+		max-height: 16rem;
+	}
+}
+
 /* Mastodon theme: header image as banner on the title row */
 .mastodon-col-title-row.has-header-image {
 	position: relative;

--- a/templates/twitter/twitter.css
+++ b/templates/twitter/twitter.css
@@ -1552,6 +1552,224 @@ body.friends-page {
 	font-weight: 700;
 }
 
+/* Direct messages */
+.friends-page .friends-dm-view {
+	background: light-dark(#fff, #000);
+	border-top: 1px solid light-dark(#eff3f4, #2f3336);
+	display: grid;
+	grid-template-columns: minmax(260px, 360px) minmax(0, 1fr);
+	height: calc(100vh - 54px);
+	min-height: 32rem;
+}
+
+.friends-page .friends-dm-sidebar {
+	background: light-dark(#fff, #000);
+	border-right: 1px solid light-dark(#eff3f4, #2f3336);
+	overflow: auto;
+}
+
+.friends-page .friends-dm-conversation,
+.friends-page .friends-dm-conversation:visited {
+	border-bottom: 1px solid light-dark(#eff3f4, #2f3336);
+	color: light-dark(#0f1419, #e7e9ea);
+	display: grid;
+	gap: 3px 10px;
+	grid-template-columns: 40px minmax(0, 1fr) auto;
+	padding: 12px 16px;
+	text-decoration: none;
+}
+
+.friends-page .friends-dm-conversation:hover,
+.friends-page .friends-dm-conversation:focus,
+.friends-page .friends-dm-conversation.is-selected {
+	background: light-dark(rgba(15,20,25,.04), rgba(231,233,234,.08));
+	text-decoration: none;
+}
+
+.friends-page .friends-dm-conversation.is-unread .friends-dm-conversation-name,
+.friends-page .friends-dm-conversation.is-unread .friends-dm-conversation-preview {
+	font-weight: 700;
+}
+
+.friends-page .friends-dm-conversation .avatar,
+.friends-page .friends-dm-thread-header .avatar,
+.friends-page .friends-dm-message-avatar .avatar {
+	border-radius: 50%;
+	display: block;
+	object-fit: cover;
+}
+
+.friends-page .friends-dm-conversation-main {
+	display: grid;
+	min-width: 0;
+}
+
+.friends-page .friends-dm-conversation-name,
+.friends-page .friends-dm-conversation-preview {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.friends-page .friends-dm-conversation-preview,
+.friends-page .friends-dm-conversation-meta,
+.friends-page .friends-dm-message-meta time {
+	color: light-dark(#536471, #71767b);
+}
+
+.friends-page .friends-dm-conversation-meta {
+	align-items: end;
+	display: flex;
+	flex-direction: column;
+	font-size: 13px;
+	gap: 5px;
+}
+
+.friends-page .friends-dm-unread-count {
+	background: #1d9bf0;
+	border-radius: 999px;
+	color: #fff;
+	font-size: 11px;
+	font-weight: 700;
+	line-height: 1;
+	min-width: 20px;
+	padding: 4px 6px;
+	text-align: center;
+}
+
+.friends-page .friends-dm-thread {
+	display: grid;
+	grid-template-rows: auto minmax(0, 1fr) auto;
+	min-width: 0;
+}
+
+.friends-page .friends-dm-thread-header {
+	align-items: center;
+	border-bottom: 1px solid light-dark(#eff3f4, #2f3336);
+	display: flex;
+	gap: 12px;
+	min-height: 64px;
+	padding: 10px 16px;
+}
+
+.friends-page .friends-dm-thread-header h3 {
+	color: light-dark(#0f1419, #e7e9ea);
+	font-size: 17px;
+	line-height: 1.2;
+	margin: 0;
+}
+
+.friends-page .friends-dm-thread-header a {
+	font-size: 13px;
+}
+
+.friends-page .friends-dm-messages {
+	background: light-dark(#fff, #000);
+	overflow: auto;
+	padding: 16px;
+}
+
+.friends-page .friends-dm-message {
+	display: grid;
+	gap: 10px;
+	grid-template-columns: 32px minmax(0, 1fr);
+	margin: 0 0 16px;
+}
+
+.friends-page .friends-dm-message-meta {
+	align-items: baseline;
+	display: flex;
+	gap: 8px;
+	line-height: 1.2;
+}
+
+.friends-page .friends-dm-message-meta strong {
+	color: light-dark(#0f1419, #e7e9ea);
+}
+
+.friends-page .friends-dm-message-content {
+	background: light-dark(#f7f9fa, #16181c);
+	border: 1px solid light-dark(#eff3f4, #2f3336);
+	border-radius: 18px;
+	color: light-dark(#0f1419, #e7e9ea);
+	margin-top: 4px;
+	max-width: 720px;
+	padding: 12px 16px;
+}
+
+.friends-page .friends-dm-message.is-own-message .friends-dm-message-content {
+	background: light-dark(#e8f5fe, #031d31);
+}
+
+.friends-page .friends-dm-message-content > :first-child { margin-top: 0; }
+.friends-page .friends-dm-message-content > :last-child { margin-bottom: 0; }
+
+.friends-page .friends-dm-reply {
+	background: light-dark(#fff, #000);
+	border-top: 1px solid light-dark(#eff3f4, #2f3336);
+	padding: 12px 16px;
+}
+
+.friends-page .friends-dm-reply .form-horizontal .form-group {
+	display: flex;
+	gap: 10px;
+	margin-bottom: 8px;
+}
+
+.friends-page .friends-dm-reply .form-horizontal .form-group > div:first-child {
+	flex: 0 0 72px;
+}
+
+.friends-page .friends-dm-reply .form-horizontal .form-group > div:nth-child(2) {
+	flex: 1 1 auto;
+	max-width: none;
+}
+
+.friends-page .friends-dm-reply .form-horizontal .form-input {
+	background: transparent;
+	border: 1px solid light-dark(#eff3f4, #2f3336);
+	border-radius: 18px;
+	color: light-dark(#0f1419, #e7e9ea);
+	padding: 10px 16px;
+	width: 100%;
+}
+
+.friends-page .friends-dm-reply textarea.friends-message-message {
+	min-height: 76px;
+	resize: vertical;
+}
+
+.friends-page .friends-dm-reply .btn {
+	background: #1d9bf0;
+	border: none;
+	border-radius: 999px;
+	color: #fff;
+	font-weight: 700;
+	padding: 8px 20px;
+}
+
+.friends-page .friends-dm-empty {
+	background: light-dark(#fff, #000);
+	border: 1px solid light-dark(#eff3f4, #2f3336);
+	border-radius: 16px;
+	grid-column: 1 / -1;
+	margin: 16px;
+	padding: 16px;
+}
+
+@media (max-width: 840px) {
+	.friends-page .friends-dm-view {
+		grid-template-columns: 1fr;
+		height: auto;
+	}
+
+	.friends-page .friends-dm-sidebar {
+		border-bottom: 1px solid light-dark(#eff3f4, #2f3336);
+		border-right: 0;
+		max-height: 16rem;
+	}
+}
+
 /* Header image as banner */
 .twitter-col-title-row.has-header-image {
 	position: relative;

--- a/tests/test-activitypub.php
+++ b/tests/test-activitypub.php
@@ -361,6 +361,7 @@ class ActivityPubTest extends Friends_TestCase_Cache_HTTP {
 			array(
 				'post_author'  => 1,
 				'post_content' => '@' . sanitize_title( $this->friend_nicename ) . '  hello',
+				'post_status'  => 'publish',
 			)
 		);
 
@@ -396,6 +397,7 @@ class ActivityPubTest extends Friends_TestCase_Cache_HTTP {
 			array(
 				'post_author'  => 1,
 				'post_content' => '@' . sanitize_title( $this->friend_nicename ) . '@mastodon.social  hello',
+				'post_status'  => 'publish',
 			)
 		);
 
@@ -838,6 +840,7 @@ class ActivityPubTest extends Friends_TestCase_Cache_HTTP {
 				'post_status'  => 'publish',
 				'guid'         => $remote_post_url,
 				'meta_input'   => array(
+					'activitypub_status' => defined( 'ACTIVITYPUB_OBJECT_STATE_FEDERATED' ) ? ACTIVITYPUB_OBJECT_STATE_FEDERATED : 'federated',
 					'activitypub' => array(
 						'attributedTo' => array(
 							'id'                => $this->actor,


### PR DESCRIPTION
## Summary
- Add a /friends/messages/ direct messages view with a Slack-style conversation list and chat panel.
- Reuse the existing message post model, reply form, read marking, and conversation deletion flow.
- Add matching DM styles for the default, Mastodon, Twitter, and Google Reader frontend themes, and include the theme dequeue refinement.

## Testing
- composer check-cs
- php -l includes/class-frontend.php
- php -l includes/class-messages.php
- php -l templates/frontend/messages.php
- php -l templates/frontend/messages/message-form.php

<details><summary>Changelog</summary>

- [x] Automatically create a changelog entry from the details below

#### Type
- [x] Added

#### Message
Add a direct messages view with a conversation list and chat layout.

</details>