### PR TITLE
Improve direct message view

### DIFF
--- a/.github/changelog/unreleased/675-from-description
+++ b/.github/changelog/unreleased/675-from-description
@@ -1,0 +1,3 @@
+Type: fixed
+
+Improve direct message links, drafts, grouping, and live refresh behavior.

--- a/friends.css
+++ b/friends.css
@@ -2385,6 +2385,19 @@ h2#page-title a.dashicons {
 		margin: 0 0 .9rem;
 	}
 
+	& .friends-dm-message.is-consecutive-message {
+		margin-top: -.55rem;
+
+		& .friends-dm-message-avatar,
+		& .friends-dm-message-meta {
+			visibility: hidden;
+		}
+
+		& .friends-dm-message-content {
+			margin-top: 0;
+		}
+	}
+
 	& .friends-dm-message.is-own-message .friends-dm-message-content {
 		background: #eef6ff;
 	}

--- a/friends.js
+++ b/friends.js
@@ -601,6 +601,76 @@
 		return window.confirm( friends.text_del_convers );
 	} );
 
+	function getMessageDraftKey( form, field ) {
+		const key = $( form ).data( 'friends-message-draft-key' );
+		if ( ! key ) {
+			return '';
+		}
+
+		return key + ':' + field;
+	}
+
+	function getMessageDraftStorage() {
+		try {
+			return window.localStorage;
+		} catch ( e ) {
+			return false;
+		}
+	}
+
+	function restoreMessageDrafts() {
+		const storage = getMessageDraftStorage();
+		if ( ! storage ) {
+			return;
+		}
+
+		$( 'form[data-friends-message-draft-key]' ).each( function () {
+			const form = this;
+			const messageKey = getMessageDraftKey( form, 'message' );
+			const subjectKey = getMessageDraftKey( form, 'subject' );
+			const message = storage.getItem( messageKey );
+			const subject = storage.getItem( subjectKey );
+
+			if ( message ) {
+				$( form ).find( 'textarea[name="friends_message_message"]' ).val( message );
+			}
+
+			if ( subject ) {
+				$( form ).find( 'input[name="friends_message_subject"]:not([type="hidden"])' ).val( subject );
+			}
+		} );
+	}
+
+	$document.on( 'input', 'textarea[name="friends_message_message"], input[name="friends_message_subject"]', function () {
+		const storage = getMessageDraftStorage();
+		if ( ! storage ) {
+			return;
+		}
+
+		const form = this.form;
+		const field = 'friends_message_subject' === this.name ? 'subject' : 'message';
+		const key = getMessageDraftKey( form, field );
+		if ( ! key ) {
+			return;
+		}
+
+		if ( this.value ) {
+			storage.setItem( key, this.value );
+		} else {
+			storage.removeItem( key );
+		}
+	} );
+
+	$document.on( 'submit', 'form[data-friends-message-draft-key]', function () {
+		const storage = getMessageDraftStorage();
+		if ( ! storage ) {
+			return;
+		}
+
+		storage.removeItem( getMessageDraftKey( this, 'message' ) );
+		storage.removeItem( getMessageDraftKey( this, 'subject' ) );
+	} );
+
 	$document.on( 'click', 'a.display-message', function () {
 		const $this = $( this ).closest( 'div' );
 		const conversation = $this.find( 'div.conversation' );
@@ -630,15 +700,58 @@
 		return false;
 	} );
 
