### PR TITLE
Link profile messages to DM view

### DIFF
--- a/.github/changelog/unreleased/673-from-description
+++ b/.github/changelog/unreleased/673-from-description
@@ -1,0 +1,3 @@
+Type: fixed
+
+Link profile message previews to the direct messages view.

--- a/friends.css
+++ b/friends.css
@@ -2261,6 +2261,24 @@ h2#page-title a.dashicons {
 		overflow: auto;
 	}
 
+	& .friends-profile-messages {
+		overflow: hidden;
+		padding: 0;
+	}
+
+	& .friends-profile-messages-header {
+		align-items: center;
+		border-bottom: 1px solid #e5e7eb;
+		display: flex;
+		justify-content: space-between;
+		padding: .65rem .7rem;
+	}
+
+	& .friends-profile-messages .friends-dm-conversation,
+	& .friends-profile-messages .friends-dm-conversation:visited {
+		grid-template-columns: minmax(0, 1fr) auto;
+	}
+
 	& .friends-dm-conversation,
 	& .friends-dm-conversation:visited {
 		border-bottom: 1px solid #e5e7eb;

--- a/templates/frontend/messages/friend.php
+++ b/templates/frontend/messages/friend.php
@@ -12,8 +12,11 @@ if ( false === strpos( $time_format, ':s' ) ) {
 }
 
 ?>
-<div class="card mt-2 p-2">
-	<strong><?php esc_html_e( 'Messages', 'friends' ); ?></strong>
+<div class="card mt-2 p-2 friends-profile-messages">
+	<div class="friends-profile-messages-header">
+		<strong><?php esc_html_e( 'Direct messages', 'friends' ); ?></strong>
+		<a href="<?php echo esc_url( home_url( '/friends/messages/' ) ); ?>"><?php esc_html_e( 'View all', 'friends' ); ?></a>
+	</div>
 	<?php
 	foreach ( $args['existing_messages']->get_posts() as $_post ) {
 		$messages = get_posts(
@@ -27,12 +30,14 @@ if ( false === strpos( $time_format, ':s' ) ) {
 		);
 		array_unshift( $messages, $_post );
 
-		$classes = array( 'display-message' => true );
-		$subject = false;
+		$classes           = array( 'friends-dm-conversation' => true );
+		$subject           = false;
 		$last_message_time = false;
+		$unread_count      = 0;
 		foreach ( $messages as $message ) {
 			if ( get_post_status( $message ) === 'friends_unread' ) {
-				$classes['unread'] = true;
+				$classes['is-unread'] = true;
+				++$unread_count;
 			}
 			$post_time = get_post_modified_time( 'U', true, $message );
 			if ( ! $last_message_time || $post_time > $last_message_time ) {
@@ -44,74 +49,22 @@ if ( false === strpos( $time_format, ':s' ) ) {
 				}
 			}
 		}
+		$conversation_url = add_query_arg( 'conversation', $_post->ID, home_url( '/friends/messages/' ) );
 		?>
-		<div class="friend-message" id="message-<?php echo esc_attr( $_post->ID ); ?>" data-id="<?php echo esc_attr( $_post->ID ); ?>" data-nonce="<?php echo esc_attr( wp_create_nonce( 'friends-mark-read' ) ); ?>">
-		<a href="" class="<?php echo esc_attr( implode( ' ', array_keys( $classes ) ) ); ?>" title="<?php echo esc_attr( date_i18n( $time_format, $last_message_time ) ); ?>">
-			<?php
-			// translators: %s is a time span.
-			echo esc_html( sprintf( __( '%s ago' ), human_time_diff( $last_message_time ) ) ); // phpcs:ignore WordPress.WP.I18n.MissingArgDomain
-			echo ': ';
-			echo esc_html( $subject );
-			?>
+		<a class="<?php echo esc_attr( implode( ' ', array_keys( $classes ) ) ); ?>" href="<?php echo esc_url( $conversation_url ); ?>">
+			<span class="friends-dm-conversation-main">
+				<span class="friends-dm-conversation-name"><?php echo esc_html( $args['friend_user']->display_name ); ?></span>
+				<span class="friends-dm-conversation-preview"><?php echo esc_html( $subject ); ?></span>
+			</span>
+			<span class="friends-dm-conversation-meta">
+				<time title="<?php echo esc_attr( date_i18n( $time_format, $last_message_time ) ); ?>">
+					<?php echo esc_html( human_time_diff( $last_message_time ) ); ?>
+				</time>
+				<?php if ( $unread_count ) : ?>
+					<span class="friends-dm-unread-count"><?php echo esc_html( number_format_i18n( $unread_count ) ); ?></span>
+				<?php endif; ?>
+			</span>
 		</a>
-		<div style="display: none" class="conversation">
-			<div class="messages">
-			<?php
-			foreach ( $messages as $message ) {
-				?>
-				<div class="message">
-				<?php
-				$post_time = get_post_modified_time( 'U', true, $message );
-				$ago = human_time_diff( $post_time );
-				$post_time = date_i18n( $time_format, $post_time );
-				$author = Friends\User::get_post_author( $message );
-				if ( get_current_user_id() === $author->ID ) {
-					echo wp_kses_post(
-						sprintf(
-							// translators: %2$s is the time span.
-							__( '<span class="author">You</span> wrote %s ago:', 'friends' ),
-							'<span class="time" title="' . esc_attr( $post_time ) . '">' . esc_html( $ago ) . '</span>'
-						)
-					);
-				} else {
-					echo wp_kses_post(
-						sprintf(
-							// translators: %1$s is the author, %2$s is the time span.
-							__( '%1$s wrote %2$s ago:', 'friends' ),
-							'<span class="author">' . esc_html( $author->display_name ) . '</span>',
-							'<span class="time" title="' . esc_attr( $post_time ) . '">' . esc_html( $ago ) . '</span>'
-						)
-					);
-				}
-				?>
-				<blockquote>
-				<?php
-				$content = make_clickable( get_the_content( null, false, $message ) );
-				echo wp_kses_post( apply_filters( 'the_content', $content ) );
-				?>
-				</blockquote>
-				</div>
-				<?php
-			}
-
-			$feed_args = array(
-				'subject'  => $title,
-				'reply_to' => $_post->ID,
-			);
-			$feed_url = get_post_meta( $_post->ID, 'friends_feed_url', true );
-			if ( $feed_url ) {
-				$feed_args['accounts'] = array( $feed_url => $args['accounts'][ $feed_url ] );
-			}
-
-			Friends\Friends::template_loader()->get_template_part(
-				'frontend/messages/message-form',
-				null,
-				array_merge( $args, $feed_args )
-			);
-		?>
-		</div>
-		</div>
-		</div>
 		<?php
 	}
 	?>

--- a/templates/google-reader/google-reader.css
+++ b/templates/google-reader/google-reader.css
@@ -509,6 +509,24 @@
 	overflow: auto;
 }
 
+.friends-page .friends-profile-messages {
+	overflow: hidden;
+	padding: 0 !important;
+}
+
+.friends-page .friends-profile-messages-header {
+	align-items: center;
+	border-bottom: 1px solid #e8e8e8;
+	display: flex;
+	justify-content: space-between;
+	padding: 7px 8px;
+}
+
+.friends-page .friends-profile-messages .friends-dm-conversation,
+.friends-page .friends-profile-messages .friends-dm-conversation:visited {
+	grid-template-columns: minmax(0, 1fr) auto;
+}
+
 .friends-page .friends-dm-conversation,
 .friends-page .friends-dm-conversation:visited {
 	border-bottom: 1px solid #e8e8e8;

--- a/templates/mastodon/mastodon.css
+++ b/templates/mastodon/mastodon.css
@@ -1438,6 +1438,32 @@ body.friends-page {
 	overflow: auto;
 }
 
+.friends-page .friends-profile-messages {
+	background: transparent;
+	border: none;
+	box-shadow: none;
+	overflow: hidden;
+	padding: 0 !important;
+}
+
+.friends-page .friends-profile-messages-header {
+	align-items: center;
+	border-bottom: 1px solid light-dark(#d4dde8, #393f4f);
+	display: flex;
+	justify-content: space-between;
+	padding: 12px 16px;
+}
+
+.friends-page .friends-profile-messages-header strong {
+	color: light-dark(#282c37, #dadada);
+	font-size: 15px;
+}
+
+.friends-page .friends-profile-messages .friends-dm-conversation,
+.friends-page .friends-profile-messages .friends-dm-conversation:visited {
+	grid-template-columns: minmax(0, 1fr) auto;
+}
+
 .friends-page .friends-dm-conversation,
 .friends-page .friends-dm-conversation:visited {
 	border-bottom: 1px solid light-dark(#d4dde8, #393f4f);

--- a/templates/twitter/twitter.css
+++ b/templates/twitter/twitter.css
@@ -1580,6 +1580,32 @@ body.friends-page {
 	overflow: auto;
 }
 
+.friends-page .friends-profile-messages {
+	background: transparent;
+	border: none;
+	box-shadow: none;
+	overflow: hidden;
+	padding: 0 !important;
+}
+
+.friends-page .friends-profile-messages-header {
+	align-items: center;
+	border-bottom: 1px solid light-dark(#eff3f4, #2f3336);
+	display: flex;
+	justify-content: space-between;
+	padding: 12px 16px;
+}
+
+.friends-page .friends-profile-messages-header strong {
+	color: light-dark(#0f1419, #e7e9ea);
+	font-size: 15px;
+}
+
+.friends-page .friends-profile-messages .friends-dm-conversation,
+.friends-page .friends-profile-messages .friends-dm-conversation:visited {
+	grid-template-columns: minmax(0, 1fr) auto;
+}
+
 .friends-page .friends-dm-conversation,
 .friends-page .friends-dm-conversation:visited {
 	border-bottom: 1px solid light-dark(#eff3f4, #2f3336);


### PR DESCRIPTION
## Summary
- Replace the embedded profile message thread with compact direct-message conversation links.
- Point each conversation to /friends/messages/?conversation={id}.
- Add theme-specific layout overrides for the new profile message rows.

## Testing
- php -l templates/frontend/messages/friend.php
- composer check-cs

<details><summary>Changelog</summary>

- [x] Automatically create a changelog entry from the details below

#### Type
- [x] Fixed

#### Message
Link profile message previews to the direct messages view.

</details>