### PR TITLE
Handle DMs from unknown ActivityPub senders

### DIFF
--- a/.github/changelog/unreleased/672-from-description
+++ b/.github/changelog/unreleased/672-from-description
@@ -1,0 +1,3 @@
+Type: fixed
+
+Show direct messages from ActivityPub users you do not follow and surface follower status on their profile.

--- a/feed-parsers/class-feed-parser-activitypub.php
+++ b/feed-parsers/class-feed-parser-activitypub.php
@@ -123,6 +123,7 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 		add_action( 'wp_ajax_friends-preview-activitypub', array( $this, 'ajax_preview' ) );
 		add_action( 'wp_ajax_friends-delete-follower', array( $this, 'ajax_delete_follower' ) );
 		add_action( 'wp_ajax_friends_check_activitypub_subscription', array( $this, 'ajax_check_subscription' ) );
+		add_action( 'wp_ajax_friends_check_activitypub_follower', array( $this, 'ajax_check_follower' ) );
 		add_action( 'wp_ajax_friends_relink_activitypub_actor', array( $this, 'ajax_relink_actor' ) );
 		add_action( 'wp_ajax_friends_refollow_activitypub', array( $this, 'ajax_refollow' ) );
 		add_action( 'friends_edit_feed_content_top', array( $this, 'render_subscription_check_button' ), 10, 3 );
@@ -881,7 +882,7 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 			return $post_id;
 		}
 		$send_to = null;