-	$( function () {
+	function getRelativeTime( timestamp ) {
+		const seconds = Math.max( 1, Math.floor( Date.now() / 1000 ) - timestamp );
+		const minute = 60;
+		const hour = 60 * minute;
+		const day = 24 * hour;
+		const week = 7 * day;
+		const month = 30 * day;
+		const year = 365 * day;
+
+		if ( seconds < minute ) {
+			return seconds + ' seconds';
+		}
+		if ( seconds < hour ) {
+			const minutes = Math.floor( seconds / minute );
+			return minutes + ' minute' + ( 1 === minutes ? '' : 's' );
+		}
+		if ( seconds < day ) {
+			const hours = Math.floor( seconds / hour );
+			return hours + ' hour' + ( 1 === hours ? '' : 's' );
+		}
+		if ( seconds < week ) {
+			const days = Math.floor( seconds / day );
+			return days + ' day' + ( 1 === days ? '' : 's' );
+		}
+		if ( seconds < month ) {
+			const weeks = Math.floor( seconds / week );
+			return weeks + ' week' + ( 1 === weeks ? '' : 's' );
+		}
+		if ( seconds < year ) {
+			const months = Math.floor( seconds / month );
+			return months + ' month' + ( 1 === months ? '' : 's' );
+		}
+
+		const years = Math.floor( seconds / year );
+		return years + ' year' + ( 1 === years ? '' : 's' );
+	}
+
+	function updateRelativeTimes( scope ) {
+		$( scope || document ).find( 'time[data-friends-relative-time]' ).each( function () {
+			const timestamp = parseInt( $( this ).data( 'friends-relative-time' ), 10 );
+			if ( ! timestamp ) {
+				return;
+			}
+
+			$( this ).text( getRelativeTime( timestamp ) + ( $( this ).data( 'friends-relative-time-suffix' ) || '' ) );
+		} );
+	}
+
+	function markCurrentDmThreadRead() {
 		const $thread = $( '.friends-dm-thread' );
 		if ( ! $thread.length ) {
 			return;
-		}
-
-		const messages = $thread.find( '.friends-dm-messages' ).get( 0 );
-		if ( messages ) {
-			messages.scrollTop = messages.scrollHeight;
 		}
 
 		if ( '1' !== String( $thread.data( 'unread' ) ) ) {
@@ -655,8 +768,78 @@
 					.removeClass( 'is-unread' )
 					.find( '.friends-dm-unread-count' )
 					.remove();
+				$thread.data( 'unread', '0' ).attr( 'data-unread', '0' );
 			},
 		} );
+	}
+
+	let isRefreshingDmView = false;
+
+	function refreshDmView() {
+		const $thread = $( '.friends-dm-thread' );
+		const $messages = $( '.friends-dm-messages' );
+		if ( isRefreshingDmView || ! $thread.length || ! $messages.length ) {
+			return;
+		}
+
+		isRefreshingDmView = true;
+
+		$.get( window.location.href ).done( function ( response ) {
+			const $response = $( $.parseHTML( response, document ) );
+			const $newSidebar = $response.find( '.friends-dm-sidebar' );
+			const $newThread = $response.find( '.friends-dm-thread' );
+			const $newMessages = $newThread.find( '.friends-dm-messages' );
+			if ( ! $newThread.length || ! $newMessages.length ) {
+				return;
+			}
+
+			const messages = $messages.get( 0 );
+			const shouldStickToBottom = messages && messages.scrollTop + messages.clientHeight >= messages.scrollHeight - 80;
+			const currentMessageIds = $messages.find( '.friends-dm-message' ).map( function () {
+				return $( this ).data( 'message-id' );
+			} ).get().join( ',' );
+			const newMessageIds = $newMessages.find( '.friends-dm-message' ).map( function () {
+				return $( this ).data( 'message-id' );
+			} ).get().join( ',' );
+
+			if ( $newSidebar.length && $newSidebar.html() !== $( '.friends-dm-sidebar' ).html() ) {
+				$( '.friends-dm-sidebar' ).html( $newSidebar.html() );
+			}
+
+			if ( newMessageIds !== currentMessageIds ) {
+				$messages.html( $newMessages.html() );
+				if ( shouldStickToBottom ) {
+					messages.scrollTop = messages.scrollHeight;
+				}
+			}
+
+			$thread
+				.data( 'unread', $newThread.data( 'unread' ) )
+				.attr( 'data-unread', $newThread.attr( 'data-unread' ) );
+			updateRelativeTimes( '.friends-dm-view' );
+			markCurrentDmThreadRead();
+		} ).always( function () {
+			isRefreshingDmView = false;
+		} );
+	}
+
+	$( function () {
+		restoreMessageDrafts();
+		updateRelativeTimes( document );
+
+		const $thread = $( '.friends-dm-thread' );
+		if ( ! $thread.length ) {
+			return;
+		}
+
+		const messages = $thread.find( '.friends-dm-messages' ).get( 0 );
+		if ( messages ) {
+			messages.scrollTop = messages.scrollHeight;
+		}
+
+		markCurrentDmThreadRead();
+		window.setInterval( updateRelativeTimes, 60000 );
+		window.setInterval( refreshDmView, 30000 );
 	} );
 
 	$document.on( 'mouseenter', 'h2#page-title a.dashicons, a.wp-block-friends-author-star.dashicons', function () {

--- a/includes/class-messages.php
+++ b/includes/class-messages.php
@@ -286,14 +286,19 @@ class Messages {
 
 		while ( $unread_messages->have_posts() ) {
 			$unread_messages->the_post();
-			$friend_user = User::get_post_author( $post );
+			$friend_user   = User::get_post_author( $post );
+			$conversation  = $post;
+			while ( $conversation->post_parent ) {
+				$conversation = get_post( $conversation->post_parent );
+			}
+			$conversation_url = add_query_arg( 'conversation', $conversation->ID, home_url( '/friends/messages/' ) );
 			$wp_menu->add_menu(
 				array(
 					'id'     => 'friend-message-' . $friend_user->ID,
 					'parent' => 'friends-menu',
 					// translators: %s is the number of open friend requests.
 					'title'  => '<span style="border-left: 2px solid #d63638; padding-left: .5em">' . esc_html( sprintf( __( 'New message from %s', 'friends' ), $friend_user->display_name ) ) . '</span>',
-					'href'   => $friend_user->get_local_friends_page_url(),
+					'href'   => $conversation_url,
 				)
 			);
 		}

--- a/includes/class-notifications.php
+++ b/includes/class-notifications.php
@@ -43,7 +43,7 @@ class Notifications {
 		add_filter( 'friends_rewrite_mail_html', array( $this, 'highlight_keywords' ), 10, 2 );
 		add_action( 'notify_new_friend_post', array( $this, 'notify_new_friend_post' ), 10, 3 );
 		add_filter( 'friends_notify_keyword_match_post', array( $this, 'notify_keyword_match_post' ), 10, 3 );
-		add_action( 'notify_friend_message_received', array( $this, 'notify_friend_message_received' ), 10, 3 );
+		add_action( 'notify_friend_message_received', array( $this, 'notify_friend_message_received' ), 10, 5 );
 		add_action( 'notify_unknown_friend_message_received', array( $this, 'notify_unknown_friend_message_received' ), 10, 4 );
 		add_action( 'activitypub_new_follower_email', array( $this, 'activitypub_new_follower_email' ), 10, 3 );
 		add_action( 'activitypub_followers_post_follow', array( $this, 'activitypub_followers_post_follow' ), 10, 4 );
@@ -216,10 +216,12 @@ class Notifications {
 	 * Notify the users of this site about a received message
 	 *
 	 * @param  User   $friend_user The user who sent the message.
-	 * @param       string $message     The message.
-	 * @param       string $subject     The subject.
+	 * @param  string $message     The message.
+	 * @param  string $subject     The subject.
+	 * @param  string $_feed_url   The feed URL.
+	 * @param  string $remote_url  The remote message URL.
 	 */
-	public function notify_friend_message_received( User $friend_user, $message, $subject ) {
+	public function notify_friend_message_received( User $friend_user, $message, $subject, $_feed_url = null, $remote_url = null ) {
 		$user = new User( Friends::get_main_friend_user_id() );
 		if ( defined( 'WP_TESTS_EMAIL' ) ) {
 			$user->user_email = WP_TESTS_EMAIL;
@@ -240,6 +242,7 @@ class Notifications {
 			'friend_user' => $friend_user,
 			'subject'     => $subject,
 			'message'     => $message,
+			'message_url' => $this->get_friend_message_url( $friend_user, $remote_url ),
 		);
 
 		$email_message = array();
@@ -257,6 +260,45 @@ class Notifications {
 		ob_end_clean();
 
 		$this->send_mail( $user->user_email, $email_title, $email_message );
+	}
+
+	/**
+	 * Get the URL for replying to a received direct message.
+	 *
+	 * @param User        $friend_user The message sender.
+	 * @param string|null $remote_url  The remote ActivityPub message URL.
+	 * @return string The reply URL.
+	 */
+	private function get_friend_message_url( User $friend_user, $remote_url = null ) {
+		if ( $remote_url ) {
+			add_filter( 'friends_frontend_post_types', array( $this, 'friends_frontend_post_types_only_messages' ), 999 );
+			$message_id = Feed::url_to_postid( $remote_url );
+			remove_filter( 'friends_frontend_post_types', array( $this, 'friends_frontend_post_types_only_messages' ), 999 );
+
+			if ( $message_id ) {
+				$message = get_post( $message_id );
+				if ( $message ) {
+					while ( $message && $message->post_parent ) {
+						$message = get_post( $message->post_parent );
+					}
+
+					if ( $message ) {
+						return add_query_arg( 'conversation', $message->ID, home_url( '/friends/messages/' ) );
+					}
+				}
+			}
+		}
+
+		return $friend_user->get_local_friends_page_url();
+	}
+
+	/**
+	 * Limit frontend post type lookups to messages.
+	 *
+	 * @return array The message post type.
+	 */
+	public function friends_frontend_post_types_only_messages() {
+		return array( Messages::CPT );
 	}
 
 	/**

--- a/templates/email/friend-message-received-text.php
+++ b/templates/email/friend-message-received-text.php
@@ -24,8 +24,7 @@ echo PHP_EOL . PHP_EOL;
 
 echo $quoted_text;
 
-// translators: %s is a URL.
-printf( wp_strip_all_tags( __( 'Go to your <a href=%s>friends page</a> to respond.', 'friends' ) ) );
+esc_html_e( 'Open the conversation to respond.', 'friends' );
 echo PHP_EOL . PHP_EOL;
 
-echo $args['friend_user']->get_local_friends_page_url();
+echo $args['message_url'];

--- a/templates/email/friend-message-received.php
+++ b/templates/email/friend-message-received.php
@@ -31,6 +31,6 @@
 <p>
 	<?php
 	// translators: %s is a URL.
-	echo wp_kses( sprintf( __( 'Go to your <a href=%s>friends page</a> to respond.', 'friends' ), esc_url( $args['friend_user']->get_local_friends_page_url() ) ), array( 'a' => array( 'href' => true ) ) );
+	echo wp_kses( sprintf( __( 'Open the <a href="%s">conversation</a> to respond.', 'friends' ), esc_url( $args['message_url'] ) ), array( 'a' => array( 'href' => true ) ) );
 	?>
 </p>

--- a/templates/frontend/messages.php
+++ b/templates/frontend/messages.php
@@ -142,7 +142,7 @@ Friends\Friends::template_loader()->get_template_part( 'frontend/header', null, 
 						<span class="friends-dm-conversation-preview"><?php echo esc_html( $conversation_row['preview'] ); ?></span>
 					</span>
 					<span class="friends-dm-conversation-meta">
-						<time title="<?php echo esc_attr( date_i18n( $time_format, $conversation_row['latest_time'] ) ); ?>">
+						<time data-friends-relative-time="<?php echo esc_attr( $conversation_row['latest_time'] ); ?>" title="<?php echo esc_attr( date_i18n( $time_format, $conversation_row['latest_time'] ) ); ?>">
 							<?php echo esc_html( human_time_diff( $conversation_row['latest_time'] ) ); ?>
 						</time>
 						<?php if ( $conversation_row['unread_count'] ) : ?>
@@ -173,14 +173,17 @@ Friends\Friends::template_loader()->get_template_part( 'frontend/header', null, 
 			</header>
 
 			<div class="friends-dm-messages">
+				<?php $previous_message_author_key = null; ?>
 				<?php foreach ( $selected_conversation['messages'] as $message ) : ?>
 					<?php
 					$message_author = Friends\User::get_post_author( $message );
 					$is_own_message = $message_author && ! is_wp_error( $message_author ) && get_current_user_id() === intval( $message_author->ID );
 					$author_name    = $message_author && ! is_wp_error( $message_author ) ? $message_author->display_name : __( 'Unknown sender', 'friends' );
 					$post_time      = get_post_modified_time( 'U', true, $message );
+					$author_key     = $message_author && ! is_wp_error( $message_author ) ? 'user-' . $message_author->ID : 'unknown';
+					$is_consecutive = $author_key === $previous_message_author_key;
 					?>
-					<div class="friends-dm-message<?php echo $is_own_message ? ' is-own-message' : ''; ?>">
+					<div class="friends-dm-message<?php echo $is_own_message ? ' is-own-message' : ''; ?><?php echo $is_consecutive ? ' is-consecutive-message' : ''; ?>" data-message-id="<?php echo esc_attr( $message->ID ); ?>">
 						<div class="friends-dm-message-avatar">
 							<?php if ( ! $is_own_message && $message_author && ! is_wp_error( $message_author ) && $message_author->get_avatar_url() ) : ?>
 								<img class="avatar" src="<?php echo esc_url( $message_author->get_avatar_url() ); ?>" alt="" width="32" height="32">
@@ -191,7 +194,7 @@ Friends\Friends::template_loader()->get_template_part( 'frontend/header', null, 
 						<div class="friends-dm-message-body">
 							<div class="friends-dm-message-meta">
 								<strong><?php echo esc_html( $is_own_message ? __( 'You', 'friends' ) : $author_name ); ?></strong>
-								<time title="<?php echo esc_attr( date_i18n( $time_format, $post_time ) ); ?>">
+								<time data-friends-relative-time="<?php echo esc_attr( $post_time ); ?>" data-friends-relative-time-suffix="<?php echo esc_attr_x( ' ago', 'relative message timestamp suffix', 'friends' ); ?>" title="<?php echo esc_attr( date_i18n( $time_format, $post_time ) ); ?>">
 									<?php
 									echo esc_html(
 										sprintf(
@@ -203,7 +206,7 @@ Friends\Friends::template_loader()->get_template_part( 'frontend/header', null, 
 									?>
 								</time>
 							</div>
-							<div class="friends-dm-message-content">
+							<div class="friends-dm-message-content" title="<?php echo esc_attr( date_i18n( $time_format, $post_time ) ); ?>">
 								<?php
 								$content = make_clickable( get_the_content( null, false, $message ) );
 								echo wp_kses_post( apply_filters( 'the_content', $content ) );
@@ -211,6 +214,7 @@ Friends\Friends::template_loader()->get_template_part( 'frontend/header', null, 
 							</div>
 						</div>
 					</div>
+					<?php $previous_message_author_key = $author_key; ?>
 				<?php endforeach; ?>
 			</div>
 

--- a/templates/frontend/messages/message-form.php
+++ b/templates/frontend/messages/message-form.php
@@ -10,8 +10,18 @@ if ( ! isset( $args['subject'] ) && ! isset( $args['reply_to'] ) ) {
 	<div class="card mt-2 p-2" id="friends-send-new-message" style="display: none">
 	<?php
 }
+
+$draft_key = implode(
+	':',
+	array(
+		'friends-message-draft',
+		get_current_user_id(),
+		$args['friend_user']->user_login,
+		isset( $args['reply_to'] ) ? 'reply-' . absint( $args['reply_to'] ) : 'new',
+	)
+);
 ?>
-<form method="post" class="form-horizontal">
+<form method="post" class="form-horizontal" data-friends-message-draft-key="<?php echo esc_attr( $draft_key ); ?>">
 	<input type="hidden" name="friends_message_recipient" value="<?php echo esc_attr( $args['friend_user']->user_login ); ?>">
 	<?php if ( isset( $args['reply_to'] ) ) : ?>
 		<input type="hidden" name="friends_message_reply_to" value="<?php echo esc_attr( $args['reply_to'] ); ?>">

--- a/tests/test-notifications.php
+++ b/tests/test-notifications.php
@@ -91,6 +91,38 @@ class NotificationTest extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test message notifications link to the direct message view.
+	 */
+	public function test_notify_friend_message_received_links_to_conversation() {
+		$that = $this;
+		update_option( 'home', 'http://me.local' );
+
+		add_filter(
+			'friends_send_mail',
+			function ( $do_send, $to, $subject, $message ) use ( $that ) {
+				$that->assertEquals( $to, \WP_TESTS_EMAIL );
+				$that->assertStringContainsString( 'sent you a message', $subject );
+				$that->assertStringContainsString( 'http://me.local/friends/messages/?conversation=', $message['html'] );
+				$that->assertStringContainsString( 'http://me.local/friends/messages/?conversation=', $message['text'] );
+				$that->assertTrue( $do_send );
+				return false;
+			},
+			10,
+			4
+		);
+
+		do_action(
+			'notify_friend_message_received',
+			new User( $this->friend_id ),
+			'<p>Hello there.</p>',
+			'',
+			'https://friend.local/users/friend',
+			'https://friend.local/messages/1',
+			null
+		);
+	}
+
+	/**
 	 * Test notifications of a new post.
 	 */
 	public function test_no_notify_new_post_single_setting() {


### PR DESCRIPTION
## Summary
- Link message notification emails and masterbar unread-message entries directly to DM conversations.
- Save message drafts locally per conversation and improve consecutive-message rendering.
- Auto-update relative timestamps and poll the current DM view for new messages.

## Testing
- composer check-cs
- php -l includes/class-messages.php
- php -l includes/class-notifications.php
- php -l templates/frontend/messages.php
- php -l templates/frontend/messages/message-form.php
- php -l templates/email/friend-message-received.php
- php -l templates/email/friend-message-received-text.php

Note: PHPUnit could not run locally because /tmp/wordpress-tests-lib/includes/functions.php is missing.

<details><summary>Changelog</summary>

- [x] Automatically create a changelog entry from the details below

#### Type
- [x] Fixed

#### Message
Improve direct message links, drafts, grouping, and live refresh behavior.

</details>