### PR TITLE
Add DM delivery indicators

### DIFF
--- a/.github/changelog/unreleased/694-from-description
+++ b/.github/changelog/unreleased/694-from-description
@@ -1,0 +1,3 @@
+Type: added
+
+Add delivery status indicators for ActivityPub direct messages.

--- a/feed-parsers/class-feed-parser-activitypub.php
+++ b/feed-parsers/class-feed-parser-activitypub.php
@@ -134,6 +134,8 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 		add_filter( 'mastodon_api_account', array( $this, 'mastodon_api_account_external_user' ), 15, 4 );
 		add_action( 'friends_message_form_accounts', array( $this, 'friends_message_form_accounts' ), 10, 2 );
 		add_action( 'friends_send_direct_message', array( $this, 'friends_send_direct_message' ), 20, 6 );
+		add_action( 'activitypub_pre_send_to_inboxes', array( $this, 'record_direct_message_delivery_targets' ), 10, 3 );
+		add_action( 'activitypub_sent_to_inbox', array( $this, 'record_direct_message_delivery_result' ), 10, 5 );
 
 		// Auto-create Friend subscription when following via ActivityPub plugin.
 		add_action( 'post_activitypub_add_to_outbox', array( $this, 'handle_outbox_follow' ), 10, 4 );
@@ -953,8 +955,168 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 		}
 
 		update_post_meta( $post_id, 'activitypub_direct_message_outbox_id', $outbox_activity_id );
+		update_post_meta( $outbox_activity_id, 'activitypub_direct_message_post_id', $post_id );
+		$this->update_direct_message_delivery_status(
+			$post_id,
+			array(
+				'status'  => 'queued',
+				'message' => __( 'Queued for delivery', 'friends' ),
+			)
+		);
 
 		return $post_id;
+	}
+
+	/**
+	 * Record the inboxes an ActivityPub direct message is being sent to.
+	 *
+	 * @param string $json           The ActivityPub Activity JSON.
+	 * @param array  $inboxes        The inboxes to send to.
+	 * @param int    $outbox_item_id The ActivityPub outbox item ID.
+	 */
+	public function record_direct_message_delivery_targets( $json, $inboxes, $outbox_item_id ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		$post_id = $this->get_direct_message_post_id_from_outbox( $outbox_item_id );
+		if ( ! $post_id ) {
+			return;
+		}
+
+		if ( empty( $inboxes ) ) {
+			$this->update_direct_message_delivery_status(
+				$post_id,
+				array(
+					'status'  => 'failed',
+					'message' => __( 'No delivery inbox found', 'friends' ),
+				)
+			);
+			return;
+		}
+
+		$this->update_direct_message_delivery_status(
+			$post_id,
+			array(
+				'status'  => 'sending',
+				'message' => __( 'Sending', 'friends' ),
+				'inboxes' => array_values( array_unique( array_map( 'esc_url_raw', $inboxes ) ) ),
+			)
+		);
+	}
+
+	/**
+	 * Record the delivery result for an ActivityPub direct message.
+	 *
+	 * @param array|\WP_Error $result         The inbox delivery result.
+	 * @param string          $inbox          The inbox URL.
+	 * @param string          $json           The ActivityPub Activity JSON.
+	 * @param int             $actor_id       The actor ID.
+	 * @param int             $outbox_item_id The ActivityPub outbox item ID.
+	 */
+	public function record_direct_message_delivery_result( $result, $inbox, $json, $actor_id, $outbox_item_id ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		$post_id = $this->get_direct_message_post_id_from_outbox( $outbox_item_id );
+		if ( ! $post_id ) {
+			return;
+		}
+
+		$status  = 'failed';
+		$message = __( 'Delivery failed', 'friends' );
+		$code    = null;
+		$error   = null;
+
+		if ( is_wp_error( $result ) ) {
+			$error = $result->get_error_message();
+		} else {
+			$code = wp_remote_retrieve_response_code( $result );
+			if ( $code >= 200 && $code < 300 ) {
+				$status  = 'delivered';
+				$message = __( 'Delivered', 'friends' );
+			} elseif ( $code ) {
+				// translators: %d is an HTTP status code.
+				$error = sprintf( __( 'Remote inbox returned HTTP %d', 'friends' ), $code );
+			}
+		}
+
+		$this->update_direct_message_delivery_status(
+			$post_id,
+			array(
+				'status'  => $status,
+				'message' => $message,
+				'inbox'   => esc_url_raw( $inbox ),
+				'code'    => $code,
+				'error'   => $error,
+			)
+		);
+	}
+
+	/**
+	 * Get a direct message post ID from an ActivityPub outbox item.
+	 *
+	 * @param int $outbox_item_id The ActivityPub outbox item ID.
+	 * @return int The direct message post ID, or 0.
+	 */
+	private function get_direct_message_post_id_from_outbox( $outbox_item_id ) {
+		$post_id = (int) get_post_meta( $outbox_item_id, 'activitypub_direct_message_post_id', true );
+		return $post_id;
+	}
+
+	/**
+	 * Update delivery metadata for a direct message.
+	 *
+	 * @param int   $post_id The direct message post ID.
+	 * @param array $status  The delivery status data.
+	 */
+	private function update_direct_message_delivery_status( $post_id, $status ) {
+		$previous = get_post_meta( $post_id, 'activitypub_direct_message_delivery', true );
+		if ( ! is_array( $previous ) ) {
+			$previous = array();
+		}
+
+		$status['updated_at'] = time();
+
+		update_post_meta(
+			$post_id,
+			'activitypub_direct_message_delivery',
+			array_filter(
+				array_merge( $previous, $status ),
+				static function ( $value ) {
+					return null !== $value && '' !== $value;
+				}
+			)
+		);
+	}
+
+	/**
+	 * Get display data for an ActivityPub direct message delivery indicator.
+	 *
+	 * @param int|\WP_Post $post The direct message post or ID.
+	 * @return array|null Delivery display data, or null for non-ActivityPub messages.
+	 */
+	public static function get_direct_message_delivery_status( $post ) {
+		$post = get_post( $post );
+		if ( ! $post || \Friends\Messages::CPT !== $post->post_type ) {
+			return null;
+		}
+
+		if ( ! get_post_meta( $post->ID, 'activitypub_direct_message_outbox_id', true ) ) {
+			return null;
+		}
+
+		$delivery = get_post_meta( $post->ID, 'activitypub_direct_message_delivery', true );
+		if ( ! is_array( $delivery ) ) {
+			$delivery = array();
+		}
+
+		$status = isset( $delivery['status'] ) ? $delivery['status'] : 'queued';
+		$labels = array(
+			'queued'    => __( 'Queued', 'friends' ),
+			'sending'   => __( 'Sending', 'friends' ),
+			'delivered' => __( 'Delivered', 'friends' ),
+			'failed'    => __( 'Delivery failed', 'friends' ),
+		);
+
+		return array(
+			'status' => $status,
+			'label'  => isset( $labels[ $status ] ) ? $labels[ $status ] : __( 'Delivery pending', 'friends' ),
+			'title'  => ! empty( $delivery['error'] ) ? $delivery['error'] : ( isset( $delivery['message'] ) ? $delivery['message'] : '' ),
+		);
 	}
 
 	public function handle_received_direct_message( $activity, $user_id ) {

--- a/feed-parsers/class-feed-parser-activitypub.php
+++ b/feed-parsers/class-feed-parser-activitypub.php
@@ -1111,11 +1111,17 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 			'delivered' => __( 'Delivered', 'friends' ),
 			'failed'    => __( 'Delivery failed', 'friends' ),
 		);
