### PR TITLE
Fix quiet public EMA posts

### DIFF
--- a/.github/changelog/unreleased/704-from-description
+++ b/.github/changelog/unreleased/704-from-description
@@ -1,0 +1,3 @@
+Type: fixed
+
+Quiet public posts created through Mastodon apps are stored as published posts with quiet-public ActivityPub visibility.

--- a/integrations/class-enable-mastodon-apps.php
+++ b/integrations/class-enable-mastodon-apps.php
@@ -23,6 +23,7 @@ class Enable_Mastodon_Apps {
 		add_filter( 'mastodon_api_favourites_args', array( get_called_class(), 'mastodon_api_favourites_args' ), 10, 2 );
 		add_filter( 'mastodon_api_bookmarks_args', array( get_called_class(), 'mastodon_api_bookmarks_args' ), 10, 2 );
 		add_filter( 'mastodon_api_status', array( get_called_class(), 'mastodon_api_status' ), 60, 2 );
+		add_filter( 'mastodon_api_submit_post_data', array( get_called_class(), 'mastodon_api_submit_post_data' ), 20, 9 );
 		add_filter( 'mastodon_api_get_notifications_query_args', array( get_called_class(), 'mastodon_api_get_notifications_query_args' ), 10, 2 );
 		add_filter( 'mastodon_api_account_statuses_excluded_post_types', array( get_called_class(), 'mastodon_api_account_statuses_excluded_post_types' ) );
 		add_filter( 'mastodon_api_account_statuses', array( get_called_class(), 'mastodon_api_account_statuses' ), 10, 3 );
@@ -117,6 +118,10 @@ class Enable_Mastodon_Apps {
 			return $status;
 		}
 
+		if ( self::get_activitypub_quiet_public_visibility() === get_post_meta( $post_id, 'activitypub_content_visibility', true ) ) {
+			$status->visibility = 'unlisted';
+		}
+
 		$reaction_post_id = $post_id;
 		$paired_post_id   = get_post_meta( $post_id, 'mastodon_reblog_id', true );
 		if ( Friends::CPT !== get_post_type( $reaction_post_id ) ) {
@@ -159,6 +164,30 @@ class Enable_Mastodon_Apps {
 		}
 
 		return $status;
+	}
+
+	public static function mastodon_api_submit_post_data( $post_data, $status_text, $in_reply_to_id, $media_ids, $post_format, $visibility, $scheduled_at, $post_id, $app ) {
+		unset( $status_text, $in_reply_to_id, $media_ids, $post_format, $post_id, $app );
+
+		if ( 'unlisted' !== $visibility ) {
+			return $post_data;
+		}
+
+		if ( empty( $scheduled_at ) ) {
+			$post_data['post_status'] = 'publish';
+		}
+
+		if ( ! isset( $post_data['meta_input'] ) || ! is_array( $post_data['meta_input'] ) ) {
+			$post_data['meta_input'] = array();
+		}
+
+		$post_data['meta_input']['activitypub_content_visibility'] = self::get_activitypub_quiet_public_visibility();
+
+		return $post_data;
+	}
+
+	private static function get_activitypub_quiet_public_visibility() {
+		return defined( 'ACTIVITYPUB_CONTENT_VISIBILITY_QUIET_PUBLIC' ) ? ACTIVITYPUB_CONTENT_VISIBILITY_QUIET_PUBLIC : 'quiet_public';
 	}
 
 	public static function mastodon_api_account_statuses( $statuses, $request, $user_id ) {

--- a/tests/test-only-ema.php
+++ b/tests/test-only-ema.php
@@ -215,6 +215,25 @@ class Only_EnableMastodonAppsTest extends Friends_TestCase_Cache_HTTP {
 		$this->assertTrue( $has_mention_query, 'tax_query should filter by mention tag for current user' );
 	}
 
+	public function test_ema_unlisted_status_is_quiet_public() {
+		$request = $this->api_request( 'POST', '/api/v1/statuses' );
+		$request->set_param( 'status', 'Quiet public test.' );
+		$request->set_param( 'visibility', 'unlisted' );
+
+		$response = $this->dispatch_authenticated( $request );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$status = $response->get_data();
+		$post = get_post( $status->id );
+		$this->posts[] = $post->ID;
+
+		$quiet_public = defined( 'ACTIVITYPUB_CONTENT_VISIBILITY_QUIET_PUBLIC' ) ? ACTIVITYPUB_CONTENT_VISIBILITY_QUIET_PUBLIC : 'quiet_public';
+
+		$this->assertSame( 'publish', $post->post_status );
+		$this->assertSame( $quiet_public, get_post_meta( $post->ID, 'activitypub_content_visibility', true ) );
+		$this->assertSame( 'unlisted', $status->visibility );
+	}
+
 	private function create_mastodon_status( $post_id ) {
 		$status                   = new \Enable_Mastodon_Apps\Entity\Status();
 		$status->id               = strval( $post_id );


### PR DESCRIPTION
Fixes #700.

## Summary
- Map EMA `visibility=unlisted` posts to published WordPress posts with ActivityPub quiet-public visibility metadata.
- Report quiet-public posts back to Mastodon clients as `unlisted`.
- Add regression coverage for unlisted EMA status submission.

## Testing
- `php -l integrations/class-enable-mastodon-apps.php`
- `php -l tests/test-only-ema.php`
- `composer check-cs`
- Not run: `composer test -- --filter Only_EnableMastodonAppsTest tests/test-only-ema.php` because `/tmp/wordpress-tests-lib/includes/functions.php` is missing locally.

<details><summary>Changelog</summary>

- [x] Automatically create a changelog entry from the details below

#### Type
- [x] Fixed

#### Message
Quiet public posts created through Mastodon apps are stored as published posts with quiet-public ActivityPub visibility.

</details>
