### PR TITLE
Notify Mastodon apps about received messages

### DIFF
--- a/.github/changelog/unreleased/711-from-description
+++ b/.github/changelog/unreleased/711-from-description
@@ -1,0 +1,3 @@
+Type: fixed
+
+Notify Mastodon apps about received direct messages.

--- a/integrations/class-enable-mastodon-apps.php
+++ b/integrations/class-enable-mastodon-apps.php
@@ -25,6 +25,7 @@ class Enable_Mastodon_Apps {
 		add_filter( 'mastodon_api_status', array( get_called_class(), 'mastodon_api_status' ), 60, 2 );
 		add_filter( 'mastodon_api_submit_post_data', array( get_called_class(), 'mastodon_api_submit_post_data' ), 20, 9 );
 		add_filter( 'mastodon_api_get_notifications_query_args', array( get_called_class(), 'mastodon_api_get_notifications_query_args' ), 10, 2 );
+		add_filter( 'mastodon_api_get_notifications_queries', array( get_called_class(), 'mastodon_api_get_notifications_queries' ), 10, 2 );
 		add_filter( 'mastodon_api_account_statuses_excluded_post_types', array( get_called_class(), 'mastodon_api_account_statuses_excluded_post_types' ) );
 		add_filter( 'mastodon_api_account_statuses', array( get_called_class(), 'mastodon_api_account_statuses' ), 10, 3 );
 	}
@@ -282,6 +283,30 @@ class Enable_Mastodon_Apps {
 		}
 
 		return new \DateTime( $post->post_modified_gmt, new \DateTimeZone( 'UTC' ) );
+	}
+
+	/**
+	 * Add the received messages as their own notification source.
+	 *
+	 * Enable Mastodon Apps queries every entry of this filter separately, so the mention
+	 * tag query that mastodon_api_get_notifications_query_args() needs for the cached
+	 * posts doesn't apply to the messages, which don't carry that tag.
+	 *
+	 * @param array  $queries The notification queries.
+	 * @param string $type    The type of notifications.
+	 * @return array The notification queries.
+	 */
+	public static function mastodon_api_get_notifications_queries( $queries, $type ) {
+		if ( 'mention' !== $type ) {
+			return $queries;
+		}
+
+		$queries[] = array(
+			'post_type'   => Messages::CPT,
+			'post_status' => array( 'friends_read', 'friends_unread' ),
+		);
+
+		return $queries;
 	}
 
 	public static function mastodon_api_get_notifications_query_args( $args, $type ) {

--- a/tests/test-only-ema.php
+++ b/tests/test-only-ema.php
@@ -215,6 +215,30 @@ class Only_EnableMastodonAppsTest extends Friends_TestCase_Cache_HTTP {
 		$this->assertTrue( $has_mention_query, 'tax_query should filter by mention tag for current user' );
 	}
 
+	public function test_ema_notifications_queries_filter() {
+		// The messages are registered as their own notification source.
+		$this->assertTrue( has_filter( 'mastodon_api_get_notifications_queries' ), 'mastodon_api_get_notifications_queries filter should be registered' );
+
+		wp_set_current_user( $this->administrator_id );
+
+		$queries = apply_filters( 'mastodon_api_get_notifications_queries', array(), 'mention' );
+
+		$message_query = null;
+		foreach ( $queries as $query ) {
+			if ( isset( $query['post_type'] ) && Messages::CPT === $query['post_type'] ) {
+				$message_query = $query;
+				break;
+			}
+		}
+
+		$this->assertNotNull( $message_query, 'The messages should be queried for notifications' );
+		$this->assertContains( 'friends_unread', $message_query['post_status'], 'Unread messages should be included' );
+		$this->assertContains( 'friends_read', $message_query['post_status'], 'Read messages should be included' );
+
+		// The mention tag query for the cached posts must stay out of it.
+		$this->assertArrayNotHasKey( 'tax_query', $message_query, 'The messages do not carry a mention tag' );
+	}
+
 	public function test_ema_unlisted_status_is_quiet_public() {
 		$request = $this->api_request( 'POST', '/api/v1/statuses' );
 		$request->set_param( 'status', 'Quiet public test.' );


### PR DESCRIPTION
Fixes akirk/enable-mastodon-apps#320

A direct message received through a Mastodon app produces no notification, so the only way to notice one is to open the conversations view.

## Changes
* Messages are only exposed to Enable Mastodon Apps through the conversation filters — they were never part of the notification query. They are now registered as a notification source through the `mastodon_api_get_notifications_queries` filter added in akirk/enable-mastodon-apps#331, which queries each source on its own. That separation matters here: the query this integration already contributes for cached posts carries a `tax_query` for the current user's mention tag, and messages don't carry that tag.
* On an Enable Mastodon Apps release without that filter this is inert, so it can go in independently.
* A test asserts that the messages are registered as their own source.

## Testing instructions
* With Friends, ActivityPub and Enable Mastodon Apps active, receive a direct message from a friend and open the notifications in a Mastodon app: it now shows up as a mention.
* Exercised in a disposable WordPress with four things waiting for the user: a comment on their post, a DM in EMA's own DM post type, a cached public mention carrying the mention tag, and a message received through Friends.

```
=== this branch + EMA with the new filter ===
notifications: 4
  mention  post_type=friend_message      <- new
  mention  post_type=friend_post_cache
  mention  post_type=ema-dm-1
  mention  post_type=comment

=== this branch + EMA main (no new filter) ===
notifications: 1
  mention  post_type=friend_post_cache   <- unchanged from before
```

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Type

- [ ] Added - for new features
- [ ] Changed - for changes in existing functionality
- [x] Fixed - for any bug fixes
- [ ] Removed - for now removed features

#### Message

Notify Mastodon apps about received direct messages.

</details>

https://claude.ai/code/session_01CUVxR8uyLTg2roNVWgp91y

<!-- friends-playground-link:start -->
## Test this PR in WordPress Playground

You can test this pull request directly in WordPress Playground:

[Launch WordPress Playground](https://akirk.github.io/playground-step-library/?redir=1&step[0]=setLandingPage&landingPage[0]=/friends/&step[1]=installPlugin&url[1]=github.com/akirk/friends/tree/feature/ema-message-notifications&step[2]=importFriendFeeds&opml[2]=https://alex.kirk.at%20Alex%20Kirk%0Ahttps://adamadam.blog%20Adam%20Zieliński)

This will install and activate the plugin with the changes from this PR.
<!-- friends-playground-link:end -->
