### PR TITLE
Show DM delivery status in conversation overview

### DIFF
--- a/.github/changelog/unreleased/703-from-description
+++ b/.github/changelog/unreleased/703-from-description
@@ -1,0 +1,3 @@
+Type: fixed
+
+Show direct message delivery status in the conversation overview and recover delivery tracking for older ActivityPub outbox items.

--- a/feed-parsers/class-feed-parser-activitypub.php
+++ b/feed-parsers/class-feed-parser-activitypub.php
@@ -1054,6 +1054,27 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 	 */
 	private function get_direct_message_post_id_from_outbox( $outbox_item_id ) {
 		$post_id = (int) get_post_meta( $outbox_item_id, 'activitypub_direct_message_post_id', true );
+		if ( $post_id ) {
+			return $post_id;
+		}
+
+		$posts = get_posts(
+			array(
+				'post_type'      => \Friends\Messages::CPT,
+				'post_status'    => array( 'friends_read', 'friends_unread' ),
+				'posts_per_page' => 1,
+				'fields'         => 'ids',
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+				'meta_key'       => 'activitypub_direct_message_outbox_id',
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+				'meta_value'     => $outbox_item_id,
+			)
+		);
+		if ( $posts ) {
+			$post_id = (int) reset( $posts );
+			update_post_meta( $outbox_item_id, 'activitypub_direct_message_post_id', $post_id );
+		}
+
 		return $post_id;
 	}
 
@@ -1095,7 +1116,8 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 			return null;
 		}
 
-		if ( ! get_post_meta( $post->ID, 'activitypub_direct_message_outbox_id', true ) ) {
+		$outbox_id = get_post_meta( $post->ID, 'activitypub_direct_message_outbox_id', true );
+		if ( ! $outbox_id ) {
 			return null;
 		}
 

--- a/friends.css
+++ b/friends.css
@@ -2535,6 +2535,60 @@ h2#page-title a.dashicons {
 		}
 	}
 
+	& .friends-dm-delivery-icon {
+		align-items: center;
+		display: inline-flex;
+		flex: 0 0 auto;
+		height: 1rem;
+		justify-content: center;
+		line-height: 1;
+		position: relative;
+		width: 1rem;
+
+		&::before {
+			border: 1.5px solid currentColor;
+			border-radius: 50%;
+			box-sizing: border-box;
+			content: "";
+			height: .9rem;
+			margin: 0;
+			width: .9rem;
+		}
+
+		&::after {
+			border: solid currentColor;
+			border-width: 0 1.5px 1.5px 0;
+			content: "";
+			height: .42rem;
+			left: .37rem;
+			position: absolute;
+			top: .22rem;
+			transform: rotate(45deg);
+			width: .22rem;
+		}
+
+		&.is-queued::before {
+			border-style: dotted;
+		}
+
+		&.is-sending::before {
+			border-style: dashed;
+		}
+
+		&.is-failed::after {
+			border: 0;
+			content: "!";
+			font-size: .65rem;
+			font-weight: 700;
+			height: auto;
+			left: auto;
+			position: absolute;
+			top: .13rem;
+			transform: none;
+			width: auto;
+		}
+	}
+
 	& .friends-dm-delivery-tooltip {
 		background: var(--friends-color-surface);
 		border: 1px solid var(--friends-color-border);

--- a/friends.js
+++ b/friends.js
@@ -929,7 +929,8 @@
 		$status
 			.attr( 'class', classes.join( ' ' ) )
 			.attr( 'title', delivery.title || '' )
-			.text( delivery.label || '' );
+			.attr( 'aria-label', delivery.label || '' )
+			.text( $status.hasClass( 'friends-dm-delivery-icon' ) ? '' : delivery.label || '' );
 	}
 
 	let isRefreshingDmDeliveryStatuses = false;

--- a/templates/frontend/messages.php
+++ b/templates/frontend/messages.php
@@ -87,15 +87,21 @@ foreach ( $top_level_messages as $top_level_message ) {
 		$message_preview = wp_strip_all_tags( get_the_excerpt( $latest_message ) );
 	}
 
+	$latest_delivery = null;
+	if ( intval( $latest_message->post_author ) === get_current_user_id() && class_exists( 'Friends\Feed_Parser_ActivityPub' ) ) {
+		$latest_delivery = Friends\Feed_Parser_ActivityPub::get_direct_message_delivery_status( $latest_message );
+	}
+
 	$conversation_rows[] = array(
-		'id'           => $top_level_message->ID,
-		'friend_user'  => $friend_user,
-		'messages'     => $thread_messages,
-		'latest'       => $latest_message,
-		'latest_time'  => $latest_message_time,
-		'preview'      => $message_preview,
-		'unread_count' => $unread_count,
-		'root_message' => $top_level_message,
+		'id'              => $top_level_message->ID,
+		'friend_user'     => $friend_user,
+		'messages'        => $thread_messages,
+		'latest'          => $latest_message,
+		'latest_delivery' => $latest_delivery,
+		'latest_time'     => $latest_message_time,
+		'preview'         => $message_preview,
+		'unread_count'    => $unread_count,
+		'root_message'    => $top_level_message,
 	);
 }
 
