### PR TITLE
Send direct messages through ActivityPub outbox

### DIFF
--- a/.github/changelog/unreleased/674-from-description
+++ b/.github/changelog/unreleased/674-from-description
@@ -1,0 +1,3 @@
+Type: fixed
+
+Send ActivityPub direct messages through the outbox so delivery can use the normal persistence and retry flow.

--- a/feed-parsers/class-feed-parser-activitypub.php
+++ b/feed-parsers/class-feed-parser-activitypub.php
@@ -895,17 +895,6 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 		}
 
 		update_post_meta( $post_id, 'activitypub_content_visibility', ACTIVITYPUB_CONTENT_VISIBILITY_PRIVATE );
-		$inbox = \Activitypub\Http::get_remote_object( $send_to );
-
-		if ( ! $inbox || \is_wp_error( $inbox ) ) {
-			return new \WP_Error( 'friends_activitypub_inbox_error', __( 'Cannot get Activitypub inbox.', 'friends' ), compact( 'post_id', 'to', 'send_to' ) );
-		}
-		$inboxes = array();
-		if ( ! empty( $inbox['endpoints']['sharedInbox'] ) ) {
-			$inboxes[] = $inbox['endpoints']['sharedInbox'];
-		} elseif ( ! empty( $inbox['inbox'] ) ) {
-			$inboxes[] = $inbox['inbox'];
-		}
 
 		require_once __DIR__ . '/activitypub/class-activitypub-transformer-message.php';
 
@@ -934,13 +923,18 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 		$activity->set_id( home_url( '?p=' . $post_id ) . '#direct-message' );
 		$activity->set_actor( $actor->get_id() );
 		$activity->set_object( $object );
-		$activity->set_to( $send_to );
+		$activity->set_to( array( $send_to ) );
 
-		$json = $activity->to_json();
-
-		foreach ( $inboxes as $inbox ) {
-			$result = \Activitypub\safe_remote_post( $inbox, $json, $actor->get__id() );
+		$outbox_activity_id = \Activitypub\add_to_outbox( $activity, null, $actor->get__id(), ACTIVITYPUB_CONTENT_VISIBILITY_PRIVATE );
+		if ( ! $outbox_activity_id ) {
+			return new \WP_Error(
+				'friends_activitypub_outbox_error',
+				__( 'Could not add ActivityPub direct message to the outbox.', 'friends' ),
+				compact( 'post_id', 'to', 'send_to' )
+			);
 		}
+
+		update_post_meta( $post_id, 'activitypub_direct_message_outbox_id', $outbox_activity_id );
 
 		return $post_id;
 	}

--- a/tests/test-activitypub.php
+++ b/tests/test-activitypub.php
@@ -671,6 +671,46 @@ class ActivityPubTest extends Friends_TestCase_Cache_HTTP {
 		return $this->assertTrue( false ); // should not be called.
 	}
 
+	public function test_direct_message_is_added_to_activitypub_outbox() {
+		$post_id = Friends::get_instance()->messages->send_message( $this->friend, $this->actor, 'Hello by DM.' );
+
+		$this->assertIsInt( $post_id );
+		$outbox_id = get_post_meta( $post_id, 'activitypub_direct_message_outbox_id', true );
+		$this->assertNotEmpty( $outbox_id );
+
+		$outbox_item = get_post( $outbox_id );
+		$this->assertInstanceOf( \WP_Post::class, $outbox_item );
+		$this->assertSame( 'ap_outbox', $outbox_item->post_type );
+		$this->assertSame( 'pending', $outbox_item->post_status );
+		$this->assertSame( 'Create', get_post_meta( $outbox_id, '_activitypub_activity_type', true ) );
+		$this->assertSame( ACTIVITYPUB_CONTENT_VISIBILITY_PRIVATE, get_post_meta( $outbox_id, 'activitypub_content_visibility', true ) );
+
+		$activity = json_decode( $outbox_item->post_content, true );
+		$this->assertSame( 'Create', $activity['type'] );
+		$this->assertContains( $this->actor, $activity['to'] );
+		$this->assertContains( $this->actor, $activity['object']['to'] );
+		$this->assertStringContainsString( '@akirk', $activity['object']['content'] );
+	}
+
+	public function test_direct_message_reply_outbox_activity_has_in_reply_to() {
+		$reply_to_post_id = $this->friend->insert_post(
+			array(
+				'post_type'    => Messages::CPT,
+				'post_content' => 'Hello from the fediverse.',
+				'post_status'  => 'friends_read',
+				'guid'         => $this->actor . '/statuses/123',
+			)
+		);
+
+		$post_id = Friends::get_instance()->messages->send_message( $this->friend, $this->actor, 'Reply by DM.', '', $reply_to_post_id );
+
+		$this->assertIsInt( $post_id );
+		$outbox_id = get_post_meta( $post_id, 'activitypub_direct_message_outbox_id', true );
+		$activity  = json_decode( get_post( $outbox_id )->post_content, true );
+
+		$this->assertSame( $this->actor . '/statuses/123', $activity['object']['inReplyTo'] );
+	}
+
 	public function example_actors() {
 		$actors = array();
 		foreach ( array( 'user', 'test' ) as $username ) {


### PR DESCRIPTION
## Summary
- Route ActivityPub direct messages through the ActivityPub outbox instead of posting directly to remote inboxes.
- Store the created outbox item ID on the local friend message.
- Add tests covering DM outbox creation and reply `inReplyTo` preservation.

## Testing
- `composer check-cs`
- `git diff --check`
- `php -l feed-parsers/class-feed-parser-activitypub.php`
- `php -l tests/test-activitypub.php`

<details><summary>Changelog</summary>

- [x] Automatically create a changelog entry from the details below

#### Type
- [x] Fixed

#### Message
Send ActivityPub direct messages through the outbox so delivery can use the normal persistence and retry flow.

</details>