### PR TITLE
Parse direct XML feeds served as text/plain

### DIFF
--- a/.github/changelog/unreleased/683-from-description
+++ b/.github/changelog/unreleased/683-from-description
@@ -1,0 +1,3 @@
+Type: fixed
+
+Parse direct XML feeds even when they are served with a text/plain content type.

--- a/feed-parsers/class-feed-parser-simplepie.php
+++ b/feed-parsers/class-feed-parser-simplepie.php
@@ -149,6 +149,21 @@ class Feed_Parser_SimplePie extends Feed_Parser_V2 {
 	}
 
 	/**
+	 * Check whether a URL looks like a direct feed file.
+	 *
+	 * @param string $url The URL to check.
+	 * @return bool Whether the URL has a feed file extension.
+	 */
+	private function is_direct_feed_url( $url ) {
+		$path = wp_parse_url( $url, PHP_URL_PATH );
+		if ( ! $path ) {
+			return false;
+		}
+
+		return (bool) preg_match( '/\.(?:atom|rdf|rss|xml)$/i', $path );
+	}
+
+	/**
 	 * Instanciate SimplePie the same way WordPress does it.
 	 *
 	 * @return     SimplePie  A simplepie instance.
@@ -274,6 +289,9 @@ class Feed_Parser_SimplePie extends Feed_Parser_V2 {
 		 */
 		$feed->set_feed_url( $url );
 		$feed->set_cache_duration( apply_filters( 'wp_feed_cache_transient_lifetime', HOUR_IN_SECONDS - 600, $url ) );
+		if ( $this->is_direct_feed_url( $url ) ) {
+			$feed->force_feed( true );
+		}
 
 		do_action_ref_array( 'wp_feed_options', array( &$feed, $url ) );
 

--- a/tests/test-feed.php
+++ b/tests/test-feed.php
@@ -180,6 +180,39 @@ class FeedTest extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test parsing a direct feed URL that is served as text/plain.
+	 */
+	public function test_parse_direct_feed_url_with_text_plain_content_type() {
+		$url = 'https://example.org/feed.xml';
+
+		$mock_text_plain_feed = function ( $preempt, $request, $request_url ) use ( $url ) {
+			if ( $request_url !== $url ) {
+				return $preempt;
+			}
+
+			return array(
+				'headers'  => array(
+					'content-type' => 'text/plain; charset=utf-8',
+				),
+				// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+				'body'     => file_get_contents( __DIR__ . '/data/friend-feed-1-public-post.rss' ),
+				'response' => array(
+					'code' => 200,
+				),
+			);
+		};
+		add_filter( 'pre_http_request', $mock_text_plain_feed, 10, 3 );
+
+		$parser = new Feed_Parser_SimplePie( Friends::get_instance()->feed );
+		$items  = $parser->fetch_feed( $url );
+
+		remove_filter( 'pre_http_request', $mock_text_plain_feed, 10 );
+
+		$this->assertNotWPError( $items );
+		$this->assertCount( 1, $items );
+	}
+
+	/**
 	 * Test parsing a feed with identical posts.
 	 */
 	public function test_parse_feed_with_identical_posts() {


### PR DESCRIPTION
## Summary
- Force SimplePie feed parsing for direct feed-file URLs such as `.xml`, `.rss`, `.atom`, and `.rdf`
- Add a regression test for an RSS feed returned with `text/plain; charset=utf-8`

## Testing
- `php -l feed-parsers/class-feed-parser-simplepie.php`
- `php -l tests/test-feed.php`
- `composer test -- --filter test_parse_direct_feed_url_with_text_plain_content_type`
- `composer check-cs`

<details><summary>Changelog</summary>

- [x] Automatically create a changelog entry from the details below

#### Type
- [x] Fixed

#### Message
Parse direct XML feeds even when they are served with a text/plain content type.

</details>