@@ -146,6 +152,9 @@ Friends\Friends::template_loader()->get_template_part( 'frontend/header', null, 
 						<time data-friends-relative-time="<?php echo esc_attr( $conversation_row['latest_time'] ); ?>" title="<?php echo esc_attr( date_i18n( $time_format, $conversation_row['latest_time'] ) ); ?>">
 							<?php echo esc_html( human_time_diff( $conversation_row['latest_time'] ) ); ?>
 						</time>
+						<?php if ( $conversation_row['latest_delivery'] ) : ?>
+							<span class="friends-dm-delivery-status friends-dm-delivery-icon is-<?php echo esc_attr( $conversation_row['latest_delivery']['status'] ); ?>" data-delivery-message-id="<?php echo esc_attr( $conversation_row['latest']->ID ); ?>" title="<?php echo esc_attr( $conversation_row['latest_delivery']['title'] ); ?>" aria-label="<?php echo esc_attr( $conversation_row['latest_delivery']['label'] ); ?>"></span>
+						<?php endif; ?>
 						<?php if ( $conversation_row['unread_count'] ) : ?>
 							<span class="friends-dm-unread-count"><?php echo esc_html( number_format_i18n( $conversation_row['unread_count'] ) ); ?></span>
 						<?php endif; ?>

--- a/templates/google-reader/google-reader.css
+++ b/templates/google-reader/google-reader.css
@@ -715,6 +715,60 @@
 	margin-right: 6px;
 }
 
