### PR TITLE
Fix federation for comments on cached ActivityPub posts

### DIFF
--- a/.github/changelog/unreleased/685-from-description
+++ b/.github/changelog/unreleased/685-from-description
@@ -1,0 +1,3 @@
+Type: fixed
+
+Fix local replies on cached ActivityPub posts not entering the outbox.

--- a/feed-parsers/class-feed-parser-activitypub.php
+++ b/feed-parsers/class-feed-parser-activitypub.php
@@ -89,6 +89,7 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 		\add_action( 'friends_get_reaction_display_name', array( $this, 'get_reaction_display_name' ), 10, 2 );
 
 		\add_filter( 'pre_comment_approved', array( $this, 'pre_comment_approved' ), 10, 2 );
+		\add_action( 'wp_insert_comment', array( $this, 'prepare_cached_post_for_comment_federation' ), 5, 2 );
 		\add_action( 'comment_post', array( $this, 'comment_post' ), 10, 3 );
 		\add_action( 'trashed_comment', array( $this, 'trashed_comment' ), 10, 2 );
 		\add_filter( 'friends_get_comments', array( $this, 'get_remote_comments' ), 10, 4 );
@@ -3768,6 +3769,41 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 
 		$activitypub = get_post_meta( $post->ID, self::SLUG, true );
 		return is_array( $activitypub ) && ! empty( $activitypub['attributedTo'] ) ? true : $queryable;
+	}
+
+	/**
+	 * Mark cached ActivityPub posts as federated before comment scheduling.
+	 *
+	 * ActivityPub only federates a new local comment when its parent post is
+	 * considered federated. Cached Friends posts are remote objects, so they do
+	 * not go through the normal local post outbox lifecycle, but local replies
+	 * still need this state so ActivityPub can queue the comment as a reply to
+	 * the remote object.
+	 *
+	 * @param int         $comment_id The comment ID.
+	 * @param \WP_Comment $comment    The comment object.
+	 */
+	public function prepare_cached_post_for_comment_federation( $comment_id, $comment ) {
+		if ( ! defined( 'ACTIVITYPUB_OBJECT_STATE_FEDERATED' ) ) {
+			return;
+		}
+
+		$comment = get_comment( $comment );
+		if ( ! $comment || ! $comment->user_id || 1 !== (int) $comment->comment_approved ) {
+			return;
+		}
+
+		$post = get_post( $comment->comment_post_ID );
+		if (
+			! $post instanceof \WP_Post ||
+			Friends::CPT !== $post->post_type ||
+			'publish' !== $post->post_status ||
+			! self::post_supports_activitypub( $post->ID )
+		) {
+			return;
+		}
+
+		update_post_meta( $post->ID, 'activitypub_status', ACTIVITYPUB_OBJECT_STATE_FEDERATED );
 	}
 
 	public function the_content( $the_content ) {

--- a/tests/test-activitypub.php
+++ b/tests/test-activitypub.php
@@ -1033,7 +1033,6 @@ class ActivityPubTest extends Friends_TestCase_Cache_HTTP {
 				'post_status'  => 'publish',
 				'guid'         => $remote_post_url,
 				'meta_input'   => array(
-					'activitypub_status' => defined( 'ACTIVITYPUB_OBJECT_STATE_FEDERATED' ) ? ACTIVITYPUB_OBJECT_STATE_FEDERATED : 'federated',
 					'activitypub' => array(
 						'attributedTo' => array(
 							'id'                => $this->actor,
@@ -1045,6 +1044,7 @@ class ActivityPubTest extends Friends_TestCase_Cache_HTTP {
 			)
 		);
 		$this->assertIsInt( $post_id );
+		$this->assertEmpty( get_post_meta( $post_id, 'activitypub_status', true ) );
 
 		// Verify get_permalink returns the remote URL (via Friends' post_type_link filter).
 		$permalink = get_permalink( $post_id );
@@ -1064,6 +1064,7 @@ class ActivityPubTest extends Friends_TestCase_Cache_HTTP {
 		$this->assertGreaterThan( 0, $comment_id );
 
 		$comment = get_comment( $comment_id );
+		$this->assertSame( ACTIVITYPUB_OBJECT_STATE_FEDERATED, get_post_meta( $post_id, 'activitypub_status', true ) );
 
 		// Verify the comment should be federated.
 		if ( function_exists( 'Activitypub\should_comment_be_federated' ) ) {


### PR DESCRIPTION
## Summary

- Mark cached ActivityPub-capable Friends posts as federated before ActivityPub evaluates newly inserted local comments.
- Allows local replies on cached remote ActivityPub posts to enter the ActivityPub outbox.
- Update the regression test so it starts without pre-seeded activitypub_status metadata, matching the production failure case.

## Test plan

- [x] composer test -- --filter ActivityPubTest::test_comment_on_cached_post_federation
- [x] composer check-cs
- [x] Confirmed repaired comment 88645 reached the Mastodon status thread.

[Test in WordPress Playground](https://akirk.github.io/playground-step-library/?redir=1&step[0]=setLandingPage&landingPage[0]=/friends/&step[1]=installPlugin&url[1]=github.com/akirk/friends/tree/fix/comment-on-cached-ap-post-federation&step[2]=importFriendFeeds&opml[2]=https://alex.kirk.at%20Alex%20Kirk%20https://adamadam.blog%20Adam%20Zieliński)

<details><summary>Changelog</summary>

- [x] Automatically create a changelog entry from the details below

#### Type
- [x] Fixed

#### Message
Fix local replies on cached ActivityPub posts not entering the outbox.

</details>