+		$titles = array(
+			'queued'    => __( 'This message is waiting for ActivityPub delivery.', 'friends' ),
+			'sending'   => __( 'This message is being delivered to the remote inbox.', 'friends' ),
+			'delivered' => __( 'The remote inbox accepted this message.', 'friends' ),
+			'failed'    => __( 'The remote inbox did not accept this message.', 'friends' ),
+		);
 
 		return array(
 			'status' => $status,
 			'label'  => isset( $labels[ $status ] ) ? $labels[ $status ] : __( 'Delivery pending', 'friends' ),
-			'title'  => ! empty( $delivery['error'] ) ? $delivery['error'] : ( isset( $delivery['message'] ) ? $delivery['message'] : '' ),
+			'title'  => ! empty( $delivery['error'] ) ? $delivery['error'] : ( isset( $titles[ $status ] ) ? $titles[ $status ] : __( 'Delivery status is pending.', 'friends' ) ),
 		);
 	}
 

--- a/feed-parsers/class-feed-parser-activitypub.php
+++ b/feed-parsers/class-feed-parser-activitypub.php
@@ -1117,11 +1117,17 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 			'delivered' => __( 'The remote inbox accepted this message.', 'friends' ),
 			'failed'    => __( 'The remote inbox did not accept this message.', 'friends' ),
 		);
+		$title  = isset( $titles[ $status ] ) ? $titles[ $status ] : __( 'Delivery status is pending.', 'friends' );
+		if ( ! empty( $delivery['error'] ) ) {
+			$title = $delivery['error'];
+		} elseif ( 'failed' === $status && ! empty( $delivery['message'] ) ) {
+			$title = $delivery['message'];
+		}
 
 		return array(
 			'status' => $status,
 			'label'  => isset( $labels[ $status ] ) ? $labels[ $status ] : __( 'Delivery pending', 'friends' ),
-			'title'  => ! empty( $delivery['error'] ) ? $delivery['error'] : ( isset( $titles[ $status ] ) ? $titles[ $status ] : __( 'Delivery status is pending.', 'friends' ) ),
+			'title'  => $title,
 		);
 	}
 

