### PR TITLE
Persist Mastodon API boosts locally

### DIFF
--- a/.github/changelog/unreleased/691-from-description
+++ b/.github/changelog/unreleased/691-from-description
@@ -1,0 +1,3 @@
+Type: fixed
+
+Persist Mastodon API boosts locally so announced boosts also appear in Mastodon account statuses.

--- a/feed-parsers/class-feed-parser-activitypub.php
+++ b/feed-parsers/class-feed-parser-activitypub.php
@@ -4495,22 +4495,45 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 
 		if ( get_post_meta( $post->ID, 'boosted', true ) ) {
 			\delete_post_meta( $post->ID, 'boosted' );
+			\delete_post_meta( $post->ID, 'boosted_at' );
 			$this->mastodon_api_unreblog( $post->ID );
 			wp_send_json_success( 'unboosted', array( 'id' => $post->ID ) );
 			return;
 		}
 		\update_post_meta( $post->ID, 'boosted', get_current_user_id() );
+		\update_post_meta( $post->ID, 'boosted_at', current_time( 'mysql', true ) );
 		$this->mastodon_api_reblog( $post->ID );
 
 		wp_send_json_success( 'boosted', array( 'id' => $post->ID ) );
 	}
 
 	public function mastodon_api_reblog( $post_id ) {
-		$this->queue_announce( get_post( $post_id ) );
+		$post = get_post( $post_id );
+		if ( ! $post ) {
+			return;
+		}
+
+		$user_id = get_current_user_id();
+		if ( ! $user_id ) {
+			return;
+		}
+
+		update_post_meta( $post->ID, 'boosted', $user_id );
+		update_post_meta( $post->ID, 'boosted_at', current_time( 'mysql', true ) );
+
+		$this->queue_announce( $post );
 	}
 
 	public function mastodon_api_unreblog( $post_id ) {
-		$this->queue_unannounce( get_post( $post_id ) );
+		$post = get_post( $post_id );
+		if ( ! $post ) {
+			return;
+		}
+
+		delete_post_meta( $post->ID, 'boosted' );
+		delete_post_meta( $post->ID, 'boosted_at' );
+
+		$this->queue_unannounce( $post );
 	}
 
 	/**

--- a/feed-parsers/class-feed-parser-activitypub.php
+++ b/feed-parsers/class-feed-parser-activitypub.php
@@ -4494,14 +4494,10 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 		}
 
 		if ( get_post_meta( $post->ID, 'boosted', true ) ) {
-			\delete_post_meta( $post->ID, 'boosted' );
-			\delete_post_meta( $post->ID, 'boosted_at' );
 			$this->mastodon_api_unreblog( $post->ID );
 			wp_send_json_success( 'unboosted', array( 'id' => $post->ID ) );
 			return;
 		}
-		\update_post_meta( $post->ID, 'boosted', get_current_user_id() );
-		\update_post_meta( $post->ID, 'boosted_at', current_time( 'mysql', true ) );
 		$this->mastodon_api_reblog( $post->ID );
 
 		wp_send_json_success( 'boosted', array( 'id' => $post->ID ) );

--- a/integrations/class-enable-mastodon-apps.php
+++ b/integrations/class-enable-mastodon-apps.php
@@ -24,6 +24,8 @@ class Enable_Mastodon_Apps {
 		add_filter( 'mastodon_api_bookmarks_args', array( get_called_class(), 'mastodon_api_bookmarks_args' ), 10, 2 );
 		add_filter( 'mastodon_api_status', array( get_called_class(), 'mastodon_api_status' ), 60, 2 );
 		add_filter( 'mastodon_api_get_notifications_query_args', array( get_called_class(), 'mastodon_api_get_notifications_query_args' ), 10, 2 );
+		add_filter( 'mastodon_api_account_statuses_excluded_post_types', array( get_called_class(), 'mastodon_api_account_statuses_excluded_post_types' ) );
+		add_filter( 'mastodon_api_account_statuses', array( get_called_class(), 'mastodon_api_account_statuses' ), 10, 3 );
 	}
 
 	public static function mastodon_api_account_follow( $user_id ) {
@@ -52,6 +54,11 @@ class Enable_Mastodon_Apps {
 	public static function mastodon_api_view_post_types( $view_post_types ) {
 		$view_post_types[] = Friends::CPT;
 		return $view_post_types;
+	}
+
+	public static function mastodon_api_account_statuses_excluded_post_types( $excluded_post_types ) {
+		$excluded_post_types[] = Friends::CPT;
+		return $excluded_post_types;
 	}
 
 	public static function mastodon_api_favourites_args( $args, $user_id ) {
@@ -152,6 +159,97 @@ class Enable_Mastodon_Apps {
 		}
 
 		return $status;
+	}
+
+	public static function mastodon_api_account_statuses( $statuses, $request, $user_id ) {
+		if ( $request->get_param( 'exclude_reblogs' ) ) {
+			return $statuses;
+		}
+
+		if ( is_wp_error( $statuses ) ) {
+			return $statuses;
+		}
+
+		$response = null;
+		if ( $statuses instanceof \WP_REST_Response ) {
+			$response = $statuses;
+			$statuses = $response->get_data();
+		}
+
+		if ( ! is_array( $statuses ) ) {
+			return $response ? $response : $statuses;
+		}
+
+		$boosted_posts = self::get_mastodon_api_boosted_posts( $request, $user_id );
+		if ( empty( $boosted_posts ) ) {
+			return $response ? $response : $statuses;
+		}
+
+		$account = apply_filters( 'mastodon_api_account', null, $user_id, $request, null );
+		if ( ! is_object( $account ) ) {
+			return $response ? $response : $statuses;
+		}
+
+		foreach ( $boosted_posts as $post ) {
+			$reblog = apply_filters( 'mastodon_api_status', null, $post->ID, array() );
+			if ( ! is_object( $reblog ) || empty( $reblog->id ) ) {
+				continue;
+			}
+
+			$status             = clone $reblog;
+			$status->account    = $account;
+			$status->reblog     = $reblog;
+			$status->content    = '';
+			$status->url        = null;
+			$status->created_at = self::get_mastodon_api_boosted_at( $post );
+			$status->reblogged  = true;
+			$statuses[]         = $status;
+		}
+
+		usort(
+			$statuses,
+			function ( $a, $b ) {
+				return $b->created_at->getTimestamp() - $a->created_at->getTimestamp();
+			}
+		);
+
+		$limit = $request->get_param( 'limit' );
+		if ( $limit > 0 ) {
+			$statuses = array_slice( $statuses, 0, $limit );
+		}
+
+		if ( $response ) {
+			$response->set_data( $statuses );
+			return $response;
+		}
+
+		return $statuses;
+	}
+
+	protected static function get_mastodon_api_boosted_posts( $request, $user_id ) {
+		$args = array(
+			'post_type'        => Friends::CPT,
+			'post_status'      => array( 'publish', 'private' ),
+			'posts_per_page'   => $request->get_param( 'limit' ),
+			'suppress_filters' => false,
+			'meta_query'       => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+				array(
+					'key'   => 'boosted',
+					'value' => strval( $user_id ),
+				),
+			),
+		);
+
+		return get_posts( $args );
+	}
+
+	protected static function get_mastodon_api_boosted_at( \WP_Post $post ) {
+		$boosted_at = get_post_meta( $post->ID, 'boosted_at', true );
+		if ( $boosted_at ) {
+			return new \DateTime( $boosted_at, new \DateTimeZone( 'UTC' ) );
+		}
+
+		return new \DateTime( $post->post_modified_gmt, new \DateTimeZone( 'UTC' ) );
 	}
 
 	public static function mastodon_api_get_notifications_query_args( $args, $type ) {

--- a/tests/test-only-ema.php
+++ b/tests/test-only-ema.php
@@ -315,6 +315,106 @@ class Only_EnableMastodonAppsTest extends Friends_TestCase_Cache_HTTP {
 		$this->assertEquals( 1, $status->favourites_count );
 	}
 
+	public function test_mastodon_api_reblog_persists_local_boost_state() {
+		wp_set_current_user( $this->administrator_id );
+
+		$friend = Subscription::create( 'api-boost.local', 'subscription', 'https://api-boost.local' );
+		$post_id = $friend->insert_post(
+			array(
+				'post_type'   => Friends::CPT,
+				'post_title'  => 'API Boost Post',
+				'post_status' => 'publish',
+			)
+		);
+		$this->posts[] = $post_id;
+
+		$parser = new class() extends Feed_Parser_ActivityPub {
+			public $announced_post_id;
+			public $unannounced_post_id;
+
+			public function __construct() {}
+
+			public function queue_announce( \WP_Post $post ) {
+				$this->announced_post_id = $post->ID;
+				return true;
+			}
+
+			public function queue_unannounce( \WP_Post $post ) {
+				$this->unannounced_post_id = $post->ID;
+				return true;
+			}
+		};
+
+		$parser->mastodon_api_reblog( $post_id );
+
+		$this->assertEquals( $this->administrator_id, get_post_meta( $post_id, 'boosted', true ) );
+		$this->assertNotEmpty( get_post_meta( $post_id, 'boosted_at', true ) );
+		$this->assertEquals( $post_id, $parser->announced_post_id );
+
+		$parser->mastodon_api_unreblog( $post_id );
+
+		$this->assertEmpty( get_post_meta( $post_id, 'boosted', true ) );
+		$this->assertEmpty( get_post_meta( $post_id, 'boosted_at', true ) );
+		$this->assertEquals( $post_id, $parser->unannounced_post_id );
+	}
+
+	public function test_ema_account_statuses_include_local_boosts() {
+		wp_set_current_user( $this->administrator_id );
+
+		$friend = Subscription::create( 'account-boost.local', 'subscription', 'https://account-boost.local' );
+		$post_id = $friend->insert_post(
+			array(
+				'post_type'     => Friends::CPT,
+				'post_title'    => 'Account Boost Post',
+				'post_status'   => 'publish',
+				'post_date_gmt' => '2024-05-01 10:00:00',
+			)
+		);
+		$this->posts[] = $post_id;
+
+		update_post_meta( $post_id, 'boosted', $this->administrator_id );
+		update_post_meta( $post_id, 'boosted_at', '2024-05-02 12:00:00' );
+
+		$status_filter = function ( $status, $filtered_post_id ) use ( $post_id ) {
+			if ( intval( $filtered_post_id ) !== intval( $post_id ) ) {
+				return $status;
+			}
+
+			$status = $this->create_mastodon_status( $post_id );
+			$status->created_at = new \DateTime( '2024-05-01 10:00:00', new \DateTimeZone( 'UTC' ) );
+			$status->account = (object) array(
+				'id' => 'remote-account',
+			);
+			return $status;
+		};
+		add_filter( 'mastodon_api_status', $status_filter, 20, 2 );
+
+		$account_filter = function ( $account, $user_id ) {
+			if ( intval( $user_id ) !== intval( $this->administrator_id ) ) {
+				return $account;
+			}
+
+			return (object) array(
+				'id' => strval( $this->administrator_id ),
+			);
+		};
+		add_filter( 'mastodon_api_account', $account_filter, 20, 2 );
+
+		$request = $this->api_request( 'GET', '/api/v1/accounts/' . $this->administrator_id . '/statuses' );
+		$request->set_param( 'limit', 20 );
+		$statuses = Enable_Mastodon_Apps::mastodon_api_account_statuses( new \WP_REST_Response( array() ), $request, $this->administrator_id );
+
+		remove_filter( 'mastodon_api_status', $status_filter, 20 );
+		remove_filter( 'mastodon_api_account', $account_filter, 20 );
+
+		$data = $statuses->get_data();
+
+		$this->assertCount( 1, $data );
+		$this->assertEquals( strval( $this->administrator_id ), $data[0]->account->id );
+		$this->assertEquals( strval( $post_id ), $data[0]->reblog->id );
+		$this->assertEquals( '2024-05-02T12:00:00+00:00', $data[0]->created_at->format( \DateTime::ATOM ) );
+	}
+
 	public function test_ema_notifications_mentions_queryable() {
 		// This test verifies that Friends posts with mention tags are properly queryable
 		// through the mastodon_api_get_notifications_query_args filter, which allows


### PR DESCRIPTION
## Summary
- Persist local boost metadata when the Mastodon API reblog hook queues an Announce
- Remove local boost metadata on unreblog
- Add boosted Friends posts to EMA account statuses as reblog wrappers
- Use boost timestamps for reblog wrapper ordering
- Add regression coverage for API reblog persistence and account-status boost visibility

## Verification
- php -l feed-parsers/class-feed-parser-activitypub.php
- php -l integrations/class-enable-mastodon-apps.php
- php -l tests/test-only-ema.php
- Live curl confirmed the backfilled recent boost appears as a reblog wrapper in account statuses

No PHPUnit run in this environment.

- [x] Automatically create a changelog entry from the details below

<details>
<summary>Changelog entry</summary>

#### Type
- [ ] Added
- [ ] Changed
- [x] Fixed
- [ ] Removed

#### Message
Persist Mastodon API boosts locally so announced boosts also appear in Mastodon account statuses.

</details>

<!-- friends-playground-link:start -->
## Test this PR in WordPress Playground

You can test this pull request directly in WordPress Playground:

[Launch WordPress Playground](https://akirk.github.io/playground-step-library/?redir=1&step[0]=setLandingPage&landingPage[0]=/friends/&step[1]=installPlugin&url[1]=github.com/akirk/friends/tree/fix/persist-mastodon-api-boosts&step[2]=importFriendFeeds&opml[2]=https://alex.kirk.at%20Alex%20Kirk%0Ahttps://adamadam.blog%20Adam%20Zieliński)

This will install and activate the plugin with the changes from this PR.
<!-- friends-playground-link:end -->