### PR TITLE
Fix mobile direct messages layout

### DIFF
--- a/.github/changelog/unreleased/693-from-description
+++ b/.github/changelog/unreleased/693-from-description
@@ -1,0 +1,3 @@
+Type: fixed
+
+Fix the mobile direct messages layout and keyboard behavior.

--- a/friends.css
+++ b/friends.css
@@ -2337,7 +2337,7 @@ h2#page-title a.dashicons {
 		border-top: 1px solid var(--friends-color-border);
 		display: grid;
 		grid-template-columns: minmax(220px, 320px) minmax(0, 1fr);
-		height: calc(100vh - 3.2rem);
+		height: calc(var(--friends-dm-viewport-height, 100vh) - 3.2rem);
 		min-height: 32rem;
 	}
 
@@ -2471,6 +2471,10 @@ h2#page-title a.dashicons {
 		}
 	}
 
+	& .friends-dm-back {
+		display: none;
+	}
+
 	& .friends-dm-messages {
 		background: var(--friends-color-surface);
 		overflow: auto;
@@ -2552,19 +2556,69 @@ h2#page-title a.dashicons {
 	}
 
 	@media (max-width: 840px) {
+		& .navbar-section.search.hide-mobile-search {
+			display: none;
+		}
+
 		& .friends-dm-view {
 			grid-template-columns: 1fr;
-			height: auto;
+			grid-template-rows: minmax(0, 1fr);
+			height: min(calc(var(--friends-dm-viewport-height, 100vh) - 3.2rem), 48rem);
+			min-height: 0;
+			overflow: hidden;
+			position: relative;
 		}
 
 		& .friends-dm-sidebar {
-			border-bottom: 1px solid var(--friends-color-border);
 			border-right: 0;
-			max-height: 16rem;
+			grid-column: 1;
+			grid-row: 1;
+			height: 100%;
+			max-height: none;
+			min-height: 0;
+			transform: translateX(0);
+			transition: transform .2s ease;
+			width: 100%;
+			z-index: 1;
 		}
 
 		& .friends-dm-thread {
-			min-height: 34rem;
+			grid-column: 1;
+			grid-row: 1;
+			height: 100%;
+			min-height: 0;
+			overflow: hidden;
+			transform: translateX(100%);
+			transition: transform .2s ease;
+			width: 100%;
+			z-index: 2;
+		}
+
+		& .friends-dm-view.is-focused-conversation .friends-dm-sidebar {
+			transform: translateX(-100%);
+		}
+
+		& .friends-dm-view.is-focused-conversation .friends-dm-thread {
+			transform: translateX(0);
+		}
+
+		& .friends-dm-back {
+			align-items: center;
+			border: 0;
+			color: var(--friends-color-text);
+			display: flex;
+			font-size: 1.25rem;
+			line-height: 1;
+			text-decoration: none;
+		}
+
+		& .friends-dm-messages {
+			min-height: 0;
+			overscroll-behavior: contain;
+		}
+
+		& .friends-dm-reply {
+			padding-bottom: calc(.65rem + env(safe-area-inset-bottom, 0px));
 		}
 	}
 

--- a/friends.js
+++ b/friends.js
@@ -774,6 +774,88 @@
 	}
 
 	let isRefreshingDmView = false;