--- a/friends.css
+++ b/friends.css
@@ -243,6 +243,7 @@ html {
 	--friends-color-link: #2e5bec;
 	--friends-color-link-hover: #1341d4;
 	--friends-color-link-visited: #5d80f0;
+	--friends-color-error: #c0392b;
 	--friends-color-focus: rgba(46, 91, 236, 0.2);
 	--friends-color-menu-hover: #dde5fc;
 	--friends-color-note-background: #f7f7f7;
@@ -264,6 +265,7 @@ html {
 		--friends-color-link: #8fb1ff;
 		--friends-color-link-hover: #b8ccff;
 		--friends-color-link-visited: #c4b5fd;
+		--friends-color-error: #ff8f8f;
 		--friends-color-focus: rgba(143, 177, 255, 0.28);
 		--friends-color-menu-hover: #22304a;
 		--friends-color-note-background: #202633;
@@ -2508,12 +2510,27 @@ h2#page-title a.dashicons {
 	& .friends-dm-message-meta {
 		align-items: baseline;
 		display: flex;
+		flex-wrap: wrap;
 		gap: .35rem;
 		line-height: 1.2;
 
 		& time {
 			color: var(--friends-color-text-muted);
 			font-size: .65rem;
+		}
+	}
+
+	& .friends-dm-delivery-status {
+		color: var(--friends-color-text-muted);
+		font-size: .65rem;
+
+		&::before {
+			content: "·";
+			margin-right: .35rem;
+		}
+
+		&.is-failed {
+			color: var(--friends-color-error);
 		}
 	}
 

--- a/friends.css
+++ b/friends.css
@@ -2522,6 +2522,7 @@ h2#page-title a.dashicons {
 
 	& .friends-dm-delivery-status {
 		color: var(--friends-color-text-muted);
+		cursor: help;
 		font-size: .65rem;
 
 		&::before {
@@ -2532,6 +2533,23 @@ h2#page-title a.dashicons {
 		&.is-failed {
 			color: var(--friends-color-error);
 		}
+	}
+
+	& .friends-dm-delivery-tooltip {
+		background: var(--friends-color-surface);
+		border: 1px solid var(--friends-color-border);
+		border-radius: .25rem;
+		box-shadow: 0 .25rem .75rem rgb(0 0 0 / 16%);
+		color: var(--friends-color-text);
+		font-size: .75rem;
+		line-height: 1.3;
+		overflow-wrap: break-word;
+		padding: .4rem .5rem;
+		pointer-events: none;
+		position: fixed;
+		white-space: normal;
+		width: min(18rem, calc(100vw - 2rem));
+		z-index: 9999;
 	}
 
 	& .friends-dm-message-content {
@@ -2569,6 +2587,13 @@ h2#page-title a.dashicons {
 		& textarea.friends-message-message {
 			min-height: 4.2rem;
 			resize: vertical;
+		}
+
+		& .delete-conversation {
+			height: auto;
+			line-height: 1.2;
+			max-width: 100%;
+			white-space: normal;
 		}
 	}
 

--- a/friends.js
+++ b/friends.js
@@ -773,7 +773,6 @@
 		} );
 	}
 
-	let isRefreshingDmView = false;
 	const dmMobileQuery = window.matchMedia ? window.matchMedia( '(max-width: 840px)' ) : null;
 
 	function isMobileDmView() {
@@ -857,51 +856,121 @@
 		}, 300 );
 	} );
 
