### PR TITLE
Clarify ActivityPub feed unfollow removal

### DIFF
--- a/.github/changelog/unreleased/689-from-description
+++ b/.github/changelog/unreleased/689-from-description
@@ -1,0 +1,3 @@
+Type: changed
+
+Clarify ActivityPub feed unfollow and removal actions.

--- a/templates/admin/edit-feeds.php
+++ b/templates/admin/edit-feeds.php
@@ -68,7 +68,12 @@ $has_last_log = false;
 										<tbody>
 											<tr>
 												<th><?php esc_html_e( 'Active', 'friends' ); ?></th>
-												<td><input type="checkbox" name="feeds[<?php echo esc_attr( $term_id ); ?>][active]" value="1" aria-label="<?php esc_attr_e( 'Feed is active', 'friends' ); ?>"<?php checked( $feed->get_active() ); ?> /></td>
+												<td>
+													<input type="checkbox" name="feeds[<?php echo esc_attr( $term_id ); ?>][active]" value="1" aria-label="<?php esc_attr_e( 'Feed is active', 'friends' ); ?>"<?php checked( $feed->get_active() ); ?> />
+													<?php if ( $feed->is_activitypub_feed() ) : ?>
+														<p class="description"><?php esc_html_e( 'Make inactive and save changes to unfollow.', 'friends' ); ?></p>
+													<?php endif; ?>
+												</td>
 											</tr>
 											<?php if ( ! $feed->is_activitypub_feed() ) : ?>
 											<tr>
@@ -84,6 +89,7 @@ $has_last_log = false;
 													<?php if ( $feed->is_activitypub_feed() ) : ?>
 														<strong><?php esc_html_e( 'ActivityPub', 'friends' ); ?></strong>
 														<input type="hidden" name="feeds[<?php echo esc_attr( $term_id ); ?>][parser]" value="activitypub" />
+														<input type="hidden" name="feeds[<?php echo esc_attr( $term_id ); ?>][ap-actor-id]" value="<?php echo esc_attr( $feed->get_ap_actor_id() ); ?>" />
 													<?php else : ?>
 													<select name="feeds[<?php echo esc_attr( $term_id ); ?>][parser]" aria-label="<?php esc_attr_e( 'Parser', 'friends' ); ?>">
 														<?php foreach ( $args['registered_parsers'] as $slug => $parser_name ) : ?>
@@ -123,17 +129,21 @@ $has_last_log = false;
 											<th><?php esc_html_e( 'Remarks', 'friends' ); ?></th>
 											<td><input type="text" name="feeds[<?php echo esc_attr( $term_id ); ?>][title]" value="<?php echo esc_attr( $feed->get_title() ); ?>" size="20" aria-label="<?php esc_attr_e( 'Feed Name', 'friends' ); ?>" /></td>
 										</tr>
-										<tr>
-											<th><?php esc_html_e( 'Actions', 'friends' ); ?></th>
-											<td>
-												<?php if ( $feed->is_activitypub_feed() ) : ?>
-													<a href="#" class="delete-feed activitypub-unfollow"><?php esc_html_e( 'Unfollow &amp; Remove', 'friends' ); ?></a>
-													<input type="hidden" name="feeds[<?php echo esc_attr( $term_id ); ?>][ap-actor-id]" value="<?php echo esc_attr( $feed->get_ap_actor_id() ); ?>" />
-												<?php else : ?>
-													<a href="#" class="delete-feed"><?php esc_html_e( 'Delete', 'friends' ); ?></a>
-												<?php endif; ?>
-											</td>
-										</tr>
+											<tr>
+												<th><?php esc_html_e( 'Actions', 'friends' ); ?></th>
+												<td>
+													<?php if ( $feed->is_activitypub_feed() ) : ?>
+														<?php if ( $feed->get_active() ) : ?>
+															<span class="dashicons dashicons-info-outline" title="<?php esc_attr_e( 'Make inactive and save changes before removing this feed.', 'friends' ); ?>" aria-label="<?php esc_attr_e( 'Make inactive and save changes before removing this feed.', 'friends' ); ?>"></span>
+															<?php esc_html_e( 'Unfollow to remove', 'friends' ); ?>
+														<?php else : ?>
+															<a href="#" class="delete-feed activitypub-unfollow"><?php esc_html_e( 'Remove', 'friends' ); ?></a>
+														<?php endif; ?>
+													<?php else : ?>
+														<a href="#" class="delete-feed"><?php esc_html_e( 'Delete', 'friends' ); ?></a>
+													<?php endif; ?>
+												</td>
+											</tr>
 										<?php do_action( 'friends_feed_list_item', $feed, $term_id ); ?>
 									</tbody>
 								</table>

--- a/templates/admin/edit-feeds.php
+++ b/templates/admin/edit-feeds.php
@@ -134,7 +134,7 @@ $has_last_log = false;
 												<td>
 													<?php if ( $feed->is_activitypub_feed() ) : ?>
 														<?php if ( $feed->get_active() ) : ?>
-															<span class="dashicons dashicons-info-outline" title="<?php esc_attr_e( 'Make inactive and save changes before removing this feed.', 'friends' ); ?>" aria-label="<?php esc_attr_e( 'Make inactive and save changes before removing this feed.', 'friends' ); ?>"></span>
+															<span class="dashicons dashicons-info-outline" title="<?php esc_attr_e( 'Make inactive and save changes so that you can remove this feed.', 'friends' ); ?>" aria-label="<?php esc_attr_e( 'Make inactive and save changes so that you can remove this feed.', 'friends' ); ?>"></span>
 															<?php esc_html_e( 'Unfollow to remove', 'friends' ); ?>
 														<?php else : ?>
 															<a href="#" class="delete-feed activitypub-unfollow"><?php esc_html_e( 'Remove', 'friends' ); ?></a>


### PR DESCRIPTION
Before:
<img width="1076" height="628" alt="Screenshot 2026-07-09 at 13 25 35" src="https://github.com/user-attachments/assets/8b596be8-d071-4a3e-a65a-aeab4bdabff6" />


After:
<img width="1102" height="500" alt="Screenshot 2026-07-09 at 13 25 59" src="https://github.com/user-attachments/assets/8877dc0d-c7c6-4e35-920a-dc9bc7f0c91c" />

## Summary
- explain that making an ActivityPub feed inactive will unfollow it
- keep the Actions row visible for active ActivityPub feeds, but show non-clickable “Unfollow to remove” guidance with an info icon
- only show the Remove link for ActivityPub feeds once they are inactive

## Testing
- php -l templates/admin/edit-feeds.php
- composer check-cs

<details><summary>Changelog</summary>

- [x] Automatically create a changelog entry from the details below

#### Type
- [x] Changed

#### Message
Clarify ActivityPub feed unfollow and removal actions.

</details>

<!-- friends-playground-link:start -->
## Test this PR in WordPress Playground

You can test this pull request directly in WordPress Playground:

[Launch WordPress Playground](https://akirk.github.io/playground-step-library/?redir=1&step[0]=setLandingPage&landingPage[0]=/friends/&step[1]=installPlugin&url[1]=github.com/akirk/friends/tree/fix/activitypub-unfollow-remove-action&step[2]=importFriendFeeds&opml[2]=https://alex.kirk.at%20Alex%20Kirk%0Ahttps://adamadam.blog%20Adam%20Zieliński)

This will install and activate the plugin with the changes from this PR.
<!-- friends-playground-link:end -->