### PR TITLE
Dispatch CI after changelog commits

### DIFF
--- a/.github/changelog/unreleased/677-from-description
+++ b/.github/changelog/unreleased/677-from-description
@@ -1,0 +1,3 @@
+Type: fixed
+
+Run CI checks on PR heads after the changelog workflow adds its generated commit.

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -4,6 +4,7 @@ on:
     types: [opened, edited, synchronize, reopened, ready_for_review, labeled, unlabeled]
 
 permissions:
+  actions: write
   contents: write
   issues: write
   pull-requests: read
@@ -197,7 +198,7 @@ jobs:
             }
 
             try {
-              await github.rest.repos.createOrUpdateFileContents( {
+              const response = await github.rest.repos.createOrUpdateFileContents( {
                 owner,
                 repo,
                 path,
@@ -205,7 +206,21 @@ jobs:
                 content: Buffer.from( content ).toString( 'base64' ),
                 branch: ref
               } );
-              core.info( `Created changelog file: ${ path }` );
+
+              const commitSha = response.data.commit.sha;
+              core.info( `Created changelog file: ${ path } in ${ commitSha }` );
+
+              // Commits made with GITHUB_TOKEN do not trigger push/pull_request workflows.
+              // Dispatch the required CI workflows explicitly so checks run on the new PR head.
+              for ( const workflow_id of [ 'test.yml', 'cs.yml', 'lint.yml' ] ) {
+                await github.rest.actions.createWorkflowDispatch( {
+                  owner,
+                  repo,
+                  workflow_id,
+                  ref
+                } );
+                core.info( `Dispatched ${ workflow_id } for ${ ref }` );
+              }
             } catch ( error ) {
-              core.setFailed( `Failed to create changelog file: ${ error.message }` );
+              core.setFailed( `Failed to create changelog file or dispatch CI: ${ error.message }` );
             }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,7 @@
 name: Friends
 on:
   push:
+  pull_request:
   workflow_dispatch:
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,6 @@
 name: Friends
 on:
   push:
-  pull_request:
   workflow_dispatch:
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,7 @@
 name: Friends
-on: [push]
+on:
+  push:
+  workflow_dispatch:
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/feed-parsers/activitypub/class-activitypub-transformer-message.php
+++ b/feed-parsers/activitypub/class-activitypub-transformer-message.php
@@ -92,6 +92,10 @@ class ActivityPub_Transformer_Message extends \Activitypub\Transformer\Post {
 		return \apply_filters( 'activitypub_the_content', $content );
 	}
 
+	public function get_rendered_content() {
+		return $this->get_content();
+	}
+
 	public function get_likes() {
 		// You can't fetch likes for a message.
 		return null;

--- a/feed-parsers/activitypub/class-activitypub-transformer-message.php
+++ b/feed-parsers/activitypub/class-activitypub-transformer-message.php
@@ -40,10 +40,35 @@ class ActivityPub_Transformer_Message extends \Activitypub\Transformer\Post {
 				if ( $acct && ! is_wp_error( $acct ) ) {
 					$acct = str_replace( 'acct:', '@', $acct );
 				}
+				if ( is_wp_error( $acct ) ) {
+					$acct = $this->get_acct_from_url( $to );
+				}
+				if ( ! $acct ) {
+					continue;
+				}
 				$this->mentions[ $acct ] = $to;
 			}
 		}
 		return $this->mentions;
+	}
+
+	private function get_acct_from_url( $url ) {
+		$host = wp_parse_url( $url, PHP_URL_HOST );
+		$path = trim( (string) wp_parse_url( $url, PHP_URL_PATH ), '/' );
+
+		if ( ! $host || ! $path ) {
+			return null;
+		}
+
+		$path_parts = explode( '/', $path );
+		$username   = end( $path_parts );
+		$username   = ltrim( $username, '@' );
+
+		if ( ! $username ) {
+			return null;
+		}
+
+		return sprintf( '@%s@%s', $username, $host );
 	}
 
 	protected function get_content() {

--- a/feed-parsers/class-feed-parser-activitypub.php
+++ b/feed-parsers/class-feed-parser-activitypub.php
@@ -910,13 +910,19 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 		}
 		$transformer->set_content_visibility( ACTIVITYPUB_CONTENT_VISIBILITY_PRIVATE );
 		$transformer->to = array( $send_to );
+		$reply_to_url    = null;
 		if ( $reply_to_post_id ) {
 			$reply_to = get_post( $reply_to_post_id );
 			if ( ! is_wp_error( $reply_to ) ) {
-				$transformer->in_reply_to = $reply_to->guid;
+				$reply_to_url               = $reply_to->guid;
+				$transformer->in_reply_to = $reply_to_url;
 			}
 		}
 		$object = $transformer->to_object();
+		$object->set_to( array( $send_to ) );
+		if ( $reply_to_url ) {
+			$object->set_in_reply_to( $reply_to_url );
+		}
 
 		$activity = new \Activitypub\Activity\Activity();
 		$activity->set_type( 'Create' );

--- a/feed-parsers/class-feed-parser-activitypub.php
+++ b/feed-parsers/class-feed-parser-activitypub.php
@@ -919,6 +919,7 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 			}
 		}
 		$object = $transformer->to_object();
+		$object->set_content( $transformer->get_rendered_content() );
 		$object->set_to( array( $send_to ) );
 		if ( $reply_to_url ) {
 			$object->set_in_reply_to( $reply_to_url );


### PR DESCRIPTION
## Summary
- Add manual dispatch support to the test workflow.
- Dispatch test, CS, and lint workflows after the changelog workflow creates its bot commit.

## Testing
- composer check-cs
- ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "#{f}: ok" }' .github/workflows/test.yml .github/workflows/changelog.yml
- git diff --check

<details><summary>Changelog</summary>

- [x] Automatically create a changelog entry from the details below

#### Type
- [x] Fixed

#### Message
Run CI checks on PR heads after the changelog workflow adds its generated commit.

</details>