+	const dmMobileQuery = window.matchMedia ? window.matchMedia( '(max-width: 840px)' ) : null;
+
+	function isMobileDmView() {
+		return dmMobileQuery && dmMobileQuery.matches;
+	}
+
+	function hasFocusedDmHash() {
+		const $thread = $( '.friends-dm-thread' );
+		return !! $thread.length && window.location.hash === '#' + $thread.attr( 'id' );
+	}
+
+	function isDmConversationVisible() {
+		return ! isMobileDmView() || hasFocusedDmHash();
+	}
+
+	function scrollCurrentDmThreadToBottom() {
+		const messages = $( '.friends-dm-thread' ).find( '.friends-dm-messages' ).get( 0 );
+		if ( messages ) {
+			messages.scrollTop = messages.scrollHeight;
+		}
+	}
+
+	function updateDmHashState() {
+		const $view = $( '.friends-dm-view' );
+		if ( ! $view.length ) {
+			return;
+		}
+
+		$view.toggleClass( 'is-focused-conversation', hasFocusedDmHash() );
+		if ( isDmConversationVisible() ) {
+			scrollCurrentDmThreadToBottom();
+			markCurrentDmThreadRead();
+		}
+	}
+
+	function updateDmViewportHeight() {
+		if ( ! $( '.friends-dm-view' ).length ) {
+			return;
+		}
+
+		const viewport = window.visualViewport || window;
+		const height = viewport.height || window.innerHeight;
+		if ( height ) {
+			document.documentElement.style.setProperty( '--friends-dm-viewport-height', height + 'px' );
+		}
+	}
+
+	function watchDmViewportHeight() {
+		if ( ! $( '.friends-dm-view' ).length ) {
+			return;
+		}
+
+		let frame = null;
+		const scheduleUpdate = function () {
+			if ( frame ) {
+				window.cancelAnimationFrame( frame );
+			}
+			frame = window.requestAnimationFrame( updateDmViewportHeight );
+		};
+
+		updateDmViewportHeight();
+		$( window ).on( 'resize orientationchange', scheduleUpdate );
+		if ( window.visualViewport ) {
+			window.visualViewport.addEventListener( 'resize', scheduleUpdate );
+			window.visualViewport.addEventListener( 'scroll', scheduleUpdate );
+		}
+		if ( dmMobileQuery && dmMobileQuery.addEventListener ) {
+			dmMobileQuery.addEventListener( 'change', updateDmHashState );
+		} else if ( dmMobileQuery && dmMobileQuery.addListener ) {
+			dmMobileQuery.addListener( updateDmHashState );
+		}
+	}
+
+	$document.on( 'focus blur', '.friends-dm-reply input, .friends-dm-reply select, .friends-dm-reply textarea', function () {
+		const reply = $( this ).closest( '.friends-dm-reply' ).get( 0 );
+		window.setTimeout( function () {
+			updateDmViewportHeight();
+			if ( reply ) {
+				reply.scrollIntoView( { block: 'end' } );
+			}
+		}, 300 );
+	} );
 
 	function refreshDmView() {
 		const $thread = $( '.friends-dm-thread' );
@@ -817,7 +899,7 @@
 				.data( 'unread', $newThread.data( 'unread' ) )
 				.attr( 'data-unread', $newThread.attr( 'data-unread' ) );
 			updateRelativeTimes( '.friends-dm-view' );
-			markCurrentDmThreadRead();
+			updateDmHashState();
 		} ).always( function () {
 			isRefreshingDmView = false;
 		} );
@@ -826,18 +908,15 @@
 	$( function () {
 		restoreMessageDrafts();
 		updateRelativeTimes( document );
+		watchDmViewportHeight();
+		updateDmHashState();
+		$( window ).on( 'hashchange', updateDmHashState );
 
 		const $thread = $( '.friends-dm-thread' );
 		if ( ! $thread.length ) {
 			return;
 		}
 
-		const messages = $thread.find( '.friends-dm-messages' ).get( 0 );
-		if ( messages ) {
-			messages.scrollTop = messages.scrollHeight;
-		}
-
-		markCurrentDmThreadRead();
 		window.setInterval( updateRelativeTimes, 60000 );
 		window.setInterval( refreshDmView, 30000 );
 	} );

--- a/includes/class-frontend.php
+++ b/includes/class-frontend.php
@@ -326,13 +326,29 @@ class Frontend {
 		return $file_paths;
 	}
 
+	/**
+	 * Get an asset version that changes when the local file changes.
+	 *
+	 * @param string $file Relative asset path.
+	 * @return string Asset version.
+	 */
+	private function get_asset_version( $file ) {
+		$path = dirname( FRIENDS_PLUGIN_FILE ) . '/' . $file;
+		if ( file_exists( $path ) ) {
+			return Friends::VERSION . '-' . filemtime( $path );
+		}
+
+		return Friends::VERSION;
+	}
+
 	public function default_theme() {
 		$handle = 'friends';
 		$file = 'friends.css';
-		$version = Friends::VERSION;
+		$version = $this->get_asset_version( $file );
 		wp_enqueue_style( $handle, plugins_url( $file, FRIENDS_PLUGIN_FILE ), array(), apply_filters( 'friends_debug_enqueue', $version, $handle, dirname( FRIENDS_PLUGIN_FILE ) . '/' . $file ) );
 
-		wp_enqueue_script( 'friends-default-theme', plugins_url( 'friends-default-theme.js', FRIENDS_PLUGIN_FILE ), array( 'jquery', 'friends' ), $version, true );
+		$file = 'friends-default-theme.js';
+		wp_enqueue_script( 'friends-default-theme', plugins_url( $file, FRIENDS_PLUGIN_FILE ), array( 'jquery', 'friends' ), $this->get_asset_version( $file ), true );
 	}
 
 	/**
@@ -346,7 +362,7 @@ class Frontend {
 
 		$handle = 'friends';
 		$file = 'friends.js';
-		$version = Friends::VERSION;
+		$version = $this->get_asset_version( $file );
 		wp_enqueue_script( $handle, plugins_url( $file, FRIENDS_PLUGIN_FILE ), array( 'common', 'jquery', 'wp-util' ), apply_filters( 'friends_debug_enqueue', $version, $handle, dirname( FRIENDS_PLUGIN_FILE ) . '/' . $file ), true );
 
 		$query_vars = wp_json_encode( $this->get_minimal_query_vars( $wp_query->query_vars ) );
@@ -524,10 +540,11 @@ class Frontend {
 	public function mastodon_theme() {
 		$handle  = 'friends-mastodon';
 		$file    = 'templates/mastodon/mastodon.css';
-		$version = Friends::VERSION;
+		$version = $this->get_asset_version( $file );
 		wp_enqueue_style( $handle, plugins_url( $file, FRIENDS_PLUGIN_FILE ), array(), apply_filters( 'friends_debug_enqueue', $version, $handle, dirname( FRIENDS_PLUGIN_FILE ) . '/' . $file ) );
 
-		wp_enqueue_script( 'friends-mastodon', plugins_url( 'templates/mastodon/mastodon.js', FRIENDS_PLUGIN_FILE ), array( 'jquery', 'friends' ), $version, true );
+		$file = 'templates/mastodon/mastodon.js';
+		wp_enqueue_script( 'friends-mastodon', plugins_url( $file, FRIENDS_PLUGIN_FILE ), array( 'jquery', 'friends' ), $this->get_asset_version( $file ), true );
 		wp_localize_script(
 			'friends-mastodon',
 			'friendsMastodon',
@@ -560,10 +577,11 @@ class Frontend {
 	public function twitter_theme() {
 		$handle  = 'friends-twitter';
 		$file    = 'templates/twitter/twitter.css';
-		$version = Friends::VERSION;
+		$version = $this->get_asset_version( $file );
 		wp_enqueue_style( $handle, plugins_url( $file, FRIENDS_PLUGIN_FILE ), array(), apply_filters( 'friends_debug_enqueue', $version, $handle, dirname( FRIENDS_PLUGIN_FILE ) . '/' . $file ) );
 
-		wp_enqueue_script( 'friends-twitter', plugins_url( 'templates/twitter/twitter.js', FRIENDS_PLUGIN_FILE ), array( 'jquery', 'friends' ), $version, true );
+		$file = 'templates/twitter/twitter.js';
+		wp_enqueue_script( 'friends-twitter', plugins_url( $file, FRIENDS_PLUGIN_FILE ), array( 'jquery', 'friends' ), $this->get_asset_version( $file ), true );
 		wp_localize_script(
 			'friends-twitter',
 			'friendsTwitter',
@@ -584,10 +602,11 @@ class Frontend {
 	public function google_reader_theme() {
 		$handle  = 'friends-google-reader';
 		$file    = 'templates/google-reader/google-reader.css';
-		$version = Friends::VERSION;
+		$version = $this->get_asset_version( $file );
 		wp_enqueue_style( $handle, plugins_url( $file, FRIENDS_PLUGIN_FILE ), array(), apply_filters( 'friends_debug_enqueue', $version, $handle, dirname( FRIENDS_PLUGIN_FILE ) . '/' . $file ) );
 
-		wp_enqueue_script( 'friends-google-reader', plugins_url( 'templates/google-reader/google-reader.js', FRIENDS_PLUGIN_FILE ), array( 'jquery' ), $version, true );
+		$file = 'templates/google-reader/google-reader.js';
+		wp_enqueue_script( 'friends-google-reader', plugins_url( $file, FRIENDS_PLUGIN_FILE ), array( 'jquery' ), $this->get_asset_version( $file ), true );
 
 		add_filter(
 			'friends_template_paths_theme_google-reader',
@@ -661,7 +680,7 @@ class Frontend {
 		// and injected via template_override.
 		$handle  = 'friends-blocks';
 		$file    = 'friends-blocks.css';
-		$version = Friends::VERSION;
+		$version = $this->get_asset_version( $file );
 		wp_enqueue_style( $handle, plugins_url( $file, FRIENDS_PLUGIN_FILE ), array(), apply_filters( 'friends_debug_enqueue', $version, $handle, dirname( FRIENDS_PLUGIN_FILE ) . '/' . $file ) );
 	}
 

--- a/templates/frontend/header.php
+++ b/templates/frontend/header.php
@@ -86,7 +86,7 @@ add_filter(
 			</dialog>
 
 
-			<section class="navbar-section search<?php echo esc_attr( is_singular() ? ' d-hide' : '' ); ?>">
+			<section class="navbar-section search<?php echo esc_attr( is_singular() ? ' d-hide' : '' ); ?><?php echo esc_attr( ! empty( $args['hide-mobile-search'] ) ? ' hide-mobile-search' : '' ); ?>">
 				<form class="input-group input-inline form-autocomplete" action="<?php echo esc_url( home_url( '/friends/' ) ); ?>">
 					<div class="form-autocomplete-input form-input">
 						<div class="has-icon-right">

--- a/templates/frontend/messages.php
+++ b/templates/frontend/messages.php
@@ -12,6 +12,7 @@ if ( ! empty( $friends_args ) && is_array( $friends_args ) ) {
 
 $args['title']            = __( 'Direct Messages', 'friends' );
 $args['no-bottom-margin'] = true;
+$args['hide-mobile-search'] = true;
 
 $time_format = get_option( 'date_format' ) . ' ' . get_option( 'time_format' );
 if ( false === strpos( $time_format, ':s' ) ) {
@@ -122,12 +123,12 @@ Friends\Friends::template_loader()->get_template_part( 'frontend/header', null, 
 			<p><?php esc_html_e( 'Open a friend profile to start a conversation.', 'friends' ); ?></p>
 		</div>
 	<?php else : ?>
-		<nav class="friends-dm-sidebar" aria-label="<?php esc_attr_e( 'Conversations', 'friends' ); ?>">
+		<nav id="friends-dm-conversations" class="friends-dm-sidebar" aria-label="<?php esc_attr_e( 'Conversations', 'friends' ); ?>">
 			<?php foreach ( $conversation_rows as $conversation_row ) : ?>
 				<?php
 				$friend_user = $conversation_row['friend_user'];
 				$is_selected = $selected_conversation && $conversation_row['id'] === $selected_conversation['id'];
-				$item_url    = add_query_arg( 'conversation', $conversation_row['id'], home_url( '/friends/messages/' ) );
+				$item_url    = add_query_arg( 'conversation', $conversation_row['id'], home_url( '/friends/messages/' ) ) . '#friends-dm-conversation-' . $conversation_row['id'];
 				?>
 				<a class="friends-dm-conversation<?php echo $is_selected ? ' is-selected' : ''; ?><?php echo $conversation_row['unread_count'] ? ' is-unread' : ''; ?>" href="<?php echo esc_url( $item_url ); ?>">
 					<?php if ( $friend_user && ! is_wp_error( $friend_user ) && $friend_user->get_avatar_url() ) : ?>
@@ -157,8 +158,11 @@ Friends\Friends::template_loader()->get_template_part( 'frontend/header', null, 
 		$selected_friend_user = $selected_conversation['friend_user'];
 		$selected_url         = add_query_arg( 'conversation', $selected_conversation['id'], home_url( '/friends/messages/' ) );
 		?>
-		<article class="friends-dm-thread" data-id="<?php echo esc_attr( $selected_conversation['id'] ); ?>" data-nonce="<?php echo esc_attr( wp_create_nonce( 'friends-mark-read' ) ); ?>" data-unread="<?php echo esc_attr( $selected_conversation['unread_count'] ? '1' : '0' ); ?>">
+		<article id="friends-dm-conversation-<?php echo esc_attr( $selected_conversation['id'] ); ?>" class="friends-dm-thread" data-id="<?php echo esc_attr( $selected_conversation['id'] ); ?>" data-nonce="<?php echo esc_attr( wp_create_nonce( 'friends-mark-read' ) ); ?>" data-unread="<?php echo esc_attr( $selected_conversation['unread_count'] ? '1' : '0' ); ?>">
 			<header class="friends-dm-thread-header">
+				<a class="friends-dm-back" href="#friends-dm-conversations" aria-label="<?php esc_attr_e( 'Back to conversations', 'friends' ); ?>">
+					<span aria-hidden="true">&larr;</span>
+				</a>
 				<?php if ( $selected_friend_user && ! is_wp_error( $selected_friend_user ) && $selected_friend_user->get_avatar_url() ) : ?>
 					<img class="avatar" src="<?php echo esc_url( $selected_friend_user->get_avatar_url() ); ?>" alt="" width="44" height="44">
 				<?php else : ?>

--- a/templates/google-reader/google-reader.css
+++ b/templates/google-reader/google-reader.css
@@ -546,7 +546,7 @@
 	border: 1px solid #d4d4d4;
 	display: grid;
 	grid-template-columns: minmax(220px, 300px) minmax(0, 1fr);
-	height: calc(100vh - 50px);
+	height: calc(var(--friends-dm-viewport-height, 100vh) - 50px);
 	min-height: 30rem;
 }
 
@@ -675,6 +675,10 @@
 	font-size: 12px;
 }
 
+.friends-page .friends-dm-back {
+	display: none;
+}
+
 .friends-page .friends-dm-messages {
 	background: #fff;
 	overflow: auto;
@@ -769,15 +773,68 @@
 }
 
 @media (max-width: 840px) {
+	.friends-page .navbar-section.search.hide-mobile-search {
+		display: none;
+	}
+
 	.friends-page .friends-dm-view {
 		grid-template-columns: 1fr;
-		height: auto;
+		grid-template-rows: minmax(0, 1fr);
+		height: min(calc(var(--friends-dm-viewport-height, 100vh) - 50px), 48rem);
+		min-height: 0;
+		overflow: hidden;
+		position: relative;
 	}
 
 	.friends-page .friends-dm-sidebar {
-		border-bottom: 1px solid #d4d4d4;
 		border-right: 0;
-		max-height: 14rem;
+		grid-column: 1;
+		grid-row: 1;
+		height: 100%;
+		max-height: none;
+		min-height: 0;
+		transform: translateX(0);
+		transition: transform .2s ease;
+		width: 100%;
+		z-index: 1;
+	}
+
+	.friends-page .friends-dm-thread {
+		grid-column: 1;
+		grid-row: 1;
+		height: 100%;
+		min-height: 0;
+		overflow: hidden;
+		transform: translateX(100%);
+		transition: transform .2s ease;
+		width: 100%;
+		z-index: 2;
+	}
+
+	.friends-page .friends-dm-view.is-focused-conversation .friends-dm-sidebar {
+		transform: translateX(-100%);
+	}
+
+	.friends-page .friends-dm-view.is-focused-conversation .friends-dm-thread {
+		transform: translateX(0);
+	}
+
+	.friends-page .friends-dm-back {
+		align-items: center;
+		color: #222;
+		display: flex;
+		font-size: 20px;
+		line-height: 1;
+		text-decoration: none;
+	}
+
+	.friends-page .friends-dm-messages {
+		min-height: 0;
+		overscroll-behavior: contain;
+	}
+
+	.friends-page .friends-dm-reply {
+		padding-bottom: calc(8px + env(safe-area-inset-bottom, 0px));
 	}
 }
 


### PR DESCRIPTION
## Summary
- Make the mobile direct messages page start on the conversation list and focus the selected thread via URL hash.
- Keep the DM reply form visible with mobile keyboard viewport handling.
- Hide the shared search bar on the mobile direct messages page.
- Add file modification time cache busting for frontend assets.

## Testing
- composer check-cs
- php -l templates/frontend/messages.php
- php -l templates/frontend/header.php
- php -l includes/class-frontend.php
- node --check friends.js
- git diff --check

<details><summary>Changelog</summary>

- [x] Automatically create a changelog entry from the details below

#### Type
- [x] Fixed

#### Message
Fix the mobile direct messages layout and keyboard behavior.

</details>

<!-- friends-playground-link:start -->
## Test this PR in WordPress Playground

You can test this pull request directly in WordPress Playground:

[Launch WordPress Playground](https://akirk.github.io/playground-step-library/?redir=1&step[0]=setLandingPage&landingPage[0]=/friends/&step[1]=installPlugin&url[1]=github.com/akirk/friends/tree/fix/mobile-direct-messages&step[2]=importFriendFeeds&opml[2]=https://alex.kirk.at%20Alex%20Kirk%0Ahttps://adamadam.blog%20Adam%20Zieliński)

This will install and activate the plugin with the changes from this PR.
<!-- friends-playground-link:end -->