### PR TITLE
Fix default theme dark mode colors

### DIFF
--- a/.github/changelog/unreleased/690-from-description
+++ b/.github/changelog/unreleased/690-from-description
@@ -1,0 +1,3 @@
+Type: fixed
+
+Fix default frontend theme colors so the page follows system dark mode.

--- a/friends.css
+++ b/friends.css
@@ -224,14 +224,57 @@ template {
 
 html {
 	box-sizing: border-box;
+	color-scheme: light dark;
 	font-size: 20px;
 	line-height: 1.5;
 	-webkit-tap-highlight-color: transparent;
 }
 
+:root {
+	--friends-color-background: #f7f8f9;
+	--friends-color-surface: #fff;
+	--friends-color-surface-alt: #f7f7f7;
+	--friends-color-surface-muted: #f8fafc;
+	--friends-color-border: #eee;
+	--friends-color-border-strong: #d6d4e8;
+	--friends-color-text: #48427c;
+	--friends-color-text-muted: #667085;
+	--friends-color-text-soft: #999;
+	--friends-color-link: #2e5bec;
+	--friends-color-link-hover: #1341d4;
+	--friends-color-link-visited: #5d80f0;
+	--friends-color-focus: rgba(46, 91, 236, 0.2);
+	--friends-color-menu-hover: #dde5fc;
+	--friends-color-note-background: #f7f7f7;
+	--friends-color-info-background: #eef6ff;
+	--friends-color-selected-background: #edf2ff;
+}
+
+@media (prefers-color-scheme: dark) {
+	:root {
+		--friends-color-background: #10131a;
+		--friends-color-surface: #171b24;
+		--friends-color-surface-alt: #202633;
+		--friends-color-surface-muted: #141821;
+		--friends-color-border: #2c3342;
+		--friends-color-border-strong: #3c465b;
+		--friends-color-text: #e7eaf2;
+		--friends-color-text-muted: #a6adbb;
+		--friends-color-text-soft: #8e96a6;
+		--friends-color-link: #8fb1ff;
+		--friends-color-link-hover: #b8ccff;
+		--friends-color-link-visited: #c4b5fd;
+		--friends-color-focus: rgba(143, 177, 255, 0.28);
+		--friends-color-menu-hover: #22304a;
+		--friends-color-note-background: #202633;
+		--friends-color-info-background: #162438;
+		--friends-color-selected-background: #1c2b45;
+	}
+}
+
 body {
-	background: #f7f8f9;
-	color: #48427c;
+	background: var(--friends-color-background);
+	color: var(--friends-color-text);
 	font-family: -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", sans-serif;
 	font-size: .8rem;
 	overflow-x: hidden;
@@ -239,21 +282,21 @@ body {
 }
 
 a {
-	color: #2e5bec;
+	color: var(--friends-color-link);
 	outline: none;
 	text-decoration: none;
 
 	&:focus {
-		box-shadow: 0 0 0 .1rem rgba(46, 91, 236, 0.2);
+		box-shadow: 0 0 0 .1rem var(--friends-color-focus);
 	}
 
 	&:focus, &:hover, &:active, &.active {
-		color: #1341d4;
+		color: var(--friends-color-link-hover);
 		text-decoration: underline;
 	}
 
 	&:visited {
-		color: #5d80f0;
+		color: var(--friends-color-link-visited);
 	}
 }
 
@@ -305,14 +348,14 @@ kbd {
 
 mark {
 	background: #ffe9b3;
-	color: #48427c;
+	color: var(--friends-color-text);
 	border-bottom: .05rem solid #ffd470;
 	border-radius: .1rem;
 	padding: .05rem .1rem 0;
 }
 
 blockquote {
-	border-left: .1rem solid #eee;
+	border-left: .1rem solid var(--friends-color-border);
 	margin-left: 0;
 	padding: .4rem .8rem;
 
@@ -418,11 +461,11 @@ legend {
 
 .form-input {
 	appearance: none;
-	background: #fff;
+	background: var(--friends-color-surface);
 	background-image: none;
-	border: .05rem solid #d6d4e8;
+	border: .05rem solid var(--friends-color-border-strong);
 	border-radius: .1rem;
-	color: #48427c;
+	color: var(--friends-color-text);
 	display: block;
 	font-size: .8rem;
 	height: 1.8rem;
@@ -435,11 +478,11 @@ legend {
 	width: 100%;
 
 	&:focus {
-		box-shadow: 0 0 0 .1rem rgba(46, 91, 236, 0.2);
-		border-color: #2e5bec;
+		box-shadow: 0 0 0 .1rem var(--friends-color-focus);
+		border-color: var(--friends-color-link);
 	}
 
-	&::placeholder { color: #d6d4e8; }
+	&::placeholder { color: var(--friends-color-text-soft); }
 	&.input-sm { font-size: .7rem; height: 1.4rem; padding: .05rem .3rem; }
 	&.input-lg { font-size: .9rem; height: 2rem; padding: .35rem .6rem; }
 	&.input-inline { display: inline-block; vertical-align: middle; width: auto; }
@@ -451,14 +494,14 @@ textarea.form-input {
 }
 
 .form-input-hint {
-	color: #d6d4e8;
+	color: var(--friends-color-text-soft);
 	font-size: .7rem;
 	margin-top: .2rem;
 }
 
 .form-select {
 	appearance: none;
-	border: .05rem solid #d6d4e8;
+	border: .05rem solid var(--friends-color-border-strong);
 	border-radius: .1rem;
 	color: inherit;
 	font-size: .8rem;
@@ -468,17 +511,17 @@ textarea.form-input {
 	padding: .25rem .4rem;
 	vertical-align: middle;
 	width: 100%;
-	background: #fff;
+	background: var(--friends-color-surface);
 
 	&:focus {
-		box-shadow: 0 0 0 .1rem rgba(46, 91, 236, 0.2);
-		border-color: #2e5bec;
+		box-shadow: 0 0 0 .1rem var(--friends-color-focus);
+		border-color: var(--friends-color-link);
 	}
 
 	&::-ms-expand { display: none; }
 
 	&:not([multiple]):not([size]) {
-		background: #fff url("data:image/svg+xml;charset=utf8,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%204%205'%3E%3Cpath%20fill='%23667189'%20d='M2%200L0%202h4zm0%205L0%203h4z'/%3E%3C/svg%3E") no-repeat right .35rem center / .4rem .5rem;
+		background: var(--friends-color-surface) url("data:image/svg+xml;charset=utf8,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%204%205'%3E%3Cpath%20fill='%23667189'%20d='M2%200L0%202h4zm0%205L0%203h4z'/%3E%3C/svg%3E") no-repeat right .35rem center / .4rem .5rem;
 		padding-right: 1.2rem;
 	}
 
@@ -531,8 +574,8 @@ textarea.form-input {
 		width: 1px;
 
 		&:focus + .form-icon {
-			box-shadow: 0 0 0 .1rem rgba(46, 91, 236, 0.2);
-			border-color: #2e5bec;
+			box-shadow: 0 0 0 .1rem var(--friends-color-focus);
+			border-color: var(--friends-color-link);
 		}
 
 		&:checked + .form-icon {
@@ -542,7 +585,7 @@ textarea.form-input {
 	}
 
 	& .form-icon {
-		border: .05rem solid #d6d4e8;
+		border: .05rem solid var(--friends-color-border-strong);
 		cursor: pointer;
 		display: inline-block;
 		position: absolute;
@@ -552,14 +595,14 @@ textarea.form-input {
 
 .form-checkbox, .form-radio {
 	& .form-icon {
-		background: #fff;
+		background: var(--friends-color-surface);
 		height: .8rem;
 		left: 0;
 		top: .3rem;
 		width: .8rem;
 	}
 
-	& input:active + .form-icon { background: #f7f7f7; }
+	& input:active + .form-icon { background: var(--friends-color-surface-alt); }
 }
 
 .form-checkbox .form-icon { border-radius: .1rem; }
@@ -615,7 +658,7 @@ textarea.form-input {
 	padding-left: 2rem;
 
 	& .form-icon {
-		background: #d6d4e8;
+		background: var(--friends-color-border-strong);
 		background-clip: padding-box;
 		border-radius: .45rem;
 		height: .9rem;
@@ -624,7 +667,7 @@ textarea.form-input {
 		width: 1.6rem;
 
 		&::before {
-			background: #fff;
+			background: var(--friends-color-surface);
 			border-radius: 50%;
 			content: "";
 			display: block;
@@ -638,15 +681,15 @@ textarea.form-input {
 	}
 
 	& input:checked + .form-icon::before { left: 14px; }
-	& input:active + .form-icon::before { background: white; }
+	& input:active + .form-icon::before { background: var(--friends-color-surface); }
 }
 
 .input-group {
 	display: flex;
 
 	& .input-group-addon {
-		background: white;
-		border: .05rem solid #d6d4e8;
+		background: var(--friends-color-surface);
+		border: .05rem solid var(--friends-color-border-strong);
 		border-radius: .1rem;
 		line-height: 1.2rem;
 		padding: .25rem .4rem;
@@ -669,15 +712,15 @@ textarea.form-input {
 
 .form-input:disabled, .form-input.disabled,
 .form-select:disabled, .form-select.disabled {
-	background-color: #f7f7f7;
+	background-color: var(--friends-color-surface-alt);
 	cursor: not-allowed;
 	opacity: .5;
 }
 
-.form-input[readonly] { background-color: white; }
+.form-input[readonly] { background-color: var(--friends-color-surface); }
 
 input:disabled + .form-icon, input.disabled + .form-icon {
-	background: #f7f7f7;
+	background: var(--friends-color-surface-alt);
 	cursor: not-allowed;
 	opacity: .5;
 }
@@ -696,10 +739,10 @@ input:disabled + .form-icon, input.disabled + .form-icon {
 
 .btn {
 	appearance: none;
-	background: #fff;
-	border: .05rem solid #2e5bec;
+	background: var(--friends-color-surface);
+	border: .05rem solid var(--friends-color-link);
 	border-radius: .1rem;
-	color: #2e5bec;
+	color: var(--friends-color-link);
 	cursor: pointer;
 	display: inline-block;
 	font-size: .8rem;
@@ -714,10 +757,10 @@ input:disabled + .form-icon, input.disabled + .form-icon {
 	vertical-align: middle;
 	white-space: nowrap;
 
-	&:focus { box-shadow: 0 0 0 .1rem rgba(46, 91, 236, 0.2); }
+	&:focus { box-shadow: 0 0 0 .1rem var(--friends-color-focus); }
 
 	&:focus, &:hover {
-		background: #dde5fc;
+		background: var(--friends-color-menu-hover);
 		border-color: #2050eb;
 		text-decoration: none;
 	}
@@ -747,9 +790,9 @@ input:disabled + .form-icon, input.disabled + .form-icon {
 	&.btn-link {
 		background: transparent;
 		border-color: transparent;
-		color: #2e5bec;
+		color: var(--friends-color-link);
 
-		&:focus, &:hover, &:active, &.active { color: #1341d4; }
+		&:focus, &:hover, &:active, &.active { color: var(--friends-color-link-hover); }
 	}
 
 	&.btn-sm { font-size: .7rem; height: 1.4rem; padding: .05rem .3rem; }
@@ -903,7 +946,7 @@ input:disabled + .form-icon, input.disabled + .form-icon {
 	}
 
 	& .off-canvas-sidebar {
-		background: white;
+		background: var(--friends-color-surface);
 		bottom: 0;
 		min-width: 10rem;
 		overflow-y: auto;
@@ -1000,8 +1043,8 @@ summary.accordion-header::-webkit-details-marker {
    ======================================================================== */
 
 .card {
-	background: #fff;
-	border: .05rem solid #eee;
+	background: var(--friends-color-surface);
+	border: .05rem solid var(--friends-color-border);
 	border-radius: .1rem;
 	display: flex;
 	flex-direction: column;
@@ -1062,7 +1105,7 @@ summary.accordion-header::-webkit-details-marker {
 
 .chip {
 	align-items: center;
-	background: #f7f7f7;
+	background: var(--friends-color-surface-alt);
 	border-radius: 5rem;
 	display: inline-flex;
 	font-size: 90%;
@@ -1103,7 +1146,7 @@ summary.accordion-header::-webkit-details-marker {
 
 .menu {
 	box-shadow: 0 .05rem .15rem rgba(62, 57, 107, 0.3);
-	background: #fff;
+	background: var(--friends-color-surface);
 	border-radius: .1rem;
 	list-style: none;
 	margin: 0;
@@ -1128,8 +1171,8 @@ summary.accordion-header::-webkit-details-marker {
 			padding: .2rem .4rem;
 			text-decoration: none;
 
-			&:focus, &:hover { background: #dde5fc; color: #2e5bec; }
-			&:active, &.active { background: #dde5fc; color: #2e5bec; }
+			&:focus, &:hover { background: var(--friends-color-menu-hover); color: var(--friends-color-link); }
+			&:active, &.active { background: var(--friends-color-menu-hover); color: var(--friends-color-link); }
 		}
 
 		& + .menu-item { margin-top: .2rem; }
@@ -1240,13 +1283,13 @@ a.text-primary:focus, a.text-primary:hover { color: #2050eb !important; }
 a.text-error:focus, a.text-error:hover { color: #cf4d00 !important; }
 .text-success { color: #32b643 !important; }
 .text-warning { color: #ffb700 !important; }
-.text-gray { color: #d6d4e8 !important; }
-.text-dark { color: #48427c !important; }
+.text-gray { color: var(--friends-color-text-soft) !important; }
+.text-dark { color: var(--friends-color-text) !important; }
 .text-light { color: #fff !important; }
 
 .bg-primary { background: #2e5bec !important; color: #fff; }
 .bg-dark { background: #3e396b !important; color: #fff; }
-.bg-gray { background: white !important; }
+.bg-gray { background: var(--friends-color-surface) !important; }
 .bg-success { background: #32b643 !important; color: #fff; }
 .bg-warning { background: #ffb700 !important; }
 .bg-error { background: #e85600 !important; color: #fff; }
@@ -1260,8 +1303,8 @@ a.text-error:focus, a.text-error:hover { color: #cf4d00 !important; }
 	position: relative;
 
 	&[data-content]::after {
-		background: #fff;
-		color: #d6d4e8;
+		background: var(--friends-color-surface);
+		color: var(--friends-color-text-soft);
 		content: attr(data-content);
 		display: inline-block;
 		font-size: .7rem;
@@ -1271,7 +1314,7 @@ a.text-error:focus, a.text-error:hover { color: #cf4d00 !important; }
 }
 
 .divider {
-	border-top: .05rem solid #eee;
+	border-top: .05rem solid var(--friends-color-border);
 	height: .05rem;
 	margin: .4rem 0;
 
@@ -1283,7 +1326,7 @@ a.text-error:focus, a.text-error:hover { color: #cf4d00 !important; }
 	padding: .8rem;
 
 	&::before {
-		border-left: .05rem solid #eee;
+		border-left: .05rem solid var(--friends-color-border);
 		bottom: .4rem;
 		content: "";
 		display: block;
@@ -1457,7 +1500,7 @@ a.text-error:focus, a.text-error:hover { color: #cf4d00 !important; }
 }
 
 .off-canvas .off-canvas-sidebar {
-	background-color: #f7f8f9;
+	background-color: var(--friends-color-background);
 	margin-top: 32px;
 	width: 12rem;
 }
@@ -1484,19 +1527,19 @@ h2#page-title a.dashicons {
 }
 
 .friends-page {
-	background-color: #f7f8f9;
-	color: #48427c;
+	background-color: var(--friends-color-background);
+	color: var(--friends-color-text);
 	overflow-wrap: break-word;
 	min-height: 100vh;
 
 	& code, & pre { overflow: auto; }
 
-	& a:visited { color: #1341d4; }
+	& a:visited { color: var(--friends-color-link-visited); }
 	& a.off-canvas-toggle:visited { color: #fff; }
-	& a, & a:visited, & a:hover, & a:focus, & a:active { color: #2e5bec; }
+	& a, & a:visited, & a:hover, & a:focus, & a:active { color: var(--friends-color-link); }
 
 	& summary.accordion-header {
-		color: #2e5bec;
+		color: var(--friends-color-link);
 		cursor: pointer;
 		white-space: nowrap;
 		text-overflow: ellipsis;
@@ -1529,7 +1572,7 @@ h2#page-title a.dashicons {
 	}
 
 	& .menu {
-		& a, & a:active, & a:visited { color: #333; padding: .2rem; }
+		& a, & a:active, & a:visited { color: var(--friends-color-text); padding: .2rem; }
 		& .menu-item + .menu-item { margin-top: 0; }
 		& .divider[data-content] { margin: 0.8rem 0 0.4rem 0; }
 		& .menu-item.friends-dropdown { margin-top: 0.2rem; margin-bottom: 0.4rem; }
@@ -1608,12 +1651,12 @@ h2#page-title a.dashicons {
 			}
 
 			& p.note {
-				border-left: 4px solid #eee;
+				border-left: 4px solid var(--friends-color-border);
 				padding: 1rem;
 				margin-left: 1rem;
 				font-size: .8rem;
-				color: #666;
-				background-color: #f7f7f7;
+				color: var(--friends-color-text-muted);
+				background-color: var(--friends-color-note-background);
 			}
 		}
 	}
@@ -1638,7 +1681,7 @@ h2#page-title a.dashicons {
 		}
 
 		& .friends-sidebar-customize {
-			color: #999;
+			color: var(--friends-color-text-soft);
 			font-size: .4rem;
 			line-height: .6rem;
 			display: block;
@@ -1676,7 +1719,7 @@ h2#page-title a.dashicons {
 		& p.description { color: #3e396b; font-size: .6rem; }
 
 		& .activitypub_preview {
-			background-color: #f7f8f9;
+			background-color: var(--friends-color-background);
 			padding: .5em;
 			margin-top: 1em;
 			margin-bottom: 1em;
@@ -1686,7 +1729,7 @@ h2#page-title a.dashicons {
 			& figcaption {
 				float: right;
 
-				& a:any-link { color: #999; }
+				& a:any-link { color: var(--friends-color-text-soft); }
 			}
 		}
 	}
@@ -1694,8 +1737,8 @@ h2#page-title a.dashicons {
 	& img.avatar { border-radius: 5px; max-width: 36px; max-height: 36px; }
 	& img.avatar.avatar-overlay { position: absolute; margin-left: -16px; margin-top: 24px; border-radius: 100%; }
 	& div.friends-widget { margin-bottom: 2em; }
-	& div.friends-main-widget h1 a { color: #222; text-decoration: none; }
-	& div.friends-widget h4 a { color: #222; text-decoration: none; }
+	& div.friends-main-widget h1 a { color: var(--friends-color-text); text-decoration: none; }
+	& div.friends-widget h4 a { color: var(--friends-color-text); text-decoration: none; }
 	& div.friends-widget a.open-requests { font-size: 90%; font-weight: normal; }
 	& div.friends-widget ul { margin: .5em 0 1em 0; padding: 0; }
 
@@ -1810,16 +1853,16 @@ h2#page-title a.dashicons {
 			justify-content: flex-end;
 
 			& a {
-				color: #2e5bec;
+				color: var(--friends-color-link);
 
 				& .dashicons { vertical-align: middle; }
 			}
 
-			& .btn:hover { color: #2e5bec; }
+			& .btn:hover { color: var(--friends-color-link); }
 		}
 
 		& footer.comments-content {
-			border-top: 1px solid #eee;
+			border-top: 1px solid var(--friends-color-border);
 
 			&.closed { display: none; }
 
@@ -1834,7 +1877,7 @@ h2#page-title a.dashicons {
 				list-style: none;
 				margin-left: 0;
 				padding-left: 5px;
-				border-left: 3px solid #eee;
+				border-left: 3px solid var(--friends-color-border);
 			}
 
 			& .comment-list .children > li {
@@ -1879,9 +1922,9 @@ h2#page-title a.dashicons {
 			padding: .35em .6em;
 			font-size: inherit;
 			line-height: 1.3;
-			border: 1px solid #ccc;
+			border: 1px solid var(--friends-color-border-strong);
 			border-radius: 3px;
-			background: #fff;
+			background: var(--friends-color-surface);
 		}
 
 		& .friends-search-input:focus {
@@ -1985,7 +2028,7 @@ h2#page-title a.dashicons {
 		}
 
 		& .opml-file-hint {
-			color: #5f5a7d;
+			color: var(--friends-color-text-muted);
 			font-size: .75rem;
 			margin: .6rem 0 0;
 		}
@@ -2029,7 +2072,7 @@ h2#page-title a.dashicons {
 		}
 
 		& .bulk-feed-list > .bulk-feed-row {
-			background: #f8f8fc;
+			background: var(--friends-color-surface-alt);
 			border-radius: .25rem;
 			padding: .65rem .75rem;
 
@@ -2056,7 +2099,7 @@ h2#page-title a.dashicons {
 		}
 
 		& .feed-preview {
-			background: #fff;
+			background: var(--friends-color-surface);
 			border-radius: .25rem;
 			box-shadow: inset 3px 0 0 #d9def7;
 			margin-top: 1rem;
@@ -2086,13 +2129,13 @@ h2#page-title a.dashicons {
 			min-width: 0;
 
 			& small {
-				color: #6b7280;
+				color: var(--friends-color-text-muted);
 				overflow-wrap: anywhere;
 			}
 		}
 
 		& .subscription-preview-description {
-			color: #5f5a7d;
+			color: var(--friends-color-text-muted);
 			margin: .6rem 0;
 		}
 
@@ -2131,7 +2174,7 @@ h2#page-title a.dashicons {
 		}
 
 		& .subscription-feed-option {
-			background: #f7f7fb;
+			background: var(--friends-color-surface-alt);
 			border-radius: .25rem;
 			margin-top: 0;
 			padding: .65rem;
@@ -2142,21 +2185,21 @@ h2#page-title a.dashicons {
 				overflow-wrap: anywhere;
 
 				& small {
-					color: #6b7280;
+					color: var(--friends-color-text-muted);
 					font-weight: 400;
 				}
 			}
 		}
 
 		& .subscription-feed-details {
-			color: #6b7280;
+			color: var(--friends-color-text-muted);
 			font-size: .7rem;
 			margin: .5rem 0 0;
 			overflow-wrap: anywhere;
 		}
 
 		& .subscription-feed-preview {
-			background: #fff;
+			background: var(--friends-color-surface);
 			border-radius: .2rem;
 			box-shadow: inset 0 0 0 1px #e8e8f3;
 			margin-top: .6rem;
@@ -2173,7 +2216,7 @@ h2#page-title a.dashicons {
 			}
 
 			& p {
-				color: #5f5a7d;
+				color: var(--friends-color-text-muted);
 				font-size: .75rem;
 				margin: .25rem 0 0;
 			}
@@ -2185,14 +2228,14 @@ h2#page-title a.dashicons {
 			gap: .1rem;
 
 			& small {
-				color: #6b7280;
+				color: var(--friends-color-text-muted);
 				font-size: .7rem;
 			}
 		}
 
 		& .subscription-preview-status,
 		& .bulk-feed-status {
-			color: #5f5a7d;
+			color: var(--friends-color-text-muted);
 			font-size: .75rem;
 
 			&.error { color: #b91c1c; }
@@ -2223,7 +2266,7 @@ h2#page-title a.dashicons {
 
 		& .subscription-item {
 			padding: 8px 0;
-			border-bottom: 1px solid #e8e8e8;
+			border-bottom: 1px solid var(--friends-color-border);
 			display: grid;
 			grid-template-columns: 40px 1fr;
 			grid-template-rows: auto auto auto;
@@ -2243,9 +2286,9 @@ h2#page-title a.dashicons {
 
 		& .subscription-info { display: inline-flex; align-items: center; gap: 4px; flex-wrap: wrap; }
 		& .starred { color: #f5a623; }
-		& .subscription-folder { font-size: 0.8em; background: #e8e8e8; padding: 1px 6px; border-radius: 3px; color: #666; }
-		& .subscription-meta { grid-column: 2; font-size: 0.85em; color: #888; }
-		& .subscription-description { grid-column: 2; font-size: 0.85em; color: #666; margin: 0; }
+		& .subscription-folder { font-size: 0.8em; background: var(--friends-color-surface-alt); padding: 1px 6px; border-radius: 3px; color: var(--friends-color-text-muted); }
+		& .subscription-meta { grid-column: 2; font-size: 0.85em; color: var(--friends-color-text-soft); }
+		& .subscription-description { grid-column: 2; font-size: 0.85em; color: var(--friends-color-text-muted); margin: 0; }
 		& .subscription-actions {
 			grid-column: 2;
 			display: flex;
@@ -2269,7 +2312,7 @@ h2#page-title a.dashicons {
 		padding: .5rem;
 		margin: 0;
 		font-size: 18px;
-		background-color: #fff;
+		background-color: var(--friends-color-surface);
 		border: 0;
 		cursor: pointer;
 		z-index: 999999;
@@ -2285,13 +2328,13 @@ h2#page-title a.dashicons {
 		& .wp-block-friends-message {
 			max-width: 80%;
 			margin: 1em;
-			border-bottom: 1px solid #eee;
+			border-bottom: 1px solid var(--friends-color-border);
 		}
 	}
 
 	& .friends-dm-view {
-		background: #fff;
-		border-top: 1px solid #e5e7eb;
+		background: var(--friends-color-surface);
+		border-top: 1px solid var(--friends-color-border);
 		display: grid;
 		grid-template-columns: minmax(220px, 320px) minmax(0, 1fr);
 		height: calc(100vh - 3.2rem);
@@ -2300,8 +2343,8 @@ h2#page-title a.dashicons {
 
 	& .friends-dm-empty {
 		align-self: start;
-		background: #fff;
-		border: 1px solid #e5e7eb;
+		background: var(--friends-color-surface);
+		border: 1px solid var(--friends-color-border);
 		border-radius: .2rem;
 		grid-column: 1 / -1;
 		margin: 1rem;
@@ -2312,8 +2355,8 @@ h2#page-title a.dashicons {
 	}
 
 	& .friends-dm-sidebar {
-		background: #f8fafc;
-		border-right: 1px solid #e5e7eb;
+		background: var(--friends-color-surface-muted);
+		border-right: 1px solid var(--friends-color-border);
 		overflow: auto;
 	}
 
@@ -2324,7 +2367,7 @@ h2#page-title a.dashicons {
 
 	& .friends-profile-messages-header {
 		align-items: center;
-		border-bottom: 1px solid #e5e7eb;
+		border-bottom: 1px solid var(--friends-color-border);
 		display: flex;
 		justify-content: space-between;
 		padding: .65rem .7rem;
@@ -2337,8 +2380,8 @@ h2#page-title a.dashicons {
 
 	& .friends-dm-conversation,
 	& .friends-dm-conversation:visited {
-		border-bottom: 1px solid #e5e7eb;
-		color: #2f3542;
+		border-bottom: 1px solid var(--friends-color-border);
+		color: var(--friends-color-text);
 		display: grid;
 		gap: .25rem .5rem;
 		grid-template-columns: 2rem minmax(0, 1fr) auto;
@@ -2349,8 +2392,8 @@ h2#page-title a.dashicons {
 	& .friends-dm-conversation:hover,
 	& .friends-dm-conversation:focus,
 	& .friends-dm-conversation.is-selected {
-		background: #edf2ff;
-		color: #1f2937;
+		background: var(--friends-color-selected-background);
+		color: var(--friends-color-text);
 		text-decoration: none;
 	}
 
@@ -2378,13 +2421,13 @@ h2#page-title a.dashicons {
 	}
 
 	& .friends-dm-conversation-preview {
-		color: #667085;
+		color: var(--friends-color-text-muted);
 		font-size: .72rem;
 	}
 
 	& .friends-dm-conversation-meta {
 		align-items: end;
-		color: #667085;
+		color: var(--friends-color-text-muted);
 		display: flex;
 		flex-direction: column;
 		font-size: .65rem;
@@ -2411,7 +2454,7 @@ h2#page-title a.dashicons {
 
 	& .friends-dm-thread-header {
 		align-items: center;
-		border-bottom: 1px solid #e5e7eb;
+		border-bottom: 1px solid var(--friends-color-border);
 		display: flex;
 		gap: .6rem;
 		min-height: 3.2rem;
@@ -2429,7 +2472,7 @@ h2#page-title a.dashicons {
 	}
 
 	& .friends-dm-messages {
-		background: #fff;
+		background: var(--friends-color-surface);
 		overflow: auto;
 		padding: .7rem .9rem;
 	}
@@ -2455,7 +2498,7 @@ h2#page-title a.dashicons {
 	}
 
 	& .friends-dm-message.is-own-message .friends-dm-message-content {
-		background: #eef6ff;
+		background: var(--friends-color-info-background);
 	}
 
 	& .friends-dm-message-meta {
@@ -2465,14 +2508,14 @@ h2#page-title a.dashicons {
 		line-height: 1.2;
 
 		& time {
-			color: #667085;
+			color: var(--friends-color-text-muted);
 			font-size: .65rem;
 		}
 	}
 
 	& .friends-dm-message-content {
-		background: #f8fafc;
-		border: 1px solid #e5e7eb;
+		background: var(--friends-color-surface-muted);
+		border: 1px solid var(--friends-color-border);
 		border-radius: .3rem;
 		margin-top: .18rem;
 		max-width: 48rem;
@@ -2483,8 +2526,8 @@ h2#page-title a.dashicons {
 	}
 
 	& .friends-dm-reply {
-		background: #f8fafc;
-		border-top: 1px solid #e5e7eb;
+		background: var(--friends-color-surface-muted);
+		border-top: 1px solid var(--friends-color-border);
 		padding: .65rem .8rem;
 
 		& form.form-horizontal .form-group {
@@ -2515,7 +2558,7 @@ h2#page-title a.dashicons {
 		}
 
 		& .friends-dm-sidebar {
-			border-bottom: 1px solid #e5e7eb;
+			border-bottom: 1px solid var(--friends-color-border);
 			border-right: 0;
 			max-height: 16rem;
 		}
@@ -2525,7 +2568,7 @@ h2#page-title a.dashicons {
 		}
 	}
 
-	& .chip { background-color: #fff; }
+	& .chip { background-color: var(--friends-color-surface); }
 
 	/* to support mastodon style tags */
 	& .invisible {


### PR DESCRIPTION
## Summary
- add light/dark color tokens for the default Friends frontend theme
- apply those tokens to the page shell, cards, forms, menus, subscriptions, and messages
- keep the existing light mode palette while honoring system dark mode

## Testing
- composer check-cs
- git diff --check

<details><summary>Changelog</summary>

- [x] Automatically create a changelog entry from the details below

#### Type
- [x] Fixed

#### Message
Fix default frontend theme colors so the page follows system dark mode.

</details>

<!-- friends-playground-link:start -->
## Test this PR in WordPress Playground

You can test this pull request directly in WordPress Playground:

[Launch WordPress Playground](https://akirk.github.io/playground-step-library/?redir=1&step[0]=setLandingPage&landingPage[0]=/friends/&step[1]=installPlugin&url[1]=github.com/akirk/friends/tree/fix/default-theme-dark-mode&step[2]=importFriendFeeds&opml[2]=https://alex.kirk.at%20Alex%20Kirk%0Ahttps://adamadam.blog%20Adam%20Zieliński)

This will install and activate the plugin with the changes from this PR.
<!-- friends-playground-link:end -->