### PR TITLE
Use latest Node 24 GitHub Actions

### DIFF
--- a/.github/changelog/unreleased/696-from-description
+++ b/.github/changelog/unreleased/696-from-description
@@ -1,0 +1,3 @@
+Type: fixed
+
+Update CI actions to avoid Node module deprecation warnings.

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: 'Check for Skip Changelog label, or if the PR is a draft'
         id: check-skip-label
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const { payload : { pull_request : { number, labels, draft = false, base : { ref } } } } = context;
@@ -40,7 +40,7 @@ jobs:
       - name: 'Check for workflow-generated changelog file'
         if: steps.check-skip-label.outputs.skip-changelog != 'true'
         id: check-changelog-file
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const { repo: { owner, repo }, payload : { pull_request : { number } } } = context;
@@ -80,7 +80,7 @@ jobs:
       - name: 'Check for changelog information in PR body'
         id: check-pr-body
         if: steps.check-skip-label.outputs.skip-changelog != 'true'
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const { payload : { pull_request : { number, body } } } = context;
@@ -136,7 +136,7 @@ jobs:
         if: steps.check-skip-label.outputs.skip-changelog != 'true' && steps.check-changelog-file.outputs.has-changelog-file != 'true' && steps.check-pr-body.outputs.has-changelog-info == 'true'
         env:
           PR_MESSAGE: '${{ steps.check-pr-body.outputs.message }}'
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.API_TOKEN_GITHUB }}
           script: |

--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,7 +8,7 @@ jobs:
     environment: production
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: WordPress Plugin Deploy
         uses: 10up/action-wordpress-plugin-deploy@stable
         env:

--- a/.github/workflows/extract-hooks.yml
+++ b/.github/workflows/extract-hooks.yml
@@ -10,5 +10,5 @@ jobs:
   extract-hooks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: akirk/extract-wp-hooks@main

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/pr-playground-comment.yml
+++ b/.github/workflows/pr-playground-comment.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Add Playground Link to PR Description
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const markerStart = '<!-- friends-playground-link:start -->';

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -21,7 +21,7 @@ jobs:
     name: Prepare release PR
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           ref: main
           fetch-depth: 0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,11 +39,11 @@ jobs:
     name: "Tests: PHP ${{ matrix.php }} - PHPUnit: ${{matrix.phpunit}} - WordPress: ${{matrix.wordpress}}"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Checkout ActivityPub plugin
         if: ${{ matrix.php >= 8.3 }}
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           repository: Automattic/wordpress-activitypub
           path: activitypub


### PR DESCRIPTION
Updates GitHub Actions workflows to the latest Node 24-compatible major versions:

- actions/checkout to v6
- actions/github-script to v9

<details><summary>Changelog</summary>

- [x] Automatically create a changelog entry from the details below

#### Type
- [x] Fixed

#### Message
Update CI actions to avoid Node module deprecation warnings.

</details>

<!-- friends-playground-link:start -->
## Test this PR in WordPress Playground

You can test this pull request directly in WordPress Playground:

[Launch WordPress Playground](https://akirk.github.io/playground-step-library/?redir=1&step[0]=setLandingPage&landingPage[0]=/friends/&step[1]=installPlugin&url[1]=github.com/akirk/friends/tree/fix/latest-node24-actions-20260728&step[2]=importFriendFeeds&opml[2]=https://alex.kirk.at%20Alex%20Kirk%0Ahttps://adamadam.blog%20Adam%20Zieliński)

This will install and activate the plugin with the changes from this PR.
<!-- friends-playground-link:end -->