### PR TITLE
Expose favourite and bookmark status to Enable Mastodon Apps

### DIFF
--- a/.github/changelog/unreleased/684-from-description
+++ b/.github/changelog/unreleased/684-from-description
@@ -1,0 +1,3 @@
+Type: fixed
+
+Hydrate Enable Mastodon Apps favourite and bookmark state from Friends reactions.

--- a/integrations/class-enable-mastodon-apps.php
+++ b/integrations/class-enable-mastodon-apps.php
@@ -106,32 +106,43 @@ class Enable_Mastodon_Apps {
 	}
 
 	public static function mastodon_api_status( $status, $post_id ) {
-		if ( ! $status || Friends::CPT !== get_post_type( $post_id ) ) {
+		if ( ! $status ) {
 			return $status;
 		}
 
 		$reaction_post_id = $post_id;
-		$reactions        = Reactions::get_post_reactions( $reaction_post_id );
-		if ( empty( $reactions ) ) {
-			$remapped_post_id = get_post_meta( $post_id, 'mastodon_reblog_id', true );
-			if ( $remapped_post_id ) {
-				$reaction_post_id = $remapped_post_id;
-				$reactions        = Reactions::get_post_reactions( $reaction_post_id );
+		$paired_post_id   = get_post_meta( $post_id, 'mastodon_reblog_id', true );
+		if ( Friends::CPT !== get_post_type( $reaction_post_id ) ) {
+			if ( ! $paired_post_id || Friends::CPT !== get_post_type( $paired_post_id ) ) {
+				return $status;
 			}
+			$reaction_post_id = $paired_post_id;
 		}
+
+		$reactions = Reactions::get_post_reactions( $reaction_post_id );
 		if ( ! is_array( $reactions ) ) {
 			return $status;
 		}
 
 		$favourite_reaction = self::get_mastodon_api_reaction( 'favourite' );
 		$bookmark_reaction  = self::get_mastodon_api_reaction( 'bookmark' );
-
-		if ( isset( $reactions[ $favourite_reaction ] ) ) {
-			$status->favourited       = (bool) $reactions[ $favourite_reaction ]->user_reacted;
-			$status->favourites_count = intval( $reactions[ $favourite_reaction ]->count );
+		$remapped_reactions = array();
+		if ( $paired_post_id && intval( $paired_post_id ) !== intval( $reaction_post_id ) ) {
+			$remapped_reactions = Reactions::get_post_reactions( $paired_post_id );
+			if ( ! is_array( $remapped_reactions ) ) {
+				$remapped_reactions = array();
+			}
 		}
-		if ( isset( $reactions[ $bookmark_reaction ] ) ) {
-			$status->bookmarked = (bool) $reactions[ $bookmark_reaction ]->user_reacted;
+
+		$favourite = $reactions[ $favourite_reaction ] ?? $remapped_reactions[ $favourite_reaction ] ?? null;
+		$bookmark  = $reactions[ $bookmark_reaction ] ?? $remapped_reactions[ $bookmark_reaction ] ?? null;
+
+		if ( $favourite ) {
+			$status->favourited       = (bool) $favourite->user_reacted;
+			$status->favourites_count = intval( $favourite->count );
+		}
+		if ( $bookmark ) {
+			$status->bookmarked = (bool) $bookmark->user_reacted;
 		}
 
 		if ( isset( $status->reblog ) ) {

--- a/integrations/class-enable-mastodon-apps.php
+++ b/integrations/class-enable-mastodon-apps.php
@@ -110,7 +110,15 @@ class Enable_Mastodon_Apps {
 			return $status;
 		}
 
-		$reactions = Reactions::get_post_reactions( $post_id );
+		$reaction_post_id = $post_id;
+		$reactions        = Reactions::get_post_reactions( $reaction_post_id );
+		if ( empty( $reactions ) ) {
+			$remapped_post_id = get_post_meta( $post_id, 'mastodon_reblog_id', true );
+			if ( $remapped_post_id ) {
+				$reaction_post_id = $remapped_post_id;
+				$reactions        = Reactions::get_post_reactions( $reaction_post_id );
+			}
+		}
 		if ( ! is_array( $reactions ) ) {
 			return $status;
 		}

--- a/integrations/class-enable-mastodon-apps.php
+++ b/integrations/class-enable-mastodon-apps.php
@@ -126,6 +126,12 @@ class Enable_Mastodon_Apps {
 			$status->bookmarked = (bool) $reactions[ $bookmark_reaction ]->user_reacted;
 		}
 
+		if ( isset( $status->reblog ) ) {
+			$status->reblog->favourited       = $status->favourited;
+			$status->reblog->bookmarked       = $status->bookmarked;
+			$status->reblog->favourites_count = $status->favourites_count;
+		}
+
 		return $status;
 	}
 

--- a/integrations/class-enable-mastodon-apps.php
+++ b/integrations/class-enable-mastodon-apps.php
@@ -22,6 +22,7 @@ class Enable_Mastodon_Apps {
 		add_filter( 'mastodon_api_view_post_types', array( get_called_class(), 'mastodon_api_view_post_types' ) );
 		add_filter( 'mastodon_api_favourites_args', array( get_called_class(), 'mastodon_api_favourites_args' ), 10, 2 );
 		add_filter( 'mastodon_api_bookmarks_args', array( get_called_class(), 'mastodon_api_bookmarks_args' ), 10, 2 );
+		add_filter( 'mastodon_api_status', array( get_called_class(), 'mastodon_api_status' ), 60, 2 );
 		add_filter( 'mastodon_api_get_notifications_query_args', array( get_called_class(), 'mastodon_api_get_notifications_query_args' ), 10, 2 );
 	}
 
@@ -55,14 +56,14 @@ class Enable_Mastodon_Apps {
 
 	public static function mastodon_api_favourites_args( $args, $user_id ) {
 		return self::mastodon_api_reaction_args(
-			apply_filters( 'friends_favourites_emoji', '2764' ), // ❤️
+			self::get_mastodon_api_reaction( 'favourite' ),
 			$args,
 			$user_id
 		);
 	}
 	public static function mastodon_api_bookmarks_args( $args, $user_id ) {
 		return self::mastodon_api_reaction_args(
-			apply_filters( 'friends_bookmarks_emoji', '2b50' ), // ⭐
+			self::get_mastodon_api_reaction( 'bookmark' ),
 			$args,
 			$user_id
 		);
@@ -94,6 +95,38 @@ class Enable_Mastodon_Apps {
 		$args['tax_query'] = $tax_query; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
 
 		return $args;
+	}
+
+	protected static function get_mastodon_api_reaction( $type ) {
+		if ( 'bookmark' === $type ) {
+			return apply_filters( 'mastodon_api_bookmark_reaction', apply_filters( 'friends_bookmarks_emoji', '2b50' ), null );
+		}
+
+		return apply_filters( 'mastodon_api_favourite_reaction', apply_filters( 'friends_favourites_emoji', '2764' ), null );
+	}
+
+	public static function mastodon_api_status( $status, $post_id ) {
+		if ( ! $status || Friends::CPT !== get_post_type( $post_id ) ) {
+			return $status;
+		}
+
+		$reactions = Reactions::get_post_reactions( $post_id );
+		if ( ! is_array( $reactions ) ) {
+			return $status;
+		}
+
+		$favourite_reaction = self::get_mastodon_api_reaction( 'favourite' );
+		$bookmark_reaction  = self::get_mastodon_api_reaction( 'bookmark' );
+
+		if ( isset( $reactions[ $favourite_reaction ] ) ) {
+			$status->favourited       = (bool) $reactions[ $favourite_reaction ]->user_reacted;
+			$status->favourites_count = intval( $reactions[ $favourite_reaction ]->count );
+		}
+		if ( isset( $reactions[ $bookmark_reaction ] ) ) {
+			$status->bookmarked = (bool) $reactions[ $bookmark_reaction ]->user_reacted;
+		}
+
+		return $status;
 	}
 
 	public static function mastodon_api_get_notifications_query_args( $args, $type ) {

--- a/tests/test-only-ema.php
+++ b/tests/test-only-ema.php
@@ -215,6 +215,106 @@ class Only_EnableMastodonAppsTest extends Friends_TestCase_Cache_HTTP {
 		$this->assertTrue( $has_mention_query, 'tax_query should filter by mention tag for current user' );
 	}
 
+	private function create_mastodon_status( $post_id ) {
+		$status                   = new \Enable_Mastodon_Apps\Entity\Status();
+		$status->id               = strval( $post_id );
+		$status->favourited       = false;
+		$status->bookmarked       = false;
+		$status->favourites_count = 0;
+		return $status;
+	}
+
+	private function add_reaction( $post_id, $reaction ) {
+		wp_set_current_user( $this->administrator_id );
+		Reactions::register_user_taxonomy( $this->administrator_id );
+		$term_id = apply_filters( 'friends_react', null, $post_id, $reaction, $this->administrator_id );
+		$this->assertNotEmpty( $term_id );
+	}
+
+	public function test_ema_status_hydrates_reactions() {
+		wp_set_current_user( $this->administrator_id );
+		$friend = Subscription::create( 'reaction.local', 'subscription', 'https://reaction.local' );
+		$post_id = $friend->insert_post(
+			array(
+				'post_type'   => Friends::CPT,
+				'post_title'  => 'Reaction Post',
+				'post_status' => 'publish',
+			)
+		);
+		$this->posts[] = $post_id;
+
+		$this->add_reaction( $post_id, '2764' );
+		$this->add_reaction( $post_id, '2b50' );
+
+		$status = Enable_Mastodon_Apps::mastodon_api_status( $this->create_mastodon_status( $post_id ), $post_id );
+
+		$this->assertTrue( $status->favourited );
+		$this->assertTrue( $status->bookmarked );
+		$this->assertEquals( 1, $status->favourites_count );
+	}
+
+	public function test_ema_status_hydrates_paired_reblog_reactions() {
+		wp_set_current_user( $this->administrator_id );
+		$original_id = wp_insert_post(
+			array(
+				'post_type'   => 'post',
+				'post_title'  => 'Original Post',
+				'post_status' => 'publish',
+			)
+		);
+		$this->posts[] = $original_id;
+
+		$friend = Subscription::create( 'boost.local', 'subscription', 'https://boost.local' );
+		$boost_id = $friend->insert_post(
+			array(
+				'post_type'   => Friends::CPT,
+				'post_title'  => 'Boost Post',
+				'post_status' => 'publish',
+			)
+		);
+		$this->posts[] = $boost_id;
+
+		update_post_meta( $original_id, 'mastodon_reblog_id', $boost_id );
+		update_post_meta( $boost_id, 'mastodon_reblog_id', $original_id );
+		$this->add_reaction( $boost_id, '2764' );
+
+		$status         = $this->create_mastodon_status( $original_id );
+		$status->reblog = $this->create_mastodon_status( $boost_id );
+
+		$status = Enable_Mastodon_Apps::mastodon_api_status( $status, $original_id );
+
+		$this->assertTrue( $status->favourited );
+		$this->assertEquals( 1, $status->favourites_count );
+		$this->assertTrue( $status->reblog->favourited );
+		$this->assertEquals( 1, $status->reblog->favourites_count );
+	}
+
+	public function test_ema_status_uses_reaction_mapping_filters() {
+		wp_set_current_user( $this->administrator_id );
+		$friend = Subscription::create( 'mapped-reaction.local', 'subscription', 'https://mapped-reaction.local' );
+		$post_id = $friend->insert_post(
+			array(
+				'post_type'   => Friends::CPT,
+				'post_title'  => 'Mapped Reaction Post',
+				'post_status' => 'publish',
+			)
+		);
+		$this->posts[] = $post_id;
+		$this->add_reaction( $post_id, '1f44d' );
+
+		$favourite_mapping = function () {
+			return '1f44d';
+		};
+		add_filter( 'mastodon_api_favourite_reaction', $favourite_mapping );
+
+		$status = Enable_Mastodon_Apps::mastodon_api_status( $this->create_mastodon_status( $post_id ), $post_id );
+
+		remove_filter( 'mastodon_api_favourite_reaction', $favourite_mapping );
+
+		$this->assertTrue( $status->favourited );
+		$this->assertEquals( 1, $status->favourites_count );
+	}
+
 	public function test_ema_notifications_mentions_queryable() {
 		// This test verifies that Friends posts with mention tags are properly queryable
 		// through the mastodon_api_get_notifications_query_args filter, which allows


### PR DESCRIPTION
## Summary
- use the current EMA app reaction mapping for favourites and bookmarks queries
- hydrate Mastodon API status fields from Friends reaction terms
- set favourites_count from the mapped favourite reaction count
- Related: https://github.com/akirk/enable-mastodon-apps/pull/305

## Testing
- php -l integrations/class-enable-mastodon-apps.php
- live POST /api/v1/statuses/3537126/favourite returned favourited=true and favourites_count=1

<details><summary>Changelog</summary>

- [x] Automatically create a changelog entry from the details below

#### Type
- [x] Fixed

#### Message
Hydrate Enable Mastodon Apps favourite and bookmark state from Friends reactions.

</details>