-	function refreshDmView() {
-		const $thread = $( '.friends-dm-thread' );
-		const $messages = $( '.friends-dm-messages' );
-		if ( isRefreshingDmView || ! $thread.length || ! $messages.length ) {
+	let dmDeliveryTooltipTimeout = null;
+
+	function hideDmDeliveryTooltip() {
+		window.clearTimeout( dmDeliveryTooltipTimeout );
+		dmDeliveryTooltipTimeout = null;
+		$( '.friends-dm-delivery-tooltip' ).remove();
+		$( '.friends-dm-delivery-status.is-showing-title' ).removeClass( 'is-showing-title' );
+	}
+
+	function showDmDeliveryTooltip( element ) {
+		const $status = $( element );
+		const title = $status.attr( 'title' );
+		if ( ! title ) {
 			return;
 		}
 
-		isRefreshingDmView = true;
+		hideDmDeliveryTooltip();
+		$status.addClass( 'is-showing-title' );
 
-		$.get( window.location.href ).done( function ( response ) {
-			const $response = $( $.parseHTML( response, document ) );
-			const $newSidebar = $response.find( '.friends-dm-sidebar' );
-			const $newThread = $response.find( '.friends-dm-thread' );
-			const $newMessages = $newThread.find( '.friends-dm-messages' );
-			if ( ! $newThread.length || ! $newMessages.length ) {
-				return;
-			}
+		const rect = element.getBoundingClientRect();
+		const $tooltip = $( '<div class="friends-dm-delivery-tooltip" role="tooltip"></div>' ).text( title );
+		$( document.body ).append( $tooltip );
 
-			const messages = $messages.get( 0 );
-			const shouldStickToBottom = messages && messages.scrollTop + messages.clientHeight >= messages.scrollHeight - 80;
-			const currentMessageIds = $messages.find( '.friends-dm-message' ).map( function () {
-				return $( this ).data( 'message-id' );
-			} ).get().join( ',' );
-			const newMessageIds = $newMessages.find( '.friends-dm-message' ).map( function () {
-				return $( this ).data( 'message-id' );
-			} ).get().join( ',' );
+		const margin = 8;
+		const width = $tooltip.outerWidth();
+		const height = $tooltip.outerHeight();
+		const left = Math.min( Math.max( margin, rect.right - width ), window.innerWidth - width - margin );
+		let top = rect.top - height - margin;
+		if ( top < margin ) {
+			top = rect.bottom + margin;
+		}
 
-			if ( $newSidebar.length && $newSidebar.html() !== $( '.friends-dm-sidebar' ).html() ) {
-				$( '.friends-dm-sidebar' ).html( $newSidebar.html() );
-			}
+		$tooltip.css( {
+			left: left + 'px',
+			top: top + 'px',
+		} );
 
-			if ( newMessageIds !== currentMessageIds ) {
-				$messages.html( $newMessages.html() );
-				if ( shouldStickToBottom ) {
-					messages.scrollTop = messages.scrollHeight;
-				}
-			}
+		dmDeliveryTooltipTimeout = window.setTimeout( hideDmDeliveryTooltip, 5000 );
+	}
 
-			$thread
-				.data( 'unread', $newThread.data( 'unread' ) )
-				.attr( 'data-unread', $newThread.attr( 'data-unread' ) );
-			updateRelativeTimes( '.friends-dm-view' );
-			updateDmHashState();
+	$document.on( 'click', '.friends-dm-delivery-status[title]', function ( event ) {
+		const $status = $( this );
+		if ( ! $status.attr( 'title' ) ) {
+			return;
+		}
+
+		event.preventDefault();
+		event.stopPropagation();
+		if ( $status.hasClass( 'is-showing-title' ) ) {
+			hideDmDeliveryTooltip();
+		} else {
+			showDmDeliveryTooltip( this );
+		}
+	} );
+
+	$document.on( 'click', hideDmDeliveryTooltip );
+	$( window ).on( 'resize scroll', hideDmDeliveryTooltip );
+
+	function updateDmDeliveryStatusElement( $status, delivery ) {
+		if ( ! delivery || ! delivery.status ) {
+			return;
+		}
+
+		const classes = ( $status.attr( 'class' ) || '' )
+			.split( /\s+/ )
+			.filter( function ( className ) {
+				return className && ! className.match( /^is-/ );
+			} );
+		classes.push( 'is-' + delivery.status );
+
+		$status
+			.attr( 'class', classes.join( ' ' ) )
+			.attr( 'title', delivery.title || '' )
+			.text( delivery.label || '' );
+	}
+
+	let isRefreshingDmDeliveryStatuses = false;
+
+	function refreshDmDeliveryStatuses() {
+		const $statuses = $( '.friends-dm-delivery-status[data-delivery-message-id]' );
+		if ( isRefreshingDmDeliveryStatuses || ! $statuses.length || ! friends.message_delivery_nonce ) {
+			return;
+		}
+
+		const postIds = $statuses.map( function () {
+			return $( this ).data( 'delivery-message-id' );
+		} ).get().filter( function ( postId, index, postIds ) {
+			return postId && postIds.indexOf( postId ) === index;
+		} );
+
+		if ( ! postIds.length ) {
+			return;
+		}
+
+		isRefreshingDmDeliveryStatuses = true;
+
+		wp.ajax.send( 'friends-get-message-delivery-statuses', {
+			data: {
+				_ajax_nonce: friends.message_delivery_nonce,
+				post_ids: postIds,
+			},
+			success( response ) {
+				const statuses = response.statuses || {};
+				Object.keys( statuses ).forEach( function ( postId ) {
+					updateDmDeliveryStatusElement(
+						$( '.friends-dm-delivery-status[data-delivery-message-id="' + postId + '"]' ),
+						statuses[ postId ]
+					);
+				} );
+			},
+			error() {
+				isRefreshingDmDeliveryStatuses = false;
+			},
 		} ).always( function () {
-			isRefreshingDmView = false;
+			isRefreshingDmDeliveryStatuses = false;
 		} );
 	}
 
@@ -918,7 +987,8 @@
 		}
 
 		window.setInterval( updateRelativeTimes, 60000 );
-		window.setInterval( refreshDmView, 30000 );
+		window.setInterval( refreshDmDeliveryStatuses, 5000 );
+		refreshDmDeliveryStatuses();
 	} );
 
 	$document.on( 'mouseenter', 'h2#page-title a.dashicons, a.wp-block-friends-author-star.dashicons', function () {

--- a/includes/class-frontend.php
+++ b/includes/class-frontend.php
@@ -368,27 +368,28 @@ class Frontend {
 		$query_vars = wp_json_encode( $this->get_minimal_query_vars( $wp_query->query_vars ) );
 
 		$variables = array(
-			'emojis_json'           => plugins_url( 'emojis.json', FRIENDS_PLUGIN_FILE ),
-			'ajax_url'              => admin_url( 'admin-ajax.php' ),
-			'rest_base'             => rest_url( 'friends/v1/' ),
-			'rest_nonce'            => wp_create_nonce( 'wp_rest' ),
-			'text_link_expired'     => __( 'The link has expired. A new link has been generated, please click it again.', 'friends' ),
-			'text_undo'             => __( 'Undo' ), // phpcs:ignore WordPress.WP.I18n.MissingArgDomain
-			'text_trash_post'       => __( 'Trash this post', 'friends' ),
-			'text_del_convers'      => __( 'Do you really want to delete this conversation?', 'friends' ),
-			'text_no_more_posts'    => __( 'No more posts available.', 'friends' ),
-			'text_checking_url'     => __( 'Checking URL.', 'friends' ),
-			'text_refreshed'        => __( 'Refreshed', 'friends' ),
-			'text_refreshing'       => __( 'Refreshing', 'friends' ),
-			'text_compact_mode'     => __( 'Compact mode', 'friends' ),
-			'text_expanded_mode'    => __( 'Expanded mode', 'friends' ),
-			'text_loading_comments' => __( 'Loading comments...', 'friends' ),
-			'text_still_loading'    => __( 'Still loading...', 'friends' ),
-			'refresh_now'           => isset( $_GET['refresh'] ) ? 'true' : 'false', // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			'query_vars'            => $query_vars,
-			'qv_sign'               => sha1( wp_salt( 'nonce' ) . $query_vars ),
-			'current_page'          => get_query_var( 'paged' ) ? get_query_var( 'paged' ) : 1,
-			'max_page'              => $wp_query->max_num_pages,
+			'emojis_json'            => plugins_url( 'emojis.json', FRIENDS_PLUGIN_FILE ),
+			'ajax_url'               => admin_url( 'admin-ajax.php' ),
+			'rest_base'              => rest_url( 'friends/v1/' ),
+			'rest_nonce'             => wp_create_nonce( 'wp_rest' ),
+			'text_link_expired'      => __( 'The link has expired. A new link has been generated, please click it again.', 'friends' ),
+			'text_undo'              => __( 'Undo' ), // phpcs:ignore WordPress.WP.I18n.MissingArgDomain
+			'text_trash_post'        => __( 'Trash this post', 'friends' ),
+			'text_del_convers'       => __( 'Do you really want to delete this conversation?', 'friends' ),
+			'text_no_more_posts'     => __( 'No more posts available.', 'friends' ),
+			'text_checking_url'      => __( 'Checking URL.', 'friends' ),
+			'text_refreshed'         => __( 'Refreshed', 'friends' ),
+			'text_refreshing'        => __( 'Refreshing', 'friends' ),
+			'text_compact_mode'      => __( 'Compact mode', 'friends' ),
+			'text_expanded_mode'     => __( 'Expanded mode', 'friends' ),
+			'text_loading_comments'  => __( 'Loading comments...', 'friends' ),
+			'text_still_loading'     => __( 'Still loading...', 'friends' ),
+			'message_delivery_nonce' => wp_create_nonce( 'friends-message-delivery-statuses' ),
+			'refresh_now'            => isset( $_GET['refresh'] ) ? 'true' : 'false', // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			'query_vars'             => $query_vars,
+			'qv_sign'                => sha1( wp_salt( 'nonce' ) . $query_vars ),
+			'current_page'           => get_query_var( 'paged' ) ? get_query_var( 'paged' ) : 1,
+			'max_page'               => $wp_query->max_num_pages,
 		);
 
 		// translators: %s is a user handle.

--- a/includes/class-messages.php
+++ b/includes/class-messages.php
@@ -48,6 +48,7 @@ class Messages {
 		add_filter( 'friends_unread_count', array( $this, 'friends_unread_messages_count' ) );
 		add_action( 'friends_own_site_menu_top', array( $this, 'friends_add_menu_unread_messages' ) );
 		add_action( 'wp_ajax_friends-mark-read', array( $this, 'mark_message_read' ) );
+		add_action( 'wp_ajax_friends-get-message-delivery-statuses', array( $this, 'get_message_delivery_statuses' ) );
 		add_action( 'friends_author_header', array( $this, 'friends_author_header' ), 10, 2 );
 		add_action( 'friends_after_header', array( $this, 'friends_display_messages' ), 10, 2 );
 		add_action( 'friends_after_header', array( $this, 'friends_message_form' ), 11, 2 );
@@ -365,6 +366,57 @@ class Messages {
 				'result' => $result,
 			)
 		);
+	}
+
+	/**
+	 * Ajax function to fetch delivery status for outgoing direct messages.
+	 */
+	public function get_message_delivery_statuses() {
+		check_ajax_referer( 'friends-message-delivery-statuses' );
+
+		if ( ! is_user_logged_in() ) {
+			wp_send_json_error(
+				array(
+					'message' => __( 'You are not authorized to view message delivery statuses.', 'friends' ),
+				),
+				403
+			);
+		}
+
+		$post_ids = array();
+		if ( isset( $_POST['post_ids'] ) && is_array( $_POST['post_ids'] ) ) {
+			$post_ids = array_map( 'absint', wp_unslash( $_POST['post_ids'] ) );
+		}
+
+		$post_ids = array_filter( array_unique( $post_ids ) );
+		if ( empty( $post_ids ) ) {
+			wp_send_json_success( array( 'statuses' => array() ) );
+		}
+
+		$statuses = array();
+		foreach ( $post_ids as $post_id ) {
+			$post = get_post( $post_id );
+			if ( ! $post || self::CPT !== $post->post_type || get_current_user_id() !== intval( $post->post_author ) ) {
+				continue;
+			}
+
+			$delivery = null;
+			if ( class_exists( 'Friends\Feed_Parser_ActivityPub' ) ) {
+				$delivery = Feed_Parser_ActivityPub::get_direct_message_delivery_status( $post );
+			}
+
+			if ( ! $delivery ) {
+				continue;
+			}
+
+			$statuses[ $post_id ] = array(
+				'status' => sanitize_html_class( $delivery['status'] ),
+				'label'  => $delivery['label'],
+				'title'  => $delivery['title'],
+			);
+		}
+
+		wp_send_json_success( array( 'statuses' => $statuses ) );
 	}
 
 	/**

--- a/templates/frontend/messages.php
+++ b/templates/frontend/messages.php
@@ -186,6 +186,10 @@ Friends\Friends::template_loader()->get_template_part( 'frontend/header', null, 
 					$post_time      = get_post_modified_time( 'U', true, $message );
 					$author_key     = $message_author && ! is_wp_error( $message_author ) ? 'user-' . $message_author->ID : 'unknown';
 					$is_consecutive = $author_key === $previous_message_author_key;
+					$delivery       = null;
+					if ( $is_own_message && class_exists( 'Friends\Feed_Parser_ActivityPub' ) ) {
+						$delivery = Friends\Feed_Parser_ActivityPub::get_direct_message_delivery_status( $message );
+					}
 					?>
 					<div class="friends-dm-message<?php echo $is_own_message ? ' is-own-message' : ''; ?><?php echo $is_consecutive ? ' is-consecutive-message' : ''; ?>" data-message-id="<?php echo esc_attr( $message->ID ); ?>">
 						<div class="friends-dm-message-avatar">
@@ -209,6 +213,9 @@ Friends\Friends::template_loader()->get_template_part( 'frontend/header', null, 
 									);
 									?>
 								</time>
+								<?php if ( $delivery ) : ?>
+									<span class="friends-dm-delivery-status is-<?php echo esc_attr( $delivery['status'] ); ?>" title="<?php echo esc_attr( $delivery['title'] ); ?>"><?php echo esc_html( $delivery['label'] ); ?></span>
+								<?php endif; ?>
 							</div>
 							<div class="friends-dm-message-content" title="<?php echo esc_attr( date_i18n( $time_format, $post_time ) ); ?>">
 								<?php

--- a/templates/frontend/messages.php
+++ b/templates/frontend/messages.php
@@ -214,7 +214,7 @@ Friends\Friends::template_loader()->get_template_part( 'frontend/header', null, 
 									?>
 								</time>
 								<?php if ( $delivery ) : ?>
-									<span class="friends-dm-delivery-status is-<?php echo esc_attr( $delivery['status'] ); ?>" title="<?php echo esc_attr( $delivery['title'] ); ?>"><?php echo esc_html( $delivery['label'] ); ?></span>
+									<span class="friends-dm-delivery-status is-<?php echo esc_attr( $delivery['status'] ); ?>" data-delivery-message-id="<?php echo esc_attr( $message->ID ); ?>" title="<?php echo esc_attr( $delivery['title'] ); ?>"><?php echo esc_html( $delivery['label'] ); ?></span>
 								<?php endif; ?>
 							</div>
 							<div class="friends-dm-message-content" title="<?php echo esc_attr( date_i18n( $time_format, $post_time ) ); ?>">

--- a/templates/frontend/messages/message-form.php
+++ b/templates/frontend/messages/message-form.php
@@ -78,13 +78,13 @@ $draft_key = implode(
 	<div class="form-group">
 		<div class="col-2 col-sm-12">
 		</div>
-		<div class="col-6 col-sm-12">
+		<div class="<?php echo esc_attr( ! empty( $args['reply_to'] ) ? 'col-4' : 'col-6' ); ?> col-sm-12">
 			<button class="btn"><?php esc_html_e( 'Send', 'friends' ); ?></button>
 		</div>
 		<?php
 		if ( ! empty( $args['reply_to'] ) ) {
 			?>
-			<div class="col-2 col-sm-12" style="text-align: right">
+			<div class="col-4 col-sm-12" style="text-align: right">
 				<button class="btn btn-link btn-sm delete-conversation text-error" name="friends_message_delete_conversation"><?php esc_html_e( 'Delete conversation', 'friends' ); ?></button>
 			</div>
 			<?php

--- a/templates/google-reader/google-reader.css
+++ b/templates/google-reader/google-reader.css
@@ -695,12 +695,27 @@
 .friends-page .friends-dm-message-meta {
 	align-items: baseline;
 	display: flex;
+	flex-wrap: wrap;
 	gap: 6px;
 	line-height: 1.2;
 }
 
 .friends-page .friends-dm-message-meta strong {
 	color: #222;
+}
+
+.friends-page .friends-dm-delivery-status {
+	color: #666;
+	font-size: 11px;
+}
+
+.friends-page .friends-dm-delivery-status::before {
+	content: "·";
+	margin-right: 6px;
+}
+
+.friends-page .friends-dm-delivery-status.is-failed {
+	color: #dd4b39;
 }
 
 .friends-page .friends-dm-message-content {

--- a/templates/google-reader/google-reader.css
+++ b/templates/google-reader/google-reader.css
@@ -706,12 +706,30 @@
 
 .friends-page .friends-dm-delivery-status {
 	color: #666;
+	cursor: help;
 	font-size: 11px;
 }
 
 .friends-page .friends-dm-delivery-status::before {
 	content: "·";
 	margin-right: 6px;
+}
+
+.friends-page .friends-dm-delivery-tooltip {
+	background: #fff;
+	border: 1px solid #c7c7c7;
+	border-radius: 3px;
+	box-shadow: 0 4px 12px rgb(0 0 0 / 16%);
+	color: #222;
+	font-size: 12px;
+	line-height: 1.3;
+	overflow-wrap: break-word;
+	padding: 6px 8px;
+	pointer-events: none;
+	position: fixed;
+	white-space: normal;
+	width: min(18rem, calc(100vw - 2rem));
+	z-index: 9999;
 }
 
 .friends-page .friends-dm-delivery-status.is-failed {
@@ -776,6 +794,13 @@
 	border-radius: 2px;
 	color: #222;
 	padding: 4px 12px;
+}
+
+.friends-page .friends-dm-reply .delete-conversation {
+	height: auto;
+	line-height: 1.2;
+	max-width: 100%;
+	white-space: normal;
 }
 
 .friends-page .friends-dm-empty {

--- a/templates/mastodon/mastodon.css
+++ b/templates/mastodon/mastodon.css
@@ -1586,12 +1586,27 @@ body.friends-page {
 .friends-page .friends-dm-message-meta {
 	align-items: baseline;
 	display: flex;
+	flex-wrap: wrap;
 	gap: 8px;
 	line-height: 1.2;
 }
 
 .friends-page .friends-dm-message-meta strong {
 	color: light-dark(#282c37, #dadada);
+}
+
+.friends-page .friends-dm-delivery-status {
+	color: light-dark(#606984, #9baec8);
+	font-size: 13px;
+}
+
+.friends-page .friends-dm-delivery-status::before {
+	content: "·";
+	margin-right: 8px;
+}
+
+.friends-page .friends-dm-delivery-status.is-failed {
+	color: light-dark(#d92d20, #ff8f8f);
 }
 
 .friends-page .friends-dm-message-content {

--- a/templates/mastodon/mastodon.css
+++ b/templates/mastodon/mastodon.css
@@ -1597,12 +1597,30 @@ body.friends-page {
 
 .friends-page .friends-dm-delivery-status {
 	color: light-dark(#606984, #9baec8);
+	cursor: help;
 	font-size: 13px;
 }
 
 .friends-page .friends-dm-delivery-status::before {
 	content: "·";
 	margin-right: 8px;
+}
+
+.friends-page .friends-dm-delivery-tooltip {
+	background: light-dark(#fff, #1f232b);
+	border: 1px solid light-dark(#d9e1e8, #393f4f);
+	border-radius: 4px;
+	box-shadow: 0 4px 12px rgb(0 0 0 / 20%);
+	color: light-dark(#282c37, #fff);
+	font-size: 13px;
+	line-height: 1.3;
+	overflow-wrap: break-word;
+	padding: 6px 8px;
+	pointer-events: none;
+	position: fixed;
+	white-space: normal;
+	width: min(18rem, calc(100vw - 2rem));
+	z-index: 9999;
 }
 
 .friends-page .friends-dm-delivery-status.is-failed {
@@ -1668,6 +1686,13 @@ body.friends-page {
 	color: #fff;
 	font-weight: 600;
 	padding: 7px 18px;
+}
+
+.friends-page .friends-dm-reply .delete-conversation {
+	height: auto;
+	line-height: 1.2;
+	max-width: 100%;
+	white-space: normal;
 }
 
 .friends-page .friends-dm-empty {

--- a/templates/twitter/twitter.css
+++ b/templates/twitter/twitter.css
@@ -1728,12 +1728,27 @@ body.friends-page {
 .friends-page .friends-dm-message-meta {
 	align-items: baseline;
 	display: flex;
+	flex-wrap: wrap;
 	gap: 8px;
 	line-height: 1.2;
 }
 
 .friends-page .friends-dm-message-meta strong {
 	color: light-dark(#0f1419, #e7e9ea);
+}
+
+.friends-page .friends-dm-delivery-status {
+	color: light-dark(#536471, #71767b);
+	font-size: 13px;
+}
+
+.friends-page .friends-dm-delivery-status::before {
+	content: "·";
+	margin-right: 8px;
+}
+
+.friends-page .friends-dm-delivery-status.is-failed {
+	color: light-dark(#f4212e, #ff8f8f);
 }
 
 .friends-page .friends-dm-message-content {

--- a/templates/twitter/twitter.css
+++ b/templates/twitter/twitter.css
@@ -1739,12 +1739,30 @@ body.friends-page {
 
 .friends-page .friends-dm-delivery-status {
 	color: light-dark(#536471, #71767b);
+	cursor: help;
 	font-size: 13px;
 }
 
 .friends-page .friends-dm-delivery-status::before {
 	content: "·";
 	margin-right: 8px;
+}
+
+.friends-page .friends-dm-delivery-tooltip {
+	background: light-dark(#fff, #15202b);
+	border: 1px solid light-dark(#cfd9de, #38444d);
+	border-radius: 4px;
+	box-shadow: 0 4px 12px rgb(0 0 0 / 20%);
+	color: light-dark(#0f1419, #f7f9f9);
+	font-size: 13px;
+	line-height: 1.3;
+	overflow-wrap: break-word;
+	padding: 6px 8px;
+	pointer-events: none;
+	position: fixed;
+	white-space: normal;
+	width: min(18rem, calc(100vw - 2rem));
+	z-index: 9999;
 }
 
 .friends-page .friends-dm-delivery-status.is-failed {
@@ -1810,6 +1828,13 @@ body.friends-page {
 	color: #fff;
 	font-weight: 700;
 	padding: 8px 20px;
+}
+
+.friends-page .friends-dm-reply .delete-conversation {
+	height: auto;
+	line-height: 1.2;
+	max-width: 100%;
+	white-space: normal;
 }
 
 .friends-page .friends-dm-empty {

--- a/tests/test-activitypub.php
+++ b/tests/test-activitypub.php
@@ -779,12 +779,58 @@ class ActivityPubTest extends Friends_TestCase_Cache_HTTP {
 		$this->assertSame( 'pending', $outbox_item->post_status );
 		$this->assertSame( 'Create', get_post_meta( $outbox_id, '_activitypub_activity_type', true ) );
 		$this->assertSame( ACTIVITYPUB_CONTENT_VISIBILITY_PRIVATE, get_post_meta( $outbox_id, 'activitypub_content_visibility', true ) );
+		$this->assertSame( $post_id, (int) get_post_meta( $outbox_id, 'activitypub_direct_message_post_id', true ) );
+
+		$delivery = Feed_Parser_ActivityPub::get_direct_message_delivery_status( $post_id );
+		$this->assertSame( 'queued', $delivery['status'] );
+		$this->assertSame( 'Queued', $delivery['label'] );
 
 		$activity = json_decode( $outbox_item->post_content, true );
 		$this->assertSame( 'Create', $activity['type'] );
 		$this->assertContains( $this->actor, $activity['to'] );
 		$this->assertContains( $this->actor, $activity['object']['to'] );
 		$this->assertStringContainsString( '@akirk', $activity['object']['content'] );
+	}
+
+	public function test_direct_message_delivery_status_tracks_inbox_result() {
+		$post_id   = Friends::get_instance()->messages->send_message( $this->friend, $this->actor, 'Hello by DM.' );
+		$outbox_id = get_post_meta( $post_id, 'activitypub_direct_message_outbox_id', true );
+		$inbox     = 'https://mastodon.local/inbox';
+
+		do_action( 'activitypub_pre_send_to_inboxes', '{}', array( $inbox ), $outbox_id );
+
+		$delivery = Feed_Parser_ActivityPub::get_direct_message_delivery_status( $post_id );
+		$this->assertSame( 'sending', $delivery['status'] );
+		$this->assertSame( 'Sending', $delivery['label'] );
+
+		do_action(
+			'activitypub_sent_to_inbox',
+			array(
+				'response' => array(
+					'code' => 202,
+				),
+			),
+			$inbox,
+			'{}',
+			get_current_user_id(),
+			$outbox_id
+		);
+
+		$delivery = Feed_Parser_ActivityPub::get_direct_message_delivery_status( $post_id );
+		$this->assertSame( 'delivered', $delivery['status'] );
+		$this->assertSame( 'Delivered', $delivery['label'] );
+	}
+
+	public function test_direct_message_delivery_status_tracks_inbox_failure() {
+		$post_id   = Friends::get_instance()->messages->send_message( $this->friend, $this->actor, 'Hello by DM.' );
+		$outbox_id = get_post_meta( $post_id, 'activitypub_direct_message_outbox_id', true );
+
+		do_action( 'activitypub_pre_send_to_inboxes', '{}', array(), $outbox_id );
+
+		$delivery = Feed_Parser_ActivityPub::get_direct_message_delivery_status( $post_id );
+		$this->assertSame( 'failed', $delivery['status'] );
+		$this->assertSame( 'Delivery failed', $delivery['label'] );
+		$this->assertSame( 'No delivery inbox found', $delivery['title'] );
 	}
 
 	public function test_direct_message_reply_outbox_activity_has_in_reply_to() {


### PR DESCRIPTION
## Summary
- Track ActivityPub direct message delivery state from inbox target/result hooks.
- Show queued/sending/delivered/failed status on outgoing DM bubbles.
- Cover delivery metadata transitions in ActivityPub DM tests.

## Testing
- composer check-cs
- composer lint
- composer test (blocked: missing /tmp/wordpress-tests-lib/includes/functions.php)

<details><summary>Changelog</summary>

- [x] Automatically create a changelog entry from the details below

#### Type
- [x] Added

#### Message
Add delivery status indicators for ActivityPub direct messages.

</details>

<!-- friends-playground-link:start -->
## Test this PR in WordPress Playground

You can test this pull request directly in WordPress Playground:

[Launch WordPress Playground](https://akirk.github.io/playground-step-library/?redir=1&step[0]=setLandingPage&landingPage[0]=/friends/&step[1]=installPlugin&url[1]=github.com/akirk/friends/tree/feature/dm-delivery-indicator&step[2]=importFriendFeeds&opml[2]=https://alex.kirk.at%20Alex%20Kirk%0Ahttps://adamadam.blog%20Adam%20Zieliński)

This will install and activate the plugin with the changes from this PR.
<!-- friends-playground-link:end -->