-		foreach ( $friend_user->get_active_feeds() as $user_feed ) {
+		foreach ( $friend_user->get_feeds() as $user_feed ) {
 			if ( 'activitypub' === $user_feed->get_parser() && $user_feed->get_url() === $to ) {
 				$send_to = $to;
 				break;
@@ -952,6 +953,13 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 			$user_feed = $this->friends_feed->get_user_feed_by_url( $actor_url );
 		}
 
+		if ( ( ! $user_feed || is_wp_error( $user_feed ) ) && class_exists( '\Activitypub\Collection\Remote_Actors' ) && Friends::check_url( $actor_url ) ) {
+			$ap_actor_post = \Activitypub\Collection\Remote_Actors::get_by_uri( $actor_url );
+			if ( ! is_wp_error( $ap_actor_post ) ) {
+				$user_feed = User_Feed::get_by_ap_actor_id( $ap_actor_post->ID );
+			}
+		}
+
 		$object = $activity['object'];
 		$remote_url = $object['id'];
 		$reply_to = null;
@@ -964,6 +972,13 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 		if ( ! $user_feed || is_wp_error( $user_feed ) ) {
 			$actor = apply_filters( 'friends_get_activitypub_metadata', array(), $actor_url );
 			if ( ! $actor || is_wp_error( $actor ) ) {
+				return;
+			}
+
+			$friend_user = $this->create_message_sender_from_actor( $actor_url, $actor );
+			if ( ! is_wp_error( $friend_user ) && $friend_user instanceof User ) {
+				$feed_url = ! empty( $actor['id'] ) && Friends::check_url( $actor['id'] ) ? $actor['id'] : $actor_url;
+				do_action( 'notify_friend_message_received', $friend_user, $message, $subject, $feed_url, $remote_url, $reply_to );
 				return;
 			}
 
@@ -990,7 +1005,76 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 
 		$friend_user = $user_feed->get_friend_user();
 
-		do_action( 'notify_friend_message_received', $friend_user, $message, $subject, $actor_url, $remote_url, $reply_to );
+		do_action( 'notify_friend_message_received', $friend_user, $message, $subject, $user_feed->get_url(), $remote_url, $reply_to );
+	}
+
+	/**
+	 * Create an inactive subscription identity for an ActivityPub DM sender.
+	 *
+	 * Receiving a direct message must make the sender visible and replyable, but
+	 * must not silently follow them or import their public outbox.
+	 *
+	 * @param string $actor_url The actor URL from the incoming activity.
+	 * @param array  $actor     The resolved actor metadata.
+	 * @return User|\WP_Error The sender subscription or an error.
+	 */
+	private function create_message_sender_from_actor( $actor_url, $actor ) {
+		$canonical_actor_url = ! empty( $actor['id'] ) && Friends::check_url( $actor['id'] ) ? $actor['id'] : $actor_url;
+		if ( ! Friends::check_url( $canonical_actor_url ) ) {
+			return new \WP_Error( 'invalid_actor_url', __( 'Invalid ActivityPub actor URL.', 'friends' ) );
+		}
+
+		$display_name = null;
+		if ( ! empty( $actor['name'] ) ) {
+			$display_name = $actor['name'];
+		} elseif ( ! empty( $actor['preferredUsername'] ) ) {
+			$display_name = $actor['preferredUsername'];
+		}
+
+		$avatar_url = null;
+		if ( ! empty( $actor['icon']['url'] ) ) {
+			$avatar_url = $actor['icon']['url'];
+		} elseif ( ! empty( $actor['icon'] ) && is_string( $actor['icon'] ) ) {
+			$avatar_url = $actor['icon'];
+		}
+
+		$host = wp_parse_url( $canonical_actor_url, PHP_URL_HOST );
+		$user_login = sanitize_title( ( $actor['preferredUsername'] ?? 'activitypub' ) . '.' . $host );
+
+		$friend_user = Subscription::create(
+			$user_login,
+			'subscription',
+			$canonical_actor_url,
+			$display_name,
+			$avatar_url,
+			$actor['summary'] ?? null
+		);
+
+		if ( is_wp_error( $friend_user ) ) {
+			return $friend_user;
+		}
+
+		$user_feed = $friend_user->save_feed(
+			$canonical_actor_url,
+			array(
+				'parser' => self::SLUG,
+				'active' => false,
+				'title'  => $display_name ? $display_name : $canonical_actor_url,
+			)
+		);
+
+		if ( is_wp_error( $user_feed ) ) {
+			return $user_feed;
+		}
+
+		if ( class_exists( '\Activitypub\Collection\Remote_Actors' ) ) {
+			$actor_post = \Activitypub\Collection\Remote_Actors::fetch_by_uri( $canonical_actor_url );
+			if ( ! is_wp_error( $actor_post ) && $actor_post instanceof \WP_Post ) {
+				$user_feed->set_ap_actor_id( $actor_post->ID );
+			}
+		}
+
+		return $friend_user;
 	}
 
 	public function register_post_meta() {
@@ -1463,6 +1547,54 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 
 		$result = $this->check_subscription_status( $feed );
 		wp_send_json_success( $result );
+	}
+
+	/**
+	 * AJAX handler for checking whether an ActivityPub actor follows the current user.
+	 */
+	public function ajax_check_follower() {
+		if ( ! isset( $_POST['actor_url'] ) ) {
+			wp_send_json_error( 'missing-parameters' );
+		}
+
+		check_ajax_referer( 'friends-check-follower' );
+
+		if ( ! is_user_logged_in() ) {
+			wp_send_json_error( 'not-authorized' );
+		}
+
+		if ( ! class_exists( '\Activitypub\Collection\Followers' ) ) {
+			wp_send_json_error( 'activitypub-plugin-not-active' );
+		}
+
+		$actor_url = sanitize_url( wp_unslash( $_POST['actor_url'] ) );
+		if ( ! Friends::check_url( $actor_url ) ) {
+			wp_send_json_error( 'invalid-actor-url' );
+		}
+
+		$user_id = self::get_activitypub_actor_id( get_current_user_id() );
+		if ( ! $user_id ) {
+			wp_send_json_error( 'missing-local-activitypub-actor' );
+		}
+
+		$follower = \Activitypub\Collection\Followers::get_by_uri( $user_id, $actor_url );
+		if ( ! is_wp_error( $follower ) ) {
+			wp_send_json_success(
+				array(
+					'follows' => true,
+					'label'   => __( 'Follows you', 'friends' ),
+					'title'   => __( 'This actor follows your ActivityPub account. Replies and direct messages should be deliverable.', 'friends' ),
+				)
+			);
+		}
+
+		wp_send_json_success(
+			array(
+				'follows' => false,
+				'label'   => __( 'Not following you', 'friends' ),
+				'title'   => __( 'This actor is not in your local ActivityPub followers list. They may not receive follower-only or direct replies from your site.', 'friends' ),
+			)
+		);
 	}
 
 	/**

--- a/friends.css
+++ b/friends.css
@@ -1082,6 +1082,21 @@ summary.accordion-header::-webkit-details-marker {
 	& .btn-clear { border-radius: 50%; transform: scale(.75); }
 }
 
+.chip.activitypub-follower-check.is-following {
+	background: #e4f6e8;
+	color: #116329;
+}
+
+.chip.activitypub-follower-check.is-not-following {
+	background: #fff4d6;
+	color: #7a4d00;
+}
+
+.chip.activitypub-follower-check.is-error {
+	background: #fde7e9;
+	color: #8a2424;
+}
+
 /* ========================================================================
    Menus
    ======================================================================== */

--- a/friends.js
+++ b/friends.js
@@ -202,6 +202,34 @@
 	}
 
 	$( function () {
+		$( '.activitypub-follower-check' ).each( function () {
+			const $pill = $( this );
+			wp.ajax.send( 'friends_check_activitypub_follower', {
+				data: {
+					_ajax_nonce: $pill.data( 'nonce' ),
+					actor_url: $pill.data( 'actor-url' ),
+				},
+				success( result ) {
+					$pill
+						.removeClass( 'is-loading is-error' )
+						.toggleClass( 'is-following', !! result.follows )
+						.toggleClass( 'is-not-following', ! result.follows )
+						.text( result.label )
+						.attr( 'title', result.title );
+				},
+				error( result ) {
+					const message = Array.isArray( result )
+						? result.map( function( error ) { return error.message || error.code; } ).join( ', ' )
+						: friends.text_error;
+					$pill
+						.removeClass( 'is-loading is-following is-not-following' )
+						.addClass( 'is-error' )
+						.text( friends.text_error )
+						.attr( 'title', message );
+				},
+			} );
+		} );
+
 		const standard_count = $( '.chip.post-count-standard' );
 		if ( standard_count.text().substr( 0, 3 ) === '...' || standard_count.text().substr( 0, 1 ) === '…' ) {
 			wp.ajax.send( 'friends-get-post-counts', {

--- a/templates/frontend/author-header.php
+++ b/templates/frontend/author-header.php
@@ -15,7 +15,7 @@ $hidden_post_count = $args['friend_user']->get_post_in_trash_count();
 $activitypub_feeds = array();
 $header_image_url = null;
 $activitypub_summary = null;
-foreach ( $args['friend_user']->get_active_feeds() as $feed ) {
+foreach ( $args['friend_user']->get_feeds() as $feed ) {
 	// Check if this is an ActivityPub feed (parser is 'activitypub').
 	if ( 'activitypub' !== $feed->get_parser() ) {
 		continue;
@@ -181,6 +181,12 @@ foreach ( $activitypub_feeds as $ap_feed ) :
 		<a class="chip activitypub-profile" href="<?php echo esc_url( $ap_feed['url'] ); ?>" target="_blank" rel="noopener" title="<?php esc_attr_e( 'ActivityPub Profile', 'friends' ); ?>">
 			<span class="dashicons dashicons-rss" style="font-size: 14px; width: 14px; height: 14px; margin-right: 4px; vertical-align: text-bottom;"></span><?php echo esc_html( $ap_display ); ?>
 		</a>
+		<span class="chip activitypub-follower-check is-loading"
+			data-actor-url="<?php echo esc_attr( $ap_feed['url'] ); ?>"
+			data-nonce="<?php echo esc_attr( wp_create_nonce( 'friends-check-follower' ) ); ?>"
+			title="<?php esc_attr_e( 'Checking whether this actor follows you.', 'friends' ); ?>">
+			<?php esc_html_e( 'Checking follower...', 'friends' ); ?>
+		</span>
 		<?php
 	endif;
 endforeach;

--- a/templates/frontend/messages.php
+++ b/templates/frontend/messages.php
@@ -23,9 +23,9 @@ $get_message_friend_user = function ( $message ) {
 	$terms = wp_get_object_terms( $message->ID, Friends\Messages::TAXONOMY );
 	if ( ! empty( $terms ) && ! is_wp_error( $terms ) ) {
 		$term = reset( $terms );
-		$user = get_user_by( 'id', absint( $term->slug ) );
+		$user = Friends\User::get_user_by_id( absint( $term->slug ) );
 		if ( $user ) {
-			return new Friends\User( $user );
+			return $user;
 		}
 	}
 

--- a/templates/google-reader/google-reader.css
+++ b/templates/google-reader/google-reader.css
@@ -266,6 +266,18 @@
 .friends-page .chip:hover { background: light-dark(#d0e0f5, #4a4d51); text-decoration: none; }
 .friends-page span.chip { color: light-dark(#666, #bdc1c6); cursor: default; }
 .friends-page span.chip:hover { background: light-dark(#e3ecf8, #3c4043); }
+.friends-page .chip.activitypub-follower-check.is-following {
+	background: light-dark(#e4f6e8, rgba(46,160,67,.22));
+	color: light-dark(#116329, #8ddb8c);
+}
+.friends-page .chip.activitypub-follower-check.is-not-following {
+	background: light-dark(#fff4d6, rgba(210,153,34,.22));
+	color: light-dark(#7a4d00, #eac55f);
+}
+.friends-page .chip.activitypub-follower-check.is-error {
+	background: light-dark(#fde7e9, rgba(218,54,51,.22));
+	color: light-dark(#8a2424, #ff9b9b);
+}
 
 /* === Search === */
 .friends-page .form-input,

--- a/templates/mastodon/mastodon.css
+++ b/templates/mastodon/mastodon.css
@@ -493,6 +493,18 @@ body.friends-page {
 .friends-page a.chip:visited { color: light-dark(#563acc, #c4bbff); }
 .friends-page .chip:hover { background: light-dark(rgba(86,58,204,.15), rgba(99,100,255,.25)); text-decoration: none; }
 .friends-page span.chip { cursor: default; }
+.friends-page .chip.activitypub-follower-check.is-following {
+	background: light-dark(#e4f6e8, rgba(46,160,67,.22));
+	color: light-dark(#116329, #8ddb8c);
+}
+.friends-page .chip.activitypub-follower-check.is-not-following {
+	background: light-dark(#fff4d6, rgba(210,153,34,.22));
+	color: light-dark(#7a4d00, #eac55f);
+}
+.friends-page .chip.activitypub-follower-check.is-error {
+	background: light-dark(#fde7e9, rgba(218,54,51,.22));
+	color: light-dark(#8a2424, #ff9b9b);
+}
 
 /* Description text in author header chips area */
 .mastodon-chips-area p {

--- a/templates/twitter/twitter.css
+++ b/templates/twitter/twitter.css
@@ -629,6 +629,18 @@ body.friends-page {
 .friends-page a.chip:visited { color: light-dark(#0f1419, #e7e9ea); }
 .friends-page .chip:hover { background: light-dark(rgba(15,20,25,.1), rgba(231,233,234,.1)); text-decoration: none; }
 .friends-page span.chip { cursor: default; }
+.friends-page .chip.activitypub-follower-check.is-following {
+	background: light-dark(#e4f6e8, rgba(46,160,67,.22));
+	color: light-dark(#116329, #8ddb8c);
+}
+.friends-page .chip.activitypub-follower-check.is-not-following {
+	background: light-dark(#fff4d6, rgba(210,153,34,.22));
+	color: light-dark(#7a4d00, #eac55f);
+}
+.friends-page .chip.activitypub-follower-check.is-error {
+	background: light-dark(#fde7e9, rgba(218,54,51,.22));
+	color: light-dark(#8a2424, #ff9b9b);
+}
 
 .twitter-chips-area p {
 	font-size: 14px;

--- a/tests/test-activitypub.php
+++ b/tests/test-activitypub.php
@@ -829,6 +829,64 @@ class ActivityPubTest extends Friends_TestCase_Cache_HTTP {
 		delete_option( 'friends_disable_auto_tagging' );
 	}
 
+	public function test_direct_message_from_unknown_actor_is_saved() {
+		$unknown_actor = 'https://mastodon.local/users/unknown-dm-sender';
+		self::$users[ $unknown_actor ] = array(
+			'id'                => $unknown_actor,
+			'url'               => $unknown_actor,
+			'name'              => 'Unknown DM Sender',
+			'preferredUsername' => 'unknown-dm-sender',
+			'icon'              => array(
+				'type' => 'Image',
+				'url'  => $unknown_actor . '.png',
+			),
+		);
+
+		$local_user = get_current_user_id();
+		$local_activitypub_id = $this->mock_local_user_activitypub_metadata( $local_user );
+		$date = gmdate( \DATE_W3C, time() - 10 );
+		$id = $unknown_actor . '/statuses/direct-message';
+		$content = 'Hello from someone you do not follow.';
+
+		$parser = Friends::get_instance()->feed->get_feed_parser( Feed_Parser_ActivityPub::SLUG );
+		$parser->handle_received_direct_message(
+			array(
+				'type'   => 'Create',
+				'id'     => $id . '/activity',
+				'actor'  => $unknown_actor,
+				'to'     => array( $local_activitypub_id ),
+				'object' => array(
+					'id'           => $id,
+					'type'         => 'Note',
+					'published'    => $date,
+					'attributedTo' => $unknown_actor,
+					'to'           => array( $local_activitypub_id ),
+					'content'      => $content,
+				),
+			),
+			$local_user
+		);
+
+		$user_feed = User_Feed::get_by_url( $unknown_actor );
+		$this->assertInstanceof( User_Feed::class, $user_feed );
+		$this->assertFalse( $user_feed->is_active(), 'Receiving a DM must not follow the sender.' );
+
+		$friend_user = $user_feed->get_friend_user();
+		$messages = get_posts(
+			array(
+				'post_type'   => Messages::CPT,
+				'post_status' => 'friends_unread',
+				'numberposts' => -1,
+			)
+		);
+
+		$this->assertCount( 1, $messages );
+		$this->assertSame( $content, $messages[0]->post_content );
+		$this->assertSame( $id, $messages[0]->guid );
+		$this->assertSame( (int) $friend_user->ID, (int) User::get_post_author( $messages[0] )->ID );
+		$this->assertSame( $unknown_actor, get_post_meta( $messages[0]->ID, 'friends_feed_url', true ) );
+	}
+
 	public function test_comment_on_cached_post_federation() {
 		$remote_post_url = 'https://mastodon.local/users/akirk/statuses/123456';
 


### PR DESCRIPTION
## Summary
- Save private ActivityPub messages from actors you do not follow by creating an inactive sender identity.
- Allow replying to those inactive ActivityPub DM sender feeds without following them.
- Add an async follower-status pill to ActivityPub friend profiles so DM deliverability can be checked.

## Testing
- composer check-cs
- php -l feed-parsers/class-feed-parser-activitypub.php
- php -l templates/frontend/author-header.php
- php -l templates/frontend/messages.php
- node --check friends.js
- Verified Diego Galvalisi follower status on alex.kirk.at via the new AJAX handler.

<details><summary>Changelog</summary>

- [x] Automatically create a changelog entry from the details below

#### Type
- [x] Fixed

#### Message
Show direct messages from ActivityPub users you do not follow and surface follower status on their profile.

</details>