### PR TITLE
Cache ActivityPub actor handles for cached posts

### DIFF
--- a/.github/changelog/unreleased/686-from-description
+++ b/.github/changelog/unreleased/686-from-description
@@ -1,0 +1,3 @@
+Type: fixed
+
+Avoid slow ActivityPub host lookups by caching actor handles for cached posts.

--- a/feed-parsers/class-feed-parser-activitypub.php
+++ b/feed-parsers/class-feed-parser-activitypub.php
@@ -301,7 +301,10 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 		if ( $is_external_user ) {
 			$feed_url = get_post_meta( $post_id, 'feed_url', true );
 			if ( $feed_url ) {
-				$actor = self::convert_actor_to_mastodon_handle( $feed_url );
+				$actor = self::get_actor_acct_from_attributed_to( $meta['attributedTo'] );
+				if ( ! $actor ) {
+					$actor = self::convert_actor_to_mastodon_handle( $feed_url );
+				}
 				$account = new Entity_Account();
 				$account->id             = $feed_url;
 				$account->username       = strtok( $actor, '@' );
@@ -339,9 +342,9 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 			if ( ! empty( $actor_metadata['preferredUsername'] ) ) {
 				$status->reblog->account->id = $attributed_to_url;
 				$status->reblog->account->username = $actor_metadata['preferredUsername'];
-				$acct = self::convert_actor_to_mastodon_handle( $attributed_to_url );
-				if ( $acct === $attributed_to_url && ! empty( $meta['attributedTo']['ap_actor_id'] ) && class_exists( '\Activitypub\Collection\Remote_Actors' ) ) {
-					$acct = \Activitypub\Collection\Remote_Actors::get_acct( $meta['attributedTo']['ap_actor_id'] );
+				$acct = self::get_actor_acct_from_attributed_to( $meta['attributedTo'] );
+				if ( ! $acct ) {
+					$acct = self::convert_actor_to_mastodon_handle( $attributed_to_url );
 				}
 				$status->reblog->account->acct = $acct;
 				if ( ! empty( $actor_metadata['name'] ) ) {
@@ -693,7 +696,8 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 			if ( $user ) {
 				foreach ( $user->get_active_feeds() as $user_feed ) {
 					if ( 'activitypub' === $user_feed->get_parser() ) {
-						$this->mapped_usernames[ $user_id ] = self::convert_actor_to_mastodon_handle( $user_feed->get_url() );
+						$acct = self::get_actor_acct_from_user_feed( $user_feed );
+						$this->mapped_usernames[ $user_id ] = $acct ? $acct : self::convert_actor_to_mastodon_handle( $user_feed->get_url() );
 						break;
 					}
 				}
@@ -733,7 +737,8 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 		if ( ! isset( $user_id_map[ $user_id ] ) && is_string( $user_id ) ) {
 			$user_feed = User_Feed::get_by_url( $user_id );
 			if ( $user_feed && ! is_wp_error( $user_feed ) ) {
-				$user_id_map[ $user_id ] = self::convert_actor_to_mastodon_handle( $user_feed->get_url() );
+				$acct = self::get_actor_acct_from_user_feed( $user_feed );
+				$user_id_map[ $user_id ] = $acct ? $acct : self::convert_actor_to_mastodon_handle( $user_feed->get_url() );
 			}
 		}
 		if ( ! isset( $user_id_map[ $user_id ] ) ) {
@@ -748,7 +753,8 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 			if ( $user ) {
 				foreach ( $user->get_active_feeds() as $user_feed ) {
 					if ( 'activitypub' === $user_feed->get_parser() ) {
-						$user_id_map[ $user_id ] = self::convert_actor_to_mastodon_handle( $user_feed->get_url() );
+						$acct = self::get_actor_acct_from_user_feed( $user_feed );
+						$user_id_map[ $user_id ] = $acct ? $acct : self::convert_actor_to_mastodon_handle( $user_feed->get_url() );
 						break;
 					}
 				}
@@ -830,11 +836,7 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 
 		$actor_metadata = self::get_actor_metadata_from_attributed_to( $meta['attributedTo'] );
 
-		// Use cached acct from AP plugin when available (avoids slow guid query).
-		$actor = null;
-		if ( ! empty( $meta['attributedTo']['ap_actor_id'] ) && class_exists( '\Activitypub\Collection\Remote_Actors' ) ) {
-			$actor = \Activitypub\Collection\Remote_Actors::get_acct( $meta['attributedTo']['ap_actor_id'] );
-		}
+		$actor = self::get_actor_acct_from_attributed_to( $meta['attributedTo'] );
 		if ( ! $actor ) {
 			$actor = self::convert_actor_to_mastodon_handle( $attributed_to );
 		}
@@ -870,8 +872,12 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 	public function friends_message_form_accounts( $accounts, User $friend_user ) {
 		foreach ( $friend_user->get_feeds() as $user_feed ) {
 			if ( 'activitypub' === $user_feed->get_parser() ) {
+				$acct = self::get_actor_acct_from_user_feed( $user_feed );
+				if ( ! $acct ) {
+					$acct = $this->convert_actor_to_mastodon_handle( $user_feed->get_url() );
+				}
 				// translators: %s is the user's handle.
-				$accounts[ $user_feed->get_url() ] = sprintf( __( '%s (via ActivityPub)', 'friends' ), '@' . $this->convert_actor_to_mastodon_handle( $user_feed->get_url() ) );
+				$accounts[ $user_feed->get_url() ] = sprintf( __( '%s (via ActivityPub)', 'friends' ), '@' . $acct );
 			}
 		}
 
@@ -2032,6 +2038,46 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 	}
 
 	/**
+	 * Get the actor acct from attributedTo metadata.
+	 *
+	 * @param array $attributed_to The attributedTo metadata array.
+	 * @return string The actor acct, or an empty string if unavailable.
+	 */
+	public static function get_actor_acct_from_attributed_to( $attributed_to ) {
+		if ( ! is_array( $attributed_to ) ) {
+			return '';
+		}
+
+		if ( ! empty( $attributed_to['acct'] ) ) {
+			return ltrim( $attributed_to['acct'], '@' );
+		}
+
+		if ( ! empty( $attributed_to['ap_actor_id'] ) && class_exists( '\Activitypub\Collection\Remote_Actors' ) ) {
+			$acct = \Activitypub\Collection\Remote_Actors::get_acct( $attributed_to['ap_actor_id'] );
+			if ( $acct ) {
+				return ltrim( $acct, '@' );
+			}
+		}
+
+		return '';
+	}
+
+	/**
+	 * Get the actor acct for an ActivityPub user feed.
+	 *
+	 * @param User_Feed $user_feed The user feed.
+	 * @return string The actor acct, or an empty string if unavailable.
+	 */
+	private static function get_actor_acct_from_user_feed( User_Feed $user_feed ) {
+		$ap_actor_id = $user_feed->get_ap_actor_id();
+		if ( ! $ap_actor_id || ! class_exists( '\Activitypub\Collection\Remote_Actors' ) ) {
+			return '';
+		}
+
+		return ltrim( \Activitypub\Collection\Remote_Actors::get_acct( $ap_actor_id ), '@' );
+	}
+
+	/**
 	 * Get actor metadata from attributedTo.
 	 *
 	 * Returns actor metadata (name, icon, summary, preferredUsername, header) using the
@@ -2046,6 +2092,7 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 		$metadata = array(
 			'url'               => null,
 			'name'              => '',
+			'acct'              => '',
 			'icon'              => '',
 			'header'            => '',
 			'summary'           => '',
@@ -2079,6 +2126,7 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 
 				if ( $actor && ! is_wp_error( $actor ) ) {
 					$metadata['url'] = $actor->get_id();
+					$metadata['acct'] = self::get_actor_acct_from_attributed_to( $attributed_to );
 					$metadata['name'] = $actor->get_name() ?? '';
 					$metadata['summary'] = $actor->get_summary() ?? '';
 					$metadata['preferredUsername'] = $actor->get_preferred_username() ?? '';
@@ -2114,6 +2162,7 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 		if ( isset( $attributed_to['name'] ) ) {
 			$metadata['name'] = $attributed_to['name'];
 		}
+		$metadata['acct'] = self::get_actor_acct_from_attributed_to( $attributed_to );
 		if ( isset( $attributed_to['icon'] ) ) {
 			$metadata['icon'] = $attributed_to['icon'];
 		}
@@ -2764,11 +2813,31 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 					$actor_post = \Activitypub\Collection\Remote_Actors::fetch_by_uri( $actor_url );
 					if ( ! is_wp_error( $actor_post ) && $actor_post instanceof \WP_Post ) {
 						$data[ self::SLUG ]['attributedTo'] = array( 'ap_actor_id' => $actor_post->ID );
+						$acct = \Activitypub\Collection\Remote_Actors::get_acct( $actor_post->ID );
+						if ( $acct ) {
+							$data[ self::SLUG ]['attributedTo']['acct'] = ltrim( $acct, '@' );
+						}
 					} else {
 						$data[ self::SLUG ]['attributedTo'] = array( 'id' => $actor_url );
 					}
 				} else {
 					$data[ self::SLUG ]['attributedTo'] = array( 'id' => $actor_url );
+				}
+				if ( empty( $data[ self::SLUG ]['attributedTo']['acct'] ) ) {
+					$acct = self::get_actor_acct_from_attributed_to(
+						array_merge(
+							$data[ self::SLUG ]['attributedTo'],
+							array_intersect_key(
+								$meta,
+								array(
+									'acct' => true,
+								)
+							)
+						)
+					);
+					if ( $acct ) {
+						$data[ self::SLUG ]['attributedTo']['acct'] = $acct;
+					}
 				}
 			}
 		}
@@ -4798,7 +4867,7 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 			array(
 				'url'     => $actor_metadata['url'],
 				'name'    => $actor_metadata['name'],
-				'handle'  => self::convert_actor_to_mastodon_handle( $actor_metadata['url'] ),
+				'handle'  => $actor_metadata['acct'] ? $actor_metadata['acct'] : self::convert_actor_to_mastodon_handle( $actor_metadata['url'] ),
 				'summary' => wp_strip_all_tags( $actor_metadata['summary'] ),
 				'emojis'  => $actor_metadata['emojis'],
 			)
@@ -4998,7 +5067,7 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 				)
 			);
 			foreach ( $term_query->get_terms() as $term ) {
-				$feed_host = wp_parse_url( $term->slug, PHP_URL_HOST );
+				$feed_host = wp_parse_url( $term->name, PHP_URL_HOST );
 				if ( $feed_host ) {
 					$known_hosts[ $feed_host ] = true;
 				}

--- a/feed-parsers/class-feed-parser-activitypub.php
+++ b/feed-parsers/class-feed-parser-activitypub.php
@@ -1490,16 +1490,14 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 				// Get the latest local post for this user.
 				$friend_user = $user_feed->get_friend_user();
 				if ( $friend_user ) {
-					$latest_local_post = new \WP_Query(
-						array(
-							'post_type'      => Friends::CPT,
-							'post_status'    => array( 'publish', 'private' ),
-							'posts_per_page' => 1,
-							'orderby'        => 'date',
-							'order'          => 'DESC',
-							'author'         => $friend_user->ID,
-						)
-					);
+					$latest_local_post = new \WP_Query();
+					$latest_local_post->set( 'post_type', Friends::CPT );
+					$latest_local_post->set( 'post_status', array( 'publish', 'private' ) );
+					$latest_local_post->set( 'posts_per_page', 1 );
+					$latest_local_post->set( 'orderby', 'date' );
+					$latest_local_post->set( 'order', 'DESC' );
+					$latest_local_post = $friend_user->modify_query_by_author( $latest_local_post );
+					$latest_local_post->get_posts();
 
 					if ( $latest_local_post->have_posts() ) {
 						$result['latest_local'] = $latest_local_post->posts[0]->post_date_gmt;

--- a/feed-parsers/class-feed-parser-activitypub.php
+++ b/feed-parsers/class-feed-parser-activitypub.php
@@ -2052,14 +2052,26 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 			return ltrim( $attributed_to['acct'], '@' );
 		}
 
-		if ( ! empty( $attributed_to['ap_actor_id'] ) && class_exists( '\Activitypub\Collection\Remote_Actors' ) ) {
-			$acct = \Activitypub\Collection\Remote_Actors::get_acct( $attributed_to['ap_actor_id'] );
-			if ( $acct ) {
-				return ltrim( $acct, '@' );
-			}
+		if ( ! empty( $attributed_to['ap_actor_id'] ) ) {
+			return self::get_actor_acct_from_remote_actor_id( $attributed_to['ap_actor_id'] );
 		}
 
 		return '';
+	}
+
+	/**
+	 * Get the actor acct from an ActivityPub remote actor post ID.
+	 *
+	 * @param int $ap_actor_id The ActivityPub remote actor post ID.
+	 * @return string The actor acct, or an empty string if unavailable.
+	 */
+	private static function get_actor_acct_from_remote_actor_id( $ap_actor_id ) {
+		$ap_actor_id = (int) $ap_actor_id;
+		if ( ! $ap_actor_id || ! class_exists( '\Activitypub\Collection\Remote_Actors' ) ) {
+			return '';
+		}
+
+		return ltrim( \Activitypub\Collection\Remote_Actors::get_acct( $ap_actor_id ), '@' );
 	}
 
 	/**
@@ -2070,11 +2082,7 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 	 */
 	private static function get_actor_acct_from_user_feed( User_Feed $user_feed ) {
 		$ap_actor_id = $user_feed->get_ap_actor_id();
-		if ( ! $ap_actor_id || ! class_exists( '\Activitypub\Collection\Remote_Actors' ) ) {
-			return '';
-		}
-
-		return ltrim( \Activitypub\Collection\Remote_Actors::get_acct( $ap_actor_id ), '@' );
+		return self::get_actor_acct_from_remote_actor_id( $ap_actor_id );
 	}
 
 	/**

--- a/includes/class-friends.php
+++ b/includes/class-friends.php
@@ -507,6 +507,8 @@ class Friends {
 			}
 		}
 
+		Migration::backfill_activitypub_attributed_to_acct();
+
 		update_option( 'friends_plugin_version', Friends::VERSION );
 	}
 

--- a/includes/class-migration.php
+++ b/includes/class-migration.php
@@ -166,6 +166,18 @@ class Migration {
 
 		self::register(
 			array(
+				'id'            => 'activitypub_attributed_to_acct',
+				'version'       => '4.2.0',
+				'title'         => 'Backfill ActivityPub Actor Handles',
+				'description'   => 'Adds cached ActivityPub actor handles to the latest 100 cached posts that already reference ap_actor posts.',
+				'method'        => 'backfill_activitypub_attributed_to_acct',
+				'status_option' => 'friends_ap_attributed_to_acct_backfilled',
+				'depends_on'    => 'activitypub_attributed_to',
+			)
+		);
+
+		self::register(
+			array(
 				'id'            => 'import_activitypub_followings',
 				'version'       => '4.0.0',
 				'title'         => 'Import ActivityPub Followings',
@@ -1689,6 +1701,71 @@ class Migration {
 	private static function finalize_ap_attributed_to_migration() {
 		delete_option( 'friends_ap_attributed_to_migration_in_progress' );
 		update_option( 'friends_ap_attributed_to_migration_completed', true, false );
+	}
+
+	/**
+	 * Backfill cached ActivityPub actor handles for the latest 100 cached posts.
+	 */
+	public static function backfill_activitypub_attributed_to_acct() {
+		if ( ! class_exists( '\Activitypub\Collection\Remote_Actors' ) || ! class_exists( __NAMESPACE__ . '\Feed_Parser_ActivityPub' ) ) {
+			update_option( 'friends_ap_attributed_to_acct_backfilled', true, false );
+			return;
+		}
+
+		if ( get_option( 'friends_ap_attributed_to_acct_backfilled' ) ) {
+			return;
+		}
+
+		global $wpdb;
+
+		$limit = 100;
+
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching
+		$posts_to_migrate = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT pm.post_id, pm.meta_value
+				FROM {$wpdb->postmeta} pm
+				INNER JOIN {$wpdb->posts} p ON p.ID = pm.post_id
+				WHERE p.post_type = %s
+				AND p.post_status IN ( 'publish', 'private' )
+				AND pm.meta_key = %s
+				AND pm.meta_value LIKE %s
+				AND pm.meta_value LIKE %s
+				AND pm.meta_value NOT LIKE %s
+				ORDER BY p.post_date_gmt DESC, p.ID DESC
+				LIMIT %d",
+				Friends::CPT,
+				Feed_Parser_ActivityPub::SLUG,
+				'%"attributedTo"%',
+				'%"ap_actor_id"%',
+				'%"acct"%',
+				$limit
+			)
+		);
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.NoCaching
+
+		$updated = 0;
+
+		foreach ( $posts_to_migrate as $row ) {
+			$meta = maybe_unserialize( $row->meta_value );
+			if ( ! is_array( $meta ) || empty( $meta['attributedTo']['ap_actor_id'] ) || ! empty( $meta['attributedTo']['acct'] ) ) {
+				continue;
+			}
+
+			$acct = \Activitypub\Collection\Remote_Actors::get_acct( $meta['attributedTo']['ap_actor_id'] );
+			if ( ! $acct ) {
+				continue;
+			}
+
+			$meta['attributedTo']['acct'] = ltrim( $acct, '@' );
+			update_post_meta( $row->post_id, Feed_Parser_ActivityPub::SLUG, $meta );
+			++$updated;
+		}
+
+		update_option( 'friends_ap_attributed_to_acct_backfilled', true, false );
+		update_option( 'friends_ap_attributed_to_acct_backfilled_count', $updated, false );
 	}
 
 	/**

--- a/templates/frontend/author-header.php
+++ b/templates/frontend/author-header.php
@@ -14,9 +14,10 @@ $display_name_html = Friends\Feed_Parser_ActivityPub::replace_custom_emojis_for_
 
 // Get ActivityPub feeds and their data (header image, profile URLs, summary).
 $activitypub_feeds = array();
+$seen_activitypub_feeds = array();
 $header_image_url = null;
 $activitypub_summary = null;
-foreach ( $args['friend_user']->get_feeds() as $feed ) {
+foreach ( $args['friend_user']->get_active_feeds() as $feed ) {
 	// Check if this is an ActivityPub feed (parser is 'activitypub').
 	if ( 'activitypub' !== $feed->get_parser() ) {
 		continue;
@@ -24,6 +25,11 @@ foreach ( $args['friend_user']->get_feeds() as $feed ) {
 
 	$ap_actor_id = $feed->get_ap_actor_id();
 	$ap_actor_url = $feed->get_ap_actor_url();
+	$ap_actor_acct = Friends\Feed_Parser_ActivityPub::get_actor_acct_from_attributed_to(
+		array(
+			'ap_actor_id' => $ap_actor_id,
+		)
+	);
 
 	// If no actor URL from linked actor, use the feed URL as the actor URL.
 	if ( ! $ap_actor_url ) {
@@ -34,9 +40,15 @@ foreach ( $args['friend_user']->get_feeds() as $feed ) {
 		continue;
 	}
 
+	$dedupe_key = $ap_actor_acct ? 'acct:' . strtolower( $ap_actor_acct ) : 'url:' . strtolower( untrailingslashit( $ap_actor_url ) );
+	if ( isset( $seen_activitypub_feeds[ $dedupe_key ] ) ) {
+		continue;
+	}
+	$seen_activitypub_feeds[ $dedupe_key ] = true;
+
 	$feed_data = array(
-		'url'    => $ap_actor_url,
-		'header' => null,
+		'url'  => $ap_actor_url,
+		'acct' => $ap_actor_acct,
 	);
 
 	// Try to get actor metadata including header image and summary.
@@ -173,7 +185,9 @@ foreach ( $activitypub_feeds as $ap_feed ) :
 		}
 		// Extract @username for Mastodon-style URLs like /@username.
 		$ap_display = $ap_hostname;
-		if ( isset( $ap_url_parts['path'] ) && preg_match( '#^/@([^/]+)#', $ap_url_parts['path'], $matches ) ) {
+		if ( ! empty( $ap_feed['acct'] ) ) {
+			$ap_display = '@' . $ap_feed['acct'];
+		} elseif ( isset( $ap_url_parts['path'] ) && preg_match( '#^/@([^/]+)#', $ap_url_parts['path'], $matches ) ) {
 			$ap_display = '@' . $matches[1] . '@' . $ap_hostname;
 		} elseif ( isset( $ap_url_parts['path'] ) && preg_match( '#^/users/([^/]+)#i', $ap_url_parts['path'], $matches ) ) {
 			$ap_display = '@' . $matches[1] . '@' . $ap_hostname;

--- a/tests/test-mastodon-api-performance.php
+++ b/tests/test-mastodon-api-performance.php
@@ -161,6 +161,27 @@ class Mastodon_API_Performance_Test extends ActivityPubTest {
 	}
 
 	/**
+	 * Test that cached acct metadata avoids known-host URL heuristics.
+	 */
+	public function test_cached_acct_metadata_is_used_for_unknown_host() {
+		$actor_url = 'https://totally-unknown.example/users/bob';
+		$post_id = $this->create_friend_post(
+			$actor_url,
+			array(
+				'id'                => $actor_url,
+				'acct'              => 'bob@totally-unknown.example',
+				'preferredUsername' => 'bob',
+				'name'              => 'Bob',
+			)
+		);
+
+		$account = apply_filters( 'mastodon_api_account', null, $this->friend_id, null, get_post( $post_id ) );
+		$this->assertInstanceOf( '\Enable_Mastodon_Apps\Entity\Account', $account );
+		$this->assertEquals( 'bob@totally-unknown.example', $account->acct );
+		$this->assertEquals( 'bob', $account->username );
+	}
+
+	/**
 	 * Test that .social TLD is treated as a known fediverse host.
 	 */
 	public function test_social_tld_is_known() {

--- a/tests/test-migration.php
+++ b/tests/test-migration.php
@@ -1292,6 +1292,89 @@ class MigrationTest extends \WP_UnitTestCase {
 		$this->assertTrue( Friends::has_pending_migrations() );
 	}
 
+	public function test_backfill_activitypub_attributed_to_acct_limits_to_latest_100_posts() {
+		if ( ! class_exists( '\Activitypub\Collection\Remote_Actors' ) ) {
+			$this->markTestSkipped( 'ActivityPub plugin is not available.' );
+		}
+
+		require_once dirname( __DIR__ ) . '/includes/class-migration.php';
+		delete_option( 'friends_ap_attributed_to_acct_backfilled' );
+		delete_option( 'friends_ap_attributed_to_acct_backfilled_count' );
+
+		$post_ids = array();
+		for ( $i = 0; $i < 101; ++$i ) {
+			$ap_actor_id = $this->factory->post->create(
+				array(
+					'post_type'   => 'ap_actor',
+					'post_title'  => 'AP Actor ' . $i,
+					'post_status' => 'publish',
+					'guid'        => 'https://example.com/users/actor' . $i,
+					'meta_input'  => array(
+						'_activitypub_acct' => 'actor' . $i . '@example.com',
+					),
+				)
+			);
+
+			$post_ids[ $i ] = $this->factory->post->create(
+				array(
+					'post_type'     => Friends::CPT,
+					'post_title'    => 'Cached ActivityPub Post ' . $i,
+					'post_status'   => 'publish',
+					'post_date'     => gmdate( 'Y-m-d H:i:s', strtotime( '2024-01-01 00:00:00' ) + $i ),
+					'post_date_gmt' => gmdate( 'Y-m-d H:i:s', strtotime( '2024-01-01 00:00:00' ) + $i ),
+					'meta_input'    => array(
+						Feed_Parser_ActivityPub::SLUG => array(
+							'attributedTo' => array(
+								'ap_actor_id' => $ap_actor_id,
+							),
+						),
+					),
+				)
+			);
+		}
+
+		$cached_actor_id = $this->factory->post->create(
+			array(
+				'post_type'   => 'ap_actor',
+				'post_title'  => 'Already Cached Actor',
+				'post_status' => 'publish',
+				'guid'        => 'https://example.com/users/cached',
+				'meta_input'  => array(
+					'_activitypub_acct' => 'cached@example.com',
+				),
+			)
+		);
+		$already_cached_post_id = $this->factory->post->create(
+			array(
+				'post_type'     => Friends::CPT,
+				'post_title'    => 'Already Cached ActivityPub Post',
+				'post_status'   => 'publish',
+				'post_date'     => '2024-01-02 00:00:00',
+				'post_date_gmt' => '2024-01-02 00:00:00',
+				'meta_input'    => array(
+					Feed_Parser_ActivityPub::SLUG => array(
+						'attributedTo' => array(
+							'ap_actor_id' => $cached_actor_id,
+							'acct'        => 'keep@example.com',
+						),
+					),
+				),
+			)
+		);
+
+		Migration::backfill_activitypub_attributed_to_acct();
+
+		$oldest_meta = get_post_meta( $post_ids[0], Feed_Parser_ActivityPub::SLUG, true );
+		$newest_meta = get_post_meta( $post_ids[100], Feed_Parser_ActivityPub::SLUG, true );
+		$cached_meta = get_post_meta( $already_cached_post_id, Feed_Parser_ActivityPub::SLUG, true );
+
+		$this->assertArrayNotHasKey( 'acct', $oldest_meta['attributedTo'] );
+		$this->assertSame( 'actor100@example.com', $newest_meta['attributedTo']['acct'] );
+		$this->assertSame( 'keep@example.com', $cached_meta['attributedTo']['acct'] );
+		$this->assertSame( 100, (int) get_option( 'friends_ap_attributed_to_acct_backfilled_count' ) );
+		$this->assertTrue( (bool) get_option( 'friends_ap_attributed_to_acct_backfilled' ) );
+	}
+
 	public function test_upgrade_plugin_sets_pending_when_migrating_from_before_4_0() {
 		require_once dirname( __DIR__ ) . '/includes/class-migration.php';
 		$this->setup_pre_migration_environment();


### PR DESCRIPTION
## Summary
- cache ActivityPub actor `acct` values on incoming cached posts when available
- prefer cached `acct` / `ap_actor_id` lookups before host-based URL heuristics
- add a one-time migration for the latest 100 cached posts with `ap_actor_id`
- show only active, de-duplicated ActivityPub feeds in the author header
- use the subscription-aware local post query when checking ActivityPub subscription health

## Testing
- `composer check-cs -- includes/class-migration.php includes/class-friends.php feed-parsers/class-feed-parser-activitypub.php tests/test-migration.php tests/test-mastodon-api-performance.php`
- `composer check-cs -- templates/frontend/author-header.php`
- `composer test`

<details><summary>Changelog</summary>

- [x] Automatically create a changelog entry from the details below

#### Type
- [x] Fixed

#### Message
Avoid slow ActivityPub host lookups by caching actor handles for cached posts and improve ActivityPub subscription status display.

</details>