### PR TITLE
Fix fatal when unfollowing a non-subscription account via Mastodon apps

### DIFF
--- a/.github/changelog/unreleased/709-from-description
+++ b/.github/changelog/unreleased/709-from-description
@@ -1,0 +1,3 @@
+Type: fixed
+
+Fix a fatal error when unfollowing an account that isn't a Friends subscription through a Mastodon app.

--- a/integrations/class-enable-mastodon-apps.php
+++ b/integrations/class-enable-mastodon-apps.php
@@ -47,6 +47,9 @@ class Enable_Mastodon_Apps {
 
 	public static function mastodon_api_account_unfollow( $user_id ) {
 		$user = User::get_user_by_id( $user_id );
+		if ( ! $user ) {
+			return;
+		}
 		foreach ( $user->get_active_feeds() as $feed ) {
 			$feed->deactivate();
 		}

--- a/tests/test-activitypub.php
+++ b/tests/test-activitypub.php
@@ -141,7 +141,7 @@ class ActivityPubTest extends Friends_TestCase_Cache_HTTP {
 
 		// Let's post a new Note through the REST API.
 		$date = gmdate( \DATE_W3C, $now++ );
-		$id = 'test' . $status_id;
+		$id = $this->actor . '/status/' . $status_id;
 		$content = 'Test ' . $date . ' ' . wp_rand();
 		$attachment_url = 'https://mastodon.local/files/original/1234.png';
 		$attachment_width = 400;
@@ -184,7 +184,7 @@ class ActivityPubTest extends Friends_TestCase_Cache_HTTP {
 
 		// Do another test post, this time with a URL that has an @-id.
 		$date = gmdate( \DATE_W3C, $now++ );
-		$id = 'test' . $status_id;
+		$id = $this->actor . '/status/' . $status_id;
 		$content = 'Test ' . $date . ' ' . wp_rand();
 
 		$request = new \WP_REST_Request( 'POST', '/activitypub/1.0/users/' . get_current_user_id() . '/inbox' );
@@ -267,7 +267,7 @@ class ActivityPubTest extends Friends_TestCase_Cache_HTTP {
 
 		// Let's post a new Note through the REST API.
 		$date = gmdate( \DATE_W3C, $now++ );
-		$id = 'test' . $status_id;
+		$id = $this->actor . '/status/' . $status_id;
 		$content = 'Test ' . $date . ' ' . wp_rand();
 		$attachment_url = 'https://mastodon.local/files/original/1234.png';
 		$attachment_width = 400;
@@ -317,7 +317,7 @@ class ActivityPubTest extends Friends_TestCase_Cache_HTTP {
 
 		// Update the post
 		$date = gmdate( \DATE_W3C, $now++ );
-		$id = 'test' . $status_id;
+		$id = $this->actor . '/status/' . $status_id;
 		$updated_content = 'Test ' . $date . ' ' . wp_rand();
 
 		$request = new \WP_REST_Request( 'POST', '/activitypub/1.0/users/' . get_current_user_id() . '/inbox' );
@@ -366,7 +366,7 @@ class ActivityPubTest extends Friends_TestCase_Cache_HTTP {
 
 		// Let's post a new Note through the REST API.
 		$date = gmdate( \DATE_W3C, $now++ );
-		$id = 'test' . $status_id;
+		$id = $this->actor . '/status/' . $status_id;
 		$content = '<a rel="mention" class="u-url mention" href="https://example.org/users/abc">@<span>abc</span></a> Test ' . $date . ' ' . wp_rand();
 
 		$request = new \WP_REST_Request( 'POST', '/activitypub/1.0/users/' . get_current_user_id() . '/inbox' );
@@ -416,7 +416,7 @@ class ActivityPubTest extends Friends_TestCase_Cache_HTTP {
 		$post_count = count( $posts );
 
 		$date = gmdate( \DATE_W3C, $now++ );
-		$id = 'test' . $status_id;
+		$id = $this->actor . '/status/' . $status_id;
 
 		$object = 'https://notiz.blog/2022/11/14/the-at-protocol/';
 


### PR DESCRIPTION
## Changes

* `Enable_Mastodon_Apps::mastodon_api_account_unfollow()` bails out when `User::get_user_by_id()` returns `false`.
* Unrelated, but needed to get this branch green: six activities in `tests/test-activitypub.php` get an id on the actor's host.

`User::get_user_by_id()` returns `false` in two ordinary cases: a WP user that lacks the `subscription` capability, and an ID that resolves to no user or no `Subscription` term (including a `>1e10` pseudo-ID whose term no longer exists). The unfollow handler used the result unguarded, so unfollowing any account that isn't a Friends subscription fataled:

```
Uncaught Error: Call to a member function get_active_feeds() on false
in integrations/class-enable-mastodon-apps.php:50
```

The sibling `mastodon_api_account_follow()` directly above already guards with `if ( ! $user )`; the unfollow path just never got the same check. It's an action, so returning early is a clean no-op — a non-subscription account has no feeds to deactivate.

### The test fix

`main` is already red on PHP 8.3 and 8.4 without this branch (confirmed by dispatching the workflow on unmodified `main`: run 33729939644). The workflow checks `Automattic/wordpress-activitypub` out from trunk, unpinned, and only for PHP >= 8.3, which is why the other versions stay green.

ActivityPub 9.3.0 added `Rest\Verification::verify_activity_id()`, which rejects an inbox activity whose `id` and `actor` are not on the same host with a 403. It runs ahead of the `activitypub_defer_signature_verification` filter, so the suite's deferral does not get past it. Six activities here carried a bare `test123` id with an actor on `https://mastodon.local`, so `test_incoming_post`, `test_incoming_update_post`, `test_incoming_mention_of_others` and `test_incoming_announce` got 403 instead of 202.

They now use the same-host form the passing tests in the same file already use. No assertion depends on the literal id, and the create/update pair in `test_incoming_update_post` still shares one id.

## Testing instructions

* With the fix reverted, firing the hook for an unknown ID reproduces the fatal at line 50:
  `wp eval 'do_action( "mastodon_api_account_unfollow", 999999 );'`
* With the fix, the same call returns cleanly. Also checked a missing-subscription pseudo-ID (`10000000001`), which likewise resolves to `false` and passes through, while a real subscription ID still resolves to a `Friends\User` and takes the deactivation path.
* `php -l` and `phpcs --standard=phpcs.xml` are clean on the changed file.
* Not run locally: the PHPUnit suite (no `wordpress-tests-lib` installed on that machine). There is no existing unfollow test to extend.
* The test fix is verified by CI: all six PHP versions pass on this branch, where 8.3 and 8.4 failed before it.

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Type

- [ ] Added - for new features
- [ ] Changed - for changes in existing functionality
- [x] Fixed - for any bug fixes
- [ ] Removed - for now removed features

#### Message

Fix a fatal error when unfollowing an account that isn't a Friends subscription through a Mastodon app.

</details>

https://claude.ai/code/session_01DHu5tsusRo3oJwZDeg2nmr

<!-- friends-playground-link:start -->
## Test this PR in WordPress Playground

You can test this pull request directly in WordPress Playground:

[Launch WordPress Playground](https://akirk.github.io/playground-step-library/?redir=1&step[0]=setLandingPage&landingPage[0]=/friends/&step[1]=installPlugin&url[1]=github.com/akirk/friends/tree/fix/ema-unfollow-unknown-account&step[2]=importFriendFeeds&opml[2]=https://alex.kirk.at%20Alex%20Kirk%0Ahttps://adamadam.blog%20Adam%20Zieliński)

This will install and activate the plugin with the changes from this PR.
<!-- friends-playground-link:end -->
