### PR TITLE
Use PAT for generated changelog commits

### DIFF
--- a/.github/changelog/unreleased/679-from-description
+++ b/.github/changelog/unreleased/679-from-description
@@ -1,0 +1,3 @@
+Type: fixed
+
+Run normal PR checks after workflow-generated changelog commits.

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -4,7 +4,6 @@ on:
     types: [opened, edited, synchronize, reopened, ready_for_review, labeled, unlabeled]
 
 permissions:
-  actions: write
   contents: write
   issues: write
   pull-requests: read
@@ -139,7 +138,7 @@ jobs:
           PR_MESSAGE: '${{ steps.check-pr-body.outputs.message }}'
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.API_TOKEN_GITHUB }}
           script: |
             const { repo: { owner, repo }, payload : { pull_request : { number, head : { ref, repo: head_repo } } } } = context;
 
@@ -207,20 +206,7 @@ jobs:
                 branch: ref
               } );
 
-              const commitSha = response.data.commit.sha;
-              core.info( `Created changelog file: ${ path } in ${ commitSha }` );
-
-              // Commits made with GITHUB_TOKEN do not trigger push/pull_request workflows.
-              // Dispatch the required CI workflows explicitly so checks run on the new PR head.
-              for ( const workflow_id of [ 'test.yml', 'cs.yml', 'lint.yml' ] ) {
-                await github.rest.actions.createWorkflowDispatch( {
-                  owner,
-                  repo,
-                  workflow_id,
-                  ref
-                } );
-                core.info( `Dispatched ${ workflow_id } for ${ ref }` );
-              }
+              core.info( `Created changelog file: ${ path } in ${ response.data.commit.sha }` );
             } catch ( error ) {
-              core.setFailed( `Failed to create changelog file or dispatch CI: ${ error.message }` );
+              core.setFailed( `Failed to create changelog file: ${ error.message }` );
             }


### PR DESCRIPTION
## Summary
- use `API_TOKEN_GITHUB` for workflow-generated changelog commits
- remove the manual workflow dispatch workaround after changelog commits
- let normal push/pull_request events attach checks to the updated PR head

## Setup required
Before this is merged, add a repository secret named `API_TOKEN_GITHUB` with a fine-grained token that can write contents to this repository.

## Testing
- composer check-cs

<details><summary>Changelog</summary>

- [x] Automatically create a changelog entry from the details below

#### Type
- [x] Fixed

#### Message
Run normal PR checks after workflow-generated changelog commits.

</details>