### PR TITLE
Fix duplicate-key DB error on redelivered ActivityPub activities

### DIFF
--- a/.github/changelog/unreleased/707-from-description
+++ b/.github/changelog/unreleased/707-from-description
@@ -1,0 +1,3 @@
+Type: fixed
+
+Avoid a duplicate-key database error when the same ActivityPub activity is redelivered.

--- a/feed-parsers/class-feed-parser-activitypub.php
+++ b/feed-parsers/class-feed-parser-activitypub.php
@@ -2741,8 +2741,19 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 	 * @param string $type  The type of the activity.
 	 */
 	public function handle_received_activity( $activity, $user_id, $type ) {
-		if ( isset( $activity['object']['id'] ) && isset( $this->activitypub_already_handled[ $activity['object']['id'] ] ) ) {
-			return;
+		if ( isset( $activity['object']['id'] ) ) {
+			if ( isset( $this->activitypub_already_handled[ $activity['object']['id'] ] ) ) {
+				return;
+			}
+
+			// Some remote servers deliver (or retry) the same activity more than once,
+			// which can otherwise be processed concurrently by two requests and race
+			// on inserting the same term_relationships row. Skip the redeliveries.
+			$duplicate_lock = 'friends_ap_seen_' . md5( $type . '|' . $activity['object']['id'] );
+			if ( false !== get_transient( $duplicate_lock ) ) {
+				return false;
+			}
+			set_transient( $duplicate_lock, true, MINUTE_IN_SECONDS );
 		}
 
 		// Check if this is a reply to an existing Friends post - if so, let the ActivityPub plugin handle it as a comment.

--- a/includes/class-friend-tag.php
+++ b/includes/class-friend-tag.php
@@ -151,7 +151,9 @@ class Friend_Tag {
 	 * @return array|false|\WP_Error Array of term IDs on success, false or WP_Error on failure.
 	 */
 	public static function add_tags( $post_id, $tags, $append = true ) {
-		return wp_set_post_terms( $post_id, $tags, self::TAXONOMY, $append );
+		// wp_set_object_terms() inserts one term_relationships row per entry without
+		// deduplicating, so a duplicate slug here triggers a duplicate key DB error.
+		return wp_set_post_terms( $post_id, array_unique( $tags ), self::TAXONOMY, $append );
 	}
 
 	/**

--- a/tests/test-feed.php
+++ b/tests/test-feed.php
@@ -887,6 +887,54 @@ class FeedTest extends \WP_UnitTestCase {
 		$this->assertContains( 'unittest', $tag_names );
 	}
 
+	public function test_feed_processing_with_duplicate_hashtags_does_not_error() {
+		// Ensure the friend_tag taxonomy is registered and CPT is using new taxonomy.
+		Friends::get_instance()->register_friend_tag_taxonomy();
+		unregister_post_type( Friends::CPT );
+		Friends::get_instance()->register_custom_post_type();
+
+		delete_option( 'friends_disable_auto_tagging' );
+
+		$user = User::get_user_by_id( $this->alex );
+
+		$feeds = $user->get_active_feeds();
+		if ( empty( $feeds ) ) {
+			$user_feed = $user->save_feed(
+				'https://example.com/feed.xml',
+				array( 'parser' => 'simplepie' )
+			);
+			$this->assertNotWPError( $user_feed );
+		} else {
+			$user_feed = $feeds[0];
+		}
+
+		// A remote post can list the same hashtag more than once; wp_set_object_terms()
+		// would otherwise try to insert the same term_relationships row twice and
+		// trigger a duplicate-key database error.
+		$feed_item = new Feed_Item(
+			array(
+				'permalink' => 'https://example.com/duplicate-hashtag-test-' . wp_rand(),
+				'title'     => 'Test Post with duplicate hashtag',
+				'content'   => 'This is a test with a duplicated hashtag',
+				'date'      => time() - 50,
+			)
+		);
+		$feed_item->friend_tags = array( 'duplicatetag', 'duplicatetag' );
+
+		$feed_items = array( $feed_item );
+		$new_posts = Friends::get_instance()->feed->process_incoming_feed_items( $feed_items, $user_feed );
+
+		$this->assertNotEmpty( $new_posts );
+		$this->assertCount( 1, $new_posts );
+		$post_id = array_keys( $new_posts )[0];
+
+		$tags = wp_get_post_terms( $post_id, Friends::TAG_TAXONOMY );
+		$tag_names = wp_list_pluck( $tags, 'name' );
+
+		$this->assertContains( 'duplicatetag', $tag_names );
+		$this->assertCount( 1, $tag_names );
+	}
+
 	public function test_feed_processing_respects_disable_auto_tagging() {
 		// Ensure the friend_tag taxonomy is registered and CPT is using new taxonomy
 		Friends::get_instance()->register_friend_tag_taxonomy();


### PR DESCRIPTION
## Summary

Fixes #706.

The log snippet in the issue shows a `Duplicate entry ... for key 'wp7w_term_relationships.PRIMARY'` error coming from `Friend_Tag::add_tags()` → `wp_set_post_terms()` → `wp_set_object_terms()`, triggered from the ActivityPub inbox REST endpoint.

`handle_received_activity()` only guarded against reprocessing the same activity within a single PHP request (an in-memory array). Remote servers can redeliver the same activity (retries, shared-inbox + personal delivery, etc.), and two such deliveries arriving close together are handled by two separate requests. Both can pass `wp_set_object_terms()`'s "does this relationship already exist" check before either has committed its `INSERT`, so one of them hits the unique key on `term_relationships` and WordPress logs the DB error.

## Changes

- `feed-parsers/class-feed-parser-activitypub.php`: `handle_received_activity()` now sets a short-lived (60s) transient keyed by activity type + object ID on entry, and returns early if that key is already present — so a redelivered activity is skipped rather than raced.
- `includes/class-friend-tag.php`: `Friend_Tag::add_tags()` dedupes its `$tags` argument before calling `wp_set_post_terms()`. Defensive fix for the related case of a single activity listing the same hashtag twice.
- `tests/test-feed.php`: added a regression test covering an incoming feed item with a duplicated hashtag.

## Test plan

- [x] `php -l` on all changed files
- [x] `phpcs --standard=WordPress` on all changed files — no new warnings vs. branch point
- [x] Reproduced the race by hand against a local site running this plugin code and confirmed the new transient lock is set on first entry and short-circuits a same-activity redelivery
- [ ] Full PHPUnit suite (local WP test harness wasn't set up in this environment)

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Type

- [x] Fixed - for any bug fixes

#### Message

Avoid a duplicate-key database error when the same ActivityPub activity is redelivered.

</details>

<!-- friends-playground-link:start -->
## Test this PR in WordPress Playground

You can test this pull request directly in WordPress Playground:

[Launch WordPress Playground](https://akirk.github.io/playground-step-library/?redir=1&step[0]=setLandingPage&landingPage[0]=/friends/&step[1]=installPlugin&url[1]=github.com/akirk/friends/tree/fix/duplicate-activitypub-delivery-term-race&step[2]=importFriendFeeds&opml[2]=https://alex.kirk.at%20Alex%20Kirk%0Ahttps://adamadam.blog%20Adam%20Zieliński)

This will install and activate the plugin with the changes from this PR.
<!-- friends-playground-link:end -->
