### PR TITLE
Document inline action update responses

### DIFF
--- a/.github/changelog/unreleased/705-from-description
+++ b/.github/changelog/unreleased/705-from-description
@@ -1,0 +1,3 @@
+Type: changed
+
+Document browser extension inline action responses that can update form state after saving.

--- a/includes/class-rest.php
+++ b/includes/class-rest.php
@@ -307,13 +307,19 @@ class REST {
 				 * Allows plugins to register actions for the Friends browser extension.
 				 *
 				 * Each action is an associative array with:
+				 * - `id` (string, optional) — stable action identifier for clients that persist action state.
 				 * - `name` (string, required) — label shown in the extension popup.
 				 * - `url` (string, required) — target URL; may contain `{current_url}` which the extension substitutes with the current page URL (URL-encoded).
 				 * - `method` (string, optional) — if `"POST"`, the extension submits a form instead of opening a link.
 				 * - `fields` (object, optional) — for POST actions, key/value pairs of form fields; values may contain `{current_url}` (raw) and `{page_html}` placeholders.
 				 * - `run` (string, optional) — if `"inline"`, the extension handles the response in place instead of opening a new tab.
 				 * - `inputs` (array, optional) — user-editable fields for inline actions.
+				 * - `submit_label` (string, optional) — label for the inline action submit button.
 				 * - `category` (string, optional) — groups actions under a named header; actions without a category appear under the default "Actions" header.
+				 *
+				 * Inline action responses may include `message`, `edit_url`, and `link_label`. They may also
+				 * include `fields`, `values`, and `submit_label` to let the browser extension update the same
+				 * inline form for follow-up edits after the first action has created server-side state.
 				 *
 				 * Example:
 				 * ```php


### PR DESCRIPTION
## Summary
- Document inline action response fields that let the browser extension update a form after server-side state is created.

## Testing
- composer check-cs
- php -l includes/class-rest.php

<details><summary>Changelog</summary>

- [x] Automatically create a changelog entry from the details below

#### Type
- [x] Changed

#### Message
Document browser extension inline action responses that can update form state after saving.

</details>

<!-- friends-playground-link:start -->
## Test this PR in WordPress Playground

You can test this pull request directly in WordPress Playground:

[Launch WordPress Playground](https://akirk.github.io/playground-step-library/?redir=1&step[0]=setLandingPage&landingPage[0]=/friends/&step[1]=installPlugin&url[1]=github.com/akirk/friends/tree/feature/post-collection-ai-tags&step[2]=importFriendFeeds&opml[2]=https://alex.kirk.at%20Alex%20Kirk%0Ahttps://adamadam.blog%20Adam%20Zieliński)

This will install and activate the plugin with the changes from this PR.
<!-- friends-playground-link:end -->