+.friends-page .friends-dm-delivery-icon {
+	align-items: center;
+	display: inline-flex;
+	flex: 0 0 auto;
+	height: 16px;
+	justify-content: center;
+	line-height: 1;
+	position: relative;
+	width: 16px;
+}
+
+.friends-page .friends-dm-delivery-icon::before {
+	border: 1.5px solid currentColor;
+	border-radius: 50%;
+	box-sizing: border-box;
+	content: "";
+	height: 14px;
+	margin: 0;
+	width: 14px;
+}
+
+.friends-page .friends-dm-delivery-icon::after {
+	border: solid currentColor;
+	border-width: 0 1.5px 1.5px 0;
+	content: "";
+	height: 7px;
+	left: 6px;
+	position: absolute;
+	top: 3px;
+	transform: rotate(45deg);
+	width: 4px;
+}
+
+.friends-page .friends-dm-delivery-icon.is-queued::before {
+	border-style: dotted;
+}
+
+.friends-page .friends-dm-delivery-icon.is-sending::before {
+	border-style: dashed;
+}
+
+.friends-page .friends-dm-delivery-icon.is-failed::after {
+	border: 0;
+	content: "!";
+	font-size: 11px;
+	font-weight: 700;
+	height: auto;
+	left: auto;
+	position: absolute;
+	top: 2px;
+	transform: none;
+	width: auto;
+}
+
 .friends-page .friends-dm-delivery-tooltip {
 	background: #fff;
 	border: 1px solid #c7c7c7;

--- a/templates/mastodon/mastodon.css
+++ b/templates/mastodon/mastodon.css
@@ -1606,6 +1606,60 @@ body.friends-page {
 	margin-right: 8px;
 }
 
+.friends-page .friends-dm-delivery-icon {
+	align-items: center;
+	display: inline-flex;
+	flex: 0 0 auto;
+	height: 16px;
+	justify-content: center;
+	line-height: 1;
+	position: relative;
+	width: 16px;
+}
+
+.friends-page .friends-dm-delivery-icon::before {
+	border: 1.5px solid currentColor;
+	border-radius: 50%;
+	box-sizing: border-box;
+	content: "";
+	height: 14px;
+	margin: 0;
+	width: 14px;
+}
+
+.friends-page .friends-dm-delivery-icon::after {
+	border: solid currentColor;
+	border-width: 0 1.5px 1.5px 0;
+	content: "";
+	height: 7px;
+	left: 6px;
+	position: absolute;
+	top: 3px;
+	transform: rotate(45deg);
+	width: 4px;
+}
+
+.friends-page .friends-dm-delivery-icon.is-queued::before {
+	border-style: dotted;
+}
+
+.friends-page .friends-dm-delivery-icon.is-sending::before {
+	border-style: dashed;
+}
+
+.friends-page .friends-dm-delivery-icon.is-failed::after {
+	border: 0;
+	content: "!";
+	font-size: 11px;
+	font-weight: 700;
+	height: auto;
+	left: auto;
+	position: absolute;
+	top: 2px;
+	transform: none;
+	width: auto;
+}
+
 .friends-page .friends-dm-delivery-tooltip {
 	background: light-dark(#fff, #1f232b);
 	border: 1px solid light-dark(#d9e1e8, #393f4f);

--- a/templates/twitter/twitter.css
+++ b/templates/twitter/twitter.css
@@ -1748,6 +1748,60 @@ body.friends-page {
 	margin-right: 8px;
 }
 
+.friends-page .friends-dm-delivery-icon {
+	align-items: center;
+	display: inline-flex;
+	flex: 0 0 auto;
+	height: 16px;
+	justify-content: center;
+	line-height: 1;
+	position: relative;
+	width: 16px;
+}
+
+.friends-page .friends-dm-delivery-icon::before {
+	border: 1.5px solid currentColor;
+	border-radius: 50%;
+	box-sizing: border-box;
+	content: "";
+	height: 14px;
+	margin: 0;
+	width: 14px;
+}
+
+.friends-page .friends-dm-delivery-icon::after {
+	border: solid currentColor;
+	border-width: 0 1.5px 1.5px 0;
+	content: "";
+	height: 7px;
+	left: 6px;
+	position: absolute;
+	top: 3px;
+	transform: rotate(45deg);
+	width: 4px;
+}
+
+.friends-page .friends-dm-delivery-icon.is-queued::before {
+	border-style: dotted;
+}
+
+.friends-page .friends-dm-delivery-icon.is-sending::before {
+	border-style: dashed;
+}
+
+.friends-page .friends-dm-delivery-icon.is-failed::after {
+	border: 0;
+	content: "!";
+	font-size: 11px;
+	font-weight: 700;
+	height: auto;
+	left: auto;
+	position: absolute;
+	top: 2px;
+	transform: none;
+	width: auto;
+}
+
 .friends-page .friends-dm-delivery-tooltip {
 	background: light-dark(#fff, #15202b);
 	border: 1px solid light-dark(#cfd9de, #38444d);

--- a/tests/test-activitypub.php
+++ b/tests/test-activitypub.php
@@ -821,6 +821,20 @@ class ActivityPubTest extends Friends_TestCase_Cache_HTTP {
 		$this->assertSame( 'Delivered', $delivery['label'] );
 	}
 
+	public function test_direct_message_delivery_status_falls_back_to_message_outbox_meta() {
+		$post_id   = Friends::get_instance()->messages->send_message( $this->friend, $this->actor, 'Hello by DM.' );
+		$outbox_id = get_post_meta( $post_id, 'activitypub_direct_message_outbox_id', true );
+		$inbox     = 'https://mastodon.local/inbox';
+
+		delete_post_meta( $outbox_id, 'activitypub_direct_message_post_id' );
+
+		do_action( 'activitypub_pre_send_to_inboxes', '{}', array( $inbox ), $outbox_id );
+
+		$delivery = Feed_Parser_ActivityPub::get_direct_message_delivery_status( $post_id );
+		$this->assertSame( 'sending', $delivery['status'] );
+		$this->assertSame( $post_id, (int) get_post_meta( $outbox_id, 'activitypub_direct_message_post_id', true ) );
+	}
+
 	public function test_direct_message_delivery_status_tracks_inbox_failure() {
 		$post_id   = Friends::get_instance()->messages->send_message( $this->friend, $this->actor, 'Hello by DM.' );
 		$outbox_id = get_post_meta( $post_id, 'activitypub_direct_message_outbox_id', true );


### PR DESCRIPTION
## Summary
- Show compact delivery icons for outgoing ActivityPub DMs in the conversation overview
- Keep overview icons updated through the existing AJAX delivery status polling
- Recover delivery callback mapping for older outbox items missing reverse message meta

## Testing
- php -l feed-parsers/class-feed-parser-activitypub.php
- php -l templates/frontend/messages.php
- php -l tests/test-activitypub.php
- node --check friends.js
- composer check-cs
- wp --url=alex.kirk.at requeued and reprocessed recent DM outbox items; both delivered with HTTP 202

<details><summary>Changelog</summary>

- [x] Automatically create a changelog entry from the details below

#### Type
- [x] Fixed

#### Message
Show direct message delivery status in the conversation overview and recover delivery tracking for older ActivityPub outbox items.

</details>

<!-- friends-playground-link:start -->
## Test this PR in WordPress Playground

You can test this pull request directly in WordPress Playground:

[Launch WordPress Playground](https://akirk.github.io/playground-step-library/?redir=1&step[0]=setLandingPage&landingPage[0]=/friends/&step[1]=installPlugin&url[1]=github.com/akirk/friends/tree/feature/dm-overview-delivery-status&step[2]=importFriendFeeds&opml[2]=https://alex.kirk.at%20Alex%20Kirk%0Ahttps://adamadam.blog%20Adam%20Zieliński)

This will install and activate the plugin with the changes from this PR.
<!-- friends-playground-link:end -->