### PR TITLE
Render custom emoji in ActivityPub actor names

### DIFF
--- a/.github/changelog/unreleased/681-from-description
+++ b/.github/changelog/unreleased/681-from-description
@@ -1,0 +1,3 @@
+Type: fixed
+
+Render ActivityPub custom emoji in actor display names.

--- a/feed-parsers/class-feed-parser-activitypub.php
+++ b/feed-parsers/class-feed-parser-activitypub.php
@@ -260,8 +260,8 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 
 
 	public function mastodon_api_mapback_user_id( $user_id ) {
-		if ( ! is_string( $user_id ) && $user_id < 1e10 ) {
-			return $user_id;
+		if ( is_numeric( $user_id ) && $user_id < 1e10 ) {
+			return absint( $user_id );
 		}
 
 		$user = self::determine_mastodon_api_user( $user_id );
@@ -2061,7 +2061,7 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 		if ( isset( $attributed_to['ap_actor_id'] ) && $attributed_to['ap_actor_id'] ) {
 			$cache_key = 'ap_' . $attributed_to['ap_actor_id'];
 		} elseif ( isset( $attributed_to['id'] ) ) {
-			$cache_key = 'id_' . $attributed_to['id'];
+			$cache_key = 'id_' . md5( wp_json_encode( $attributed_to ) );
 		}
 		if ( $cache_key && isset( $cache[ $cache_key ] ) ) {
 			return $cache[ $cache_key ];
@@ -2300,7 +2300,30 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 	 * @return string HTML with custom emoji images.
 	 */
 	public static function replace_custom_emojis_for_user( $text, ?User $friend_user = null ) {
-		return self::replace_custom_emojis( $text, self::get_custom_emojis_for_user( $friend_user ) );
+		$emojis = self::get_custom_emojis_for_user( $friend_user );
+		$html   = self::replace_custom_emojis( $text, $emojis );
+
+		if ( empty( $emojis ) || ! $friend_user || esc_html( $text ) !== $html ) {
+			return $html;
+		}
+
+		foreach ( $friend_user->get_active_feeds() as $user_feed ) {
+			if ( self::SLUG !== $user_feed->get_parser() ) {
+				continue;
+			}
+
+			$ap_actor_id = $user_feed->get_ap_actor_id();
+			if ( ! $ap_actor_id ) {
+				continue;
+			}
+
+			$actor_title = get_post_field( 'post_title', $ap_actor_id );
+			if ( $actor_title && $actor_title !== $text ) {
+				return self::replace_custom_emojis( $actor_title, $emojis );
+			}
+		}
+
+		return $html;
 	}
 
 	/**

--- a/feed-parsers/class-feed-parser-activitypub.php
+++ b/feed-parsers/class-feed-parser-activitypub.php
@@ -2265,6 +2265,62 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 	}
 
 	/**
+	 * Get custom emoji metadata for a Friends user with an ActivityPub feed.
+	 *
+	 * @param User|null $friend_user The Friends user.
+	 * @return array Map of shortcode to image URL.
+	 */
+	public static function get_custom_emojis_for_user( ?User $friend_user = null ) {
+		if ( ! $friend_user ) {
+			return array();
+		}
+
+		foreach ( $friend_user->get_active_feeds() as $user_feed ) {
+			if ( self::SLUG !== $user_feed->get_parser() ) {
+				continue;
+			}
+
+			$ap_actor_id = $user_feed->get_ap_actor_id();
+			if ( ! $ap_actor_id ) {
+				continue;
+			}
+
+			self::refresh_actor_if_stale( $ap_actor_id );
+			return self::get_custom_emojis_from_actor_post( $ap_actor_id );
+		}
+
+		return array();
+	}
+
+	/**
+	 * Replaces custom emoji shortcodes in a Friends user's display name.
+	 *
+	 * @param string    $text        The display name.
+	 * @param User|null $friend_user The Friends user.
+	 * @return string HTML with custom emoji images.
+	 */
+	public static function replace_custom_emojis_for_user( $text, ?User $friend_user = null ) {
+		return self::replace_custom_emojis( $text, self::get_custom_emojis_for_user( $friend_user ) );
+	}
+
+	/**
+	 * Get the HTML allowed for rendered ActivityPub custom emoji.
+	 *
+	 * @return array Allowed HTML.
+	 */
+	public static function get_custom_emoji_allowed_html() {
+		return array(
+			'img' => array(
+				'alt'     => true,
+				'class'   => true,
+				'loading' => true,
+				'src'     => true,
+				'title'   => true,
+			),
+		);
+	}
+
+	/**
 	 * Gets the external mentions user.
 	 *
 	 * @return     User  The external mentions user.

--- a/friends.css
+++ b/friends.css
@@ -1554,6 +1554,16 @@ h2#page-title a.dashicons {
 	& dialog { border: 0; box-shadow: 0 0 10px rgba(0, 0, 0, 0.6); }
 	& header.navbar section.navbar-section.author { flex: 3; min-width: 20em; }
 	& summary.quick-status-panel-opener { margin-bottom: 2em; cursor: pointer; }
+	& .activitypub-custom-emoji {
+		display: inline-block;
+		width: auto;
+		max-width: 1.5em;
+		height: 1em;
+		max-height: 1em;
+		margin: 0 0.05em;
+		object-fit: contain;
+		vertical-align: -0.15em;
+	}
 
 	& article {
 		margin-bottom: 2em;
@@ -1565,16 +1575,6 @@ h2#page-title a.dashicons {
 		}
 
 		& .overflow { height: .5em; }
-		& .post-meta .boosted .activitypub-custom-emoji {
-			display: inline-block;
-			width: auto;
-			max-width: 1.5em;
-			height: 1em;
-			max-height: 1em;
-			margin: 0 0.05em;
-			object-fit: contain;
-			vertical-align: -0.15em;
-		}
 		& .boosted .follow-button, & .boosted .follow-button span.name { display: none; }
 		& .boosted:hover .follow-button { display: inline; }
 

--- a/includes/class-blocks.php
+++ b/includes/class-blocks.php
@@ -1322,7 +1322,7 @@ class Blocks {
 				'class' => 'wp-block-friends-author-name',
 				'id'    => 'page-title',
 			)
-		) . '>' . esc_html( $author->display_name ) . '</h2>';
+		) . '>' . wp_kses( Feed_Parser_ActivityPub::replace_custom_emojis_for_user( $author->display_name, $author ), Feed_Parser_ActivityPub::get_custom_emoji_allowed_html() ) . '</h2>';
 	}
 
 	/**

--- a/includes/class-frontend.php
+++ b/includes/class-frontend.php
@@ -872,18 +872,19 @@ class Frontend {
 				} else {
 					return '';
 				}
-				if ( empty( $author ) ) {
+				if ( empty( $author ) || is_wp_error( $author ) ) {
 					return '';
 				}
 
-				$author_name = $author->display_name;
+				$author_name      = $author->display_name;
+				$author_name_html = Feed_Parser_ActivityPub::replace_custom_emojis_for_user( $author_name, $author );
 				$override_author_name = apply_filters( 'friends_override_author_name', '', $author_name, $block->context['postId'] );
 				if ( isset( $attributes['isLink'] ) && $attributes['isLink'] ) {
-					$author_name = sprintf( '<a href="%1$s" target="%2$s" class="wp-block-post-author-name__link">%3$s</a>', $author->get_local_friends_page_url(), esc_attr( $attributes['linkTarget'] ), $author_name );
+					$author_name_html = sprintf( '<a href="%1$s" target="%2$s" class="wp-block-post-author-name__link">%3$s</a>', esc_url( $author->get_local_friends_page_url() ), esc_attr( $attributes['linkTarget'] ), $author_name_html );
 				}
 
 				if ( $override_author_name && trim( str_replace( $override_author_name, '', $author_name ) ) === $author_name ) {
-					$author_name .= ' – ' . esc_html( $override_author_name );
+					$author_name_html .= ' – ' . esc_html( $override_author_name );
 				}
 
 				$classes = array();
@@ -895,7 +896,23 @@ class Frontend {
 				}
 				$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => implode( ' ', $classes ) ) );
 
-				return sprintf( '<div %1$s>%2$s</div>', $wrapper_attributes, $author_name );
+				return sprintf(
+					'<div %1$s>%2$s</div>',
+					$wrapper_attributes,
+					wp_kses(
+						$author_name_html,
+						array_merge(
+							Feed_Parser_ActivityPub::get_custom_emoji_allowed_html(),
+							array(
+								'a' => array(
+									'class'  => true,
+									'href'   => true,
+									'target' => true,
+								),
+							)
+						)
+					)
+				);
 			};
 		}
 		return $settings;

--- a/includes/class-user-feed.php
+++ b/includes/class-user-feed.php
@@ -233,6 +233,15 @@ class User_Feed {
 			register_taxonomy_for_object_type( self::TAXONOMY, \Activitypub\Collection\Remote_Actors::POST_TYPE );
 		}
 
+		$object_ids = get_objects_in_term( $this->term->term_id, self::TAXONOMY );
+		if ( ! is_wp_error( $object_ids ) ) {
+			foreach ( $object_ids as $object_id ) {
+				if ( absint( $ap_actor_id ) !== absint( $object_id ) && 'ap_actor' === get_post_type( $object_id ) ) {
+					wp_remove_object_terms( $object_id, $this->term->term_id, self::TAXONOMY );
+				}
+			}
+		}
+
 		return wp_set_object_terms( absint( $ap_actor_id ), $this->term->term_id, self::TAXONOMY );
 	}
 

--- a/templates/frontend/author-header.php
+++ b/templates/frontend/author-header.php
@@ -10,6 +10,7 @@ $_feeds = count( $args['friend_user']->get_feeds() );
 $rules = count( $args['friend_user']->get_feed_rules() );
 $active_feeds = count( $args['friend_user']->get_active_feeds() );
 $hidden_post_count = $args['friend_user']->get_post_in_trash_count();
+$display_name_html = Friends\Feed_Parser_ActivityPub::replace_custom_emojis_for_user( $args['friend_user']->display_name, $args['friend_user'] );
 
 // Get ActivityPub feeds and their data (header image, profile URLs, summary).
 $activitypub_feeds = array();
@@ -112,7 +113,7 @@ if ( $args['friends']->frontend->reaction ) {
 		<img src="<?php echo esc_attr( $args['friend_user']->get_avatar_url() ); ?>" alt="<?php echo esc_attr( $args['friend_user']->display_name ); ?>" class="avatar" width="36" height="36" style="vertical-align: middle;" />
 		<?php
 	}
-	echo esc_html( $args['friend_user']->display_name );
+	echo wp_kses( $display_name_html, Friends\Feed_Parser_ActivityPub::get_custom_emoji_allowed_html() );
 }
 ?>
 </a>

--- a/templates/frontend/parts/header-status.php
+++ b/templates/frontend/parts/header-status.php
@@ -83,8 +83,9 @@ $author_url = apply_filters( 'friends_author_url', $friend_user->get_local_frien
 				// Only apply this for the External user - for regular subscriptions, always use friend_user display name.
 				$is_external_user = 'external' === $friend_user->user_login;
 				$names_differ     = $is_external_user && $override_author_name && trim( str_replace( $override_author_name, '', $author_name ) ) === $author_name;
+				$display_name     = $names_differ ? $override_author_name : $friend_user->display_name;
 				?>
-				<a href="<?php echo esc_attr( $author_url ); ?>"><strong><?php echo esc_html( $names_differ ? $override_author_name : $friend_user->display_name ); ?></strong></a>
+				<a href="<?php echo esc_attr( $author_url ); ?>"><strong><?php echo wp_kses( Friends\Feed_Parser_ActivityPub::replace_custom_emojis_for_user( $display_name, $friend_user ), Friends\Feed_Parser_ActivityPub::get_custom_emoji_allowed_html() ); ?></strong></a>
 				<?php do_action( 'friends_post_author_meta', $friend_user ); ?>
 				<?php if ( get_post_meta( get_the_ID(), '_has_mention_in_comments', true ) ) : ?>
 					<span class="mention-indicator" title="<?php esc_attr_e( 'You were mentioned in a comment', 'friends' ); ?>">@</span>

--- a/templates/frontend/parts/header.php
+++ b/templates/frontend/parts/header.php
@@ -70,8 +70,9 @@ $author_url = apply_filters( 'friends_author_url', $friend_user->get_local_frien
 				// Only apply this for the External user - for regular subscriptions, always use friend_user display name.
 				$is_external_user = 'external' === $friend_user->user_login;
 				$names_differ     = $is_external_user && $override_author_name && trim( str_replace( $override_author_name, '', $author_name ) ) === $author_name;
+				$display_name     = $names_differ ? $override_author_name : $friend_user->display_name;
 				?>
-				<a href="<?php echo esc_attr( $author_url ); ?>"><strong><?php echo esc_html( $names_differ ? $override_author_name : $friend_user->display_name ); ?></strong></a>
+				<a href="<?php echo esc_attr( $author_url ); ?>"><strong><?php echo wp_kses( Friends\Feed_Parser_ActivityPub::replace_custom_emojis_for_user( $display_name, $friend_user ), Friends\Feed_Parser_ActivityPub::get_custom_emoji_allowed_html() ); ?></strong></a>
 				<?php do_action( 'friends_post_author_meta', $friend_user ); ?>
 				<?php if ( get_post_meta( get_the_ID(), '_has_mention_in_comments', true ) ) : ?>
 					<span class="mention-indicator" title="<?php esc_attr_e( 'You were mentioned in a comment', 'friends' ); ?>">@</span>

--- a/templates/google-reader/google-reader.css
+++ b/templates/google-reader/google-reader.css
@@ -1082,8 +1082,7 @@
 	background: light-dark(#edf2fc, #2a2d35);
 }
 
-/* Follow button: hidden by default on boosted posts, shown on hover */
-.friends-page .posts .post-meta .boosted .activitypub-custom-emoji {
+.friends-page .activitypub-custom-emoji {
 	display: inline-block;
 	width: auto;
 	max-width: 1.5em;

--- a/templates/mastodon/mastodon.css
+++ b/templates/mastodon/mastodon.css
@@ -833,7 +833,7 @@ body.friends-page {
 	font-weight: 400;
 }
 
-.friends-page .posts .post-meta .boosted .activitypub-custom-emoji {
+.friends-page .activitypub-custom-emoji {
 	display: inline-block;
 	width: auto;
 	max-width: 1.5em;

--- a/templates/twitter/twitter.css
+++ b/templates/twitter/twitter.css
@@ -969,7 +969,7 @@ body.friends-page {
 	font-weight: 400;
 }
 
-.friends-page .posts .post-meta .boosted .activitypub-custom-emoji {
+.friends-page .activitypub-custom-emoji {
 	display: inline-block;
 	width: auto;
 	max-width: 1.5em;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -11,6 +11,10 @@ if ( ! $_tests_dir ) {
 	$_tests_dir = rtrim( sys_get_temp_dir(), '/\\' ) . '/wordpress-tests-lib';
 }
 
+if ( ! getenv( 'RANDFILE' ) ) {
+	putenv( 'RANDFILE=' . rtrim( sys_get_temp_dir(), '/\\' ) . '/.rnd' );
+}
+
 // Forward custom PHPUnit Polyfills configuration to PHPUnit bootstrap file.
 $_phpunit_polyfills_path = getenv( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH' );
 if ( false !== $_phpunit_polyfills_path ) {

--- a/tests/test-activitypub.php
+++ b/tests/test-activitypub.php
@@ -88,6 +88,48 @@ class ActivityPubTest extends Friends_TestCase_Cache_HTTP {
 		$this->assertStringContainsString( ':unknown:', $html );
 	}
 
+	public function test_replace_custom_emojis_for_activitypub_user() {
+		$user_feed = User_Feed::get_by_url( $this->actor );
+		$this->assertInstanceOf( User_Feed::class, $user_feed );
+
+		$ap_actor_id = $this->factory->post->create(
+			array(
+				'post_type'    => 'ap_actor',
+				'post_status'  => 'publish',
+				'post_title'   => 'Alex :party:',
+				'post_content' => wp_json_encode(
+					array(
+						'id'  => $this->actor,
+						'tag' => array(
+							array(
+								'type' => 'Emoji',
+								'name' => ':party:',
+								'icon' => array(
+									'url' => 'https://example.com/party.png',
+								),
+							),
+						),
+					)
+				),
+				'guid'         => $this->actor,
+			)
+		);
+
+		$user_feed->set_ap_actor_id( $ap_actor_id );
+		wp_update_user(
+			array(
+				'ID'           => $this->friend_id,
+				'display_name' => 'Alex :party:',
+			)
+		);
+
+		$friend = User::get_user_by_id( $this->friend_id );
+		$html   = Feed_Parser_ActivityPub::replace_custom_emojis_for_user( $friend->display_name, $friend );
+
+		$this->assertStringContainsString( 'Alex ', $html );
+		$this->assertStringContainsString( '<img class="activitypub-custom-emoji" src="https://example.com/party.png" alt=":party:" title="party" loading="lazy" />', $html );
+	}
+
 	public function test_incoming_post() {
 		$this->friend->update_user_option( 'activitypub_friends_show_replies', '1' );
 		$now = time() - 10;


### PR DESCRIPTION
## Summary
- Render ActivityPub custom emoji shortcodes in regular Friends actor display names, not only boost attribution.
- Apply the rendering in classic post headers, profile headings, and block-theme author name output.
- Broaden custom emoji sizing styles across Friends frontend themes.

## Testing
- php -l feed-parsers/class-feed-parser-activitypub.php
- php -l includes/class-frontend.php
- php -l includes/class-blocks.php
- php -l templates/frontend/parts/header.php
- php -l templates/frontend/parts/header-status.php
- php -l templates/frontend/author-header.php
- php -l tests/test-activitypub.php
- composer check-cs

Could not run phpunit because /tmp/wordpress-tests-lib is not installed in this environment.

<details><summary>Changelog</summary>

- [x] Automatically create a changelog entry from the details below

#### Type
- [x] Fixed

#### Message
Render ActivityPub custom emoji in actor display names.

</details>