### PR TITLE
Show link previews for posts that link to an article

### DIFF
--- a/.github/changelog/unreleased/712-from-description
+++ b/.github/changelog/unreleased/712-from-description
@@ -1,0 +1,3 @@
+Type: added
+
+Show a link preview card for posts that link to an article, with a setting to turn it off.

--- a/friends-blocks.css
+++ b/friends-blocks.css
@@ -236,3 +236,59 @@ ul.friend-posts img.avatar {
 		grid-template-columns: 1fr;
 	}
 }
+
+/* === Link Previews === */
+/* Colors stay theme-neutral here since the block theme inherits its palette. */
+.friends-page a.friends-link-preview {
+	display: flex;
+	flex-direction: column;
+	margin-top: 12px;
+	overflow: hidden;
+	border: 1px solid rgba(128, 128, 128, .35);
+	border-radius: 8px;
+	background: rgba(128, 128, 128, .07);
+	color: inherit;
+	text-decoration: none;
+}
+
+.friends-page a.friends-link-preview:hover {
+	border-color: rgba(128, 128, 128, .6);
+	text-decoration: none;
+}
+
+.friends-page a.friends-link-preview .friends-link-preview-image img {
+	display: block;
+	width: 100%;
+	height: auto;
+	object-fit: cover;
+	aspect-ratio: 1.91 / 1;
+}
+
+.friends-page a.friends-link-preview .friends-link-preview-text {
+	display: flex;
+	flex-direction: column;
+	gap: 3px;
+	padding: 12px;
+	min-width: 0;
+}
+
+.friends-page a.friends-link-preview .friends-link-preview-host {
+	font-size: 13px;
+	text-transform: uppercase;
+	opacity: .7;
+}
+
+.friends-page a.friends-link-preview .friends-link-preview-title {
+	font-weight: 600;
+	line-height: 1.3;
+}
+
+.friends-page a.friends-link-preview .friends-link-preview-description {
+	font-size: 14px;
+	line-height: 1.4;
+	opacity: .8;
+	display: -webkit-box;
+	-webkit-line-clamp: 3;
+	-webkit-box-orient: vertical;
+	overflow: hidden;
+}

--- a/friends.css
+++ b/friends.css
@@ -2848,3 +2848,68 @@ header.has-header-image {
 		max-width: 19em;
 	}
 }
+
+/* ========================================================================
+   Link Previews
+   ======================================================================== */
+
+.friends-page a.friends-link-preview {
+	display: flex;
+	flex-direction: column;
+	margin-top: .8rem;
+	overflow: hidden;
+	border: .05rem solid var(--friends-color-border-strong);
+	border-radius: .4rem;
+	background: var(--friends-color-surface-alt);
+	color: inherit;
+	text-decoration: none;
+
+	&:hover, &:focus {
+		border-color: var(--friends-color-link);
+		text-decoration: none;
+	}
+
+	& .friends-link-preview-image {
+		display: block;
+		background: var(--friends-color-surface-muted);
+
+		& img {
+			display: block;
+			width: 100%;
+			height: auto;
+			max-height: 24rem;
+			object-fit: cover;
+			aspect-ratio: 1.91 / 1;
+		}
+	}
+
+	& .friends-link-preview-text {
+		display: flex;
+		flex-direction: column;
+		gap: .2rem;
+		padding: .6rem .8rem;
+		min-width: 0;
+	}
+
+	& .friends-link-preview-host {
+		color: var(--friends-color-text-soft);
+		font-size: .7rem;
+		text-transform: uppercase;
+		letter-spacing: .02em;
+	}
+
+	& .friends-link-preview-title {
+		font-weight: 600;
+		line-height: 1.3;
+	}
+
+	& .friends-link-preview-description {
+		color: var(--friends-color-text-muted);
+		font-size: .7rem;
+		line-height: 1.4;
+		display: -webkit-box;
+		-webkit-line-clamp: 3;
+		-webkit-box-orient: vertical;
+		overflow: hidden;
+	}
+}

--- a/friends.php
+++ b/friends.php
@@ -47,6 +47,7 @@ require_once __DIR__ . '/includes/class-blocks.php';
 require_once __DIR__ . '/includes/class-feed.php';
 require_once __DIR__ . '/includes/class-frontend.php';
 require_once __DIR__ . '/includes/class-import.php';
+require_once __DIR__ . '/includes/class-link-preview.php';
 require_once __DIR__ . '/includes/class-logging.php';
 require_once __DIR__ . '/includes/class-messages.php';
 require_once __DIR__ . '/includes/class-migration.php';

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -490,7 +490,7 @@ class Admin {
 		}
 
 		$this->check_admin_settings();
-		foreach ( array( 'disable_auto_tagging' ) as $checkbox ) {
+		foreach ( array( 'disable_auto_tagging', 'disable_link_previews' ) as $checkbox ) {
 			if ( isset( $_POST[ $checkbox ] ) && boolval( $_POST[ $checkbox ] ) ) {
 				update_option( 'friends_' . $checkbox, true );
 			} else {
@@ -1294,6 +1294,7 @@ class Admin {
 					'compose_post_format'              => get_option( 'friends_compose_post_format', 'status' ),
 					'exclude_compose_format_from_feed' => get_option( 'friends_exclude_compose_format_from_feed' ),
 					'disable_auto_tagging'             => get_option( 'friends_disable_auto_tagging' ),
+					'disable_link_previews'            => get_option( 'friends_disable_link_previews' ),
 					'retention_days'                   => Friends::get_retention_days(),
 					'retention_number'                 => Friends::get_retention_number(),
 					'retention_days_enabled'           => get_option( 'friends_enable_retention_days' ),

--- a/includes/class-blocks.php
+++ b/includes/class-blocks.php
@@ -1066,6 +1066,7 @@ class Blocks {
 		$content = get_the_content();
 		$content = wp_kses_post( $content );
 		$content = wpautop( $content );
+		$content .= Link_Preview::render();
 
 		return '<div class="wp-block-friends-post-content">' . $content . '</div>';
 	}

--- a/includes/class-friends.php
+++ b/includes/class-friends.php
@@ -73,6 +73,13 @@ class Friends {
 	public $frontend;
 
 	/**
+	 * A reference to the Link_Preview object.
+	 *
+	 * @var Link_Preview
+	 */
+	public $link_preview;
+
+	/**
 	 * A reference to the REST object.
 	 *
 	 * @var REST
@@ -125,6 +132,8 @@ class Friends {
 		$this->reactions      = new Reactions( $this );
 		$this->rest           = new REST( $this );
 		$this->abilities      = new Abilities( $this );
+
+		$this->link_preview = new Link_Preview( $this );
 
 		new Third_Parties( $this );
 		new Blocks( $this );

--- a/includes/class-link-preview.php
+++ b/includes/class-link-preview.php
@@ -1,0 +1,504 @@
+<?php
+/**
+ * Friends Link Preview
+ *
+ * This contains the functions for fetching and displaying link previews.
+ *
+ * @package Friends
+ */
+
+namespace Friends;
+
+/**
+ * This is the class for the link previews of the Friends Plugin.
+ *
+ * Incoming posts that just contain a link (for example Mastodon statuses that
+ * point to a news article) are enriched with the Open Graph metadata of that
+ * link so that a preview card can be displayed alongside the post.
+ *
+ * @since 4.3
+ *
+ * @package Friends
+ * @author Alex Kirk
+ */
+class Link_Preview {
+	const META         = 'link_preview';
+	const META_CHECKED = 'link_preview_checked';
+	const CRON_HOOK    = 'friends_fetch_link_preview';
+
+	/**
+	 * How long to wait before looking at a post again that had no preview.
+	 */
+	const RETRY_AFTER = WEEK_IN_SECONDS;
+
+	/**
+	 * How much of the remote document to download while looking for meta tags.
+	 */
+	const MAX_RESPONSE_SIZE = 300000;
+
+	/**
+	 * Contains a reference to the Friends class.
+	 *
+	 * @var Friends
+	 */
+	private $friends = null;
+
+	/**
+	 * Constructor
+	 *
+	 * @param Friends $friends A reference to the Friends object.
+	 */
+	public function __construct( Friends $friends ) {
+		$this->friends = $friends;
+		$this->register_hooks();
+	}
+
+	/**
+	 * Register the WordPress hooks
+	 */
+	private function register_hooks() {
+		add_action( 'friends_retrieved_new_posts', array( $this, 'queue_new_posts' ), 10, 2 );
+		add_action( self::CRON_HOOK, array( $this, 'fetch_link_preview' ) );
+	}
+
+	/**
+	 * Whether link previews should be fetched and displayed.
+	 *
+	 * @return     bool  True if enabled.
+	 */
+	public static function is_enabled() {
+		return ! get_option( 'friends_disable_link_previews' );
+	}
+
+	/**
+	 * Queue newly retrieved posts for a link preview lookup.
+	 *
+	 * @param      User_Feed $user_feed     The user feed the posts came from.
+	 * @param      array     $new_post_ids  The ids of the newly created posts.
+	 */
+	public function queue_new_posts( $user_feed, $new_post_ids ) {
+		if ( ! self::is_enabled() || ! is_array( $new_post_ids ) ) {
+			return;
+		}
+
+		foreach ( $new_post_ids as $post_id ) {
+			self::queue( $post_id );
+		}
+	}
+
+	/**
+	 * Schedule a link preview lookup for a post.
+	 *
+	 * @param      int $post_id  The post id.
+	 */
+	public static function queue( $post_id ) {
+		$post_id = intval( $post_id );
+		if ( ! $post_id ) {
+			return;
+		}
+
+		if ( wp_next_scheduled( self::CRON_HOOK, array( $post_id ) ) ) {
+			return;
+		}
+
+		wp_schedule_single_event( time(), self::CRON_HOOK, array( $post_id ) );
+	}
+
+	/**
+	 * Cron callback: look up the link preview for a post.
+	 *
+	 * @param      int $post_id  The post id.
+	 */
+	public function fetch_link_preview( $post_id ) {
+		self::update_link_preview( $post_id );
+	}
+
+	/**
+	 * Get the link preview for a post, scheduling a lookup if we don't have one yet.
+	 *
+	 * @param      \WP_Post|int|null $post   The post (defaults to the current post).
+	 *
+	 * @return     array|false       The link preview data or false if there is none.
+	 */
+	public static function get_for_post( $post = null ) {
+		if ( ! self::is_enabled() ) {
+			return false;
+		}
+
+		$post = get_post( $post );
+		if ( ! $post ) {
+			return false;
+		}
+
+		$preview = get_post_meta( $post->ID, self::META, true );
+		if ( is_array( $preview ) && ! empty( $preview['url'] ) ) {
+			/**
+			 * Filters the link preview data before it is displayed.
+			 *
+			 * @param array    $preview  The link preview data.
+			 * @param \WP_Post $post     The post the preview belongs to.
+			 */
+			return apply_filters( 'friends_link_preview', $preview, $post );
+		}
+
+		$checked = intval( get_post_meta( $post->ID, self::META_CHECKED, true ) );
+		if ( ( ! $checked || $checked < time() - self::RETRY_AFTER ) && self::is_supported_post( $post ) ) {
+			self::queue( $post->ID );
+		}
+
+		return false;
+	}
+
+	/**
+	 * Whether a post is a candidate for a link preview.
+	 *
+	 * @param      \WP_Post $post   The post.
+	 *
+	 * @return     bool     True if a preview could be shown for this post.
+	 */
+	public static function is_supported_post( $post ) {
+		if ( ! in_array( $post->post_type, apply_filters( 'friends_frontend_post_types', array() ), true ) ) {
+			return false;
+		}
+
+		$post_format = get_post_format( $post );
+		if ( ! $post_format ) {
+			$post_format = 'standard';
+		}
+
+		/**
+		 * Filters the post formats for which link previews are shown.
+		 *
+		 * @param array    $post_formats  The post formats.
+		 * @param \WP_Post $post          The post.
+		 */
+		$post_formats = apply_filters( 'friends_link_preview_post_formats', array( 'status', 'link', 'aside' ), $post );
+
+		return in_array( $post_format, $post_formats, true );
+	}
+
+	/**
+	 * Look up the link preview for a post and store it in post meta.
+	 *
+	 * @param      int  $post_id  The post id.
+	 * @param      bool $force    Whether to look it up even if we already did.
+	 *
+	 * @return     array|false  The link preview data or false if there is none.
+	 */
+	public static function update_link_preview( $post_id, $force = false ) {
+		if ( ! self::is_enabled() ) {
+			return false;
+		}
+
+		$post = get_post( $post_id );
+		if ( ! $post || ! self::is_supported_post( $post ) ) {
+			return false;
+		}
+
+		if ( ! $force ) {
+			$checked = intval( get_post_meta( $post->ID, self::META_CHECKED, true ) );
+			if ( $checked && $checked > time() - self::RETRY_AFTER ) {
+				$preview = get_post_meta( $post->ID, self::META, true );
+				return is_array( $preview ) && ! empty( $preview['url'] ) ? $preview : false;
+			}
+		}
+
+		update_post_meta( $post->ID, self::META_CHECKED, time() );
+
+		$url = self::extract_url( $post );
+		if ( ! $url ) {
+			update_post_meta( $post->ID, self::META, array() );
+			return false;
+		}
+
+		$preview = self::fetch( $url );
+		if ( is_wp_error( $preview ) ) {
+			do_action( 'friends_link_preview_failed', $url, $preview, $post );
+			update_post_meta( $post->ID, self::META, array() );
+			return false;
+		}
+
+		update_post_meta( $post->ID, self::META, $preview );
+
+		return $preview;
+	}
+
+	/**
+	 * Find the URL in a post that a preview should be shown for.
+	 *
+	 * Mirrors what Mastodon does: the first link in the post that is not a
+	 * mention or a hashtag, and only if the post doesn't already show media.
+	 *
+	 * @param      \WP_Post $post   The post.
+	 *
+	 * @return     string|false  The url or false if there is none.
+	 */
+	public static function extract_url( $post ) {
+		$content = $post->post_content;
+
+		if ( preg_match( '/<(?:img|video|audio|iframe|embed|object)[\s\/>]/i', $content ) ) {
+			// The post already displays media, no need for a preview card.
+			return false;
+		}
+
+		if ( ! preg_match_all( '/<a\s((?>[^>"\']+|"[^"]*"|\'[^\']*\')*)>/i', $content, $matches ) ) {
+			return false;
+		}
+
+		$own_host = wp_parse_url( $post->guid, PHP_URL_HOST );
+
+		foreach ( $matches[1] as $attributes ) {
+			if ( ! preg_match( '/\bhref\s*=\s*(["\'])(.*?)\1/is', $attributes, $m ) ) {
+				continue;
+			}
+			$url = html_entity_decode( trim( $m[2] ), ENT_QUOTES, get_bloginfo( 'charset' ) );
+
+			if ( preg_match( '/\bclass\s*=\s*(["\'])(.*?)\1/is', $attributes, $m ) ) {
+				$classes = preg_split( '/\s+/', strtolower( $m[2] ) );
+				if ( array_intersect( $classes, array( 'mention', 'hashtag', 'u-url' ) ) ) {
+					continue;
+				}
+			}
+
+			if ( preg_match( '/\brel\s*=\s*(["\'])(.*?)\1/is', $attributes, $m ) ) {
+				$rels = preg_split( '/\s+/', strtolower( $m[2] ) );
+				if ( array_intersect( $rels, array( 'tag', 'author' ) ) ) {
+					continue;
+				}
+			}
+
+			$parsed_url = wp_parse_url( $url );
+			if ( ! isset( $parsed_url['host'] ) || ! isset( $parsed_url['scheme'] ) ) {
+				continue;
+			}
+			if ( ! in_array( strtolower( $parsed_url['scheme'] ), array( 'http', 'https' ), true ) ) {
+				continue;
+			}
+			if ( $own_host && strtolower( $parsed_url['host'] ) === strtolower( $own_host ) ) {
+				// Don't preview the post itself or its neighbors on the same site.
+				continue;
+			}
+			if ( preg_match( '/\.(?:jpe?g|png|gif|webp|avif|svg|mp4|webm|mp3|ogg|pdf)$/i', $parsed_url['path'] ?? '' ) ) {
+				continue;
+			}
+
+			/**
+			 * Filters the URL a link preview will be fetched for.
+			 *
+			 * Return false to not show a link preview for this post.
+			 *
+			 * @param string   $url   The url.
+			 * @param \WP_Post $post  The post.
+			 */
+			return apply_filters( 'friends_link_preview_url', $url, $post );
+		}
+
+		return false;
+	}
+
+	/**
+	 * Download a URL and extract its Open Graph metadata.
+	 *
+	 * @param      string $url    The url.
+	 *
+	 * @return     array|\WP_Error  The link preview data or an error.
+	 */
+	public static function fetch( $url ) {
+		$response = wp_safe_remote_get(
+			$url,
+			array(
+				'timeout'             => 10,
+				'redirection'         => 3,
+				'limit_response_size' => self::MAX_RESPONSE_SIZE,
+				'headers'             => array(
+					'Accept' => 'text/html,application/xhtml+xml',
+				),
+			)
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$response_code = wp_remote_retrieve_response_code( $response );
+		if ( $response_code < 200 || $response_code >= 300 ) {
+			return new \WP_Error( 'friends_link_preview_http_error', wp_remote_retrieve_response_message( $response ), $response_code );
+		}
+
+		$content_type = wp_remote_retrieve_header( $response, 'content-type' );
+		if ( $content_type && false === stripos( $content_type, 'html' ) ) {
+			return new \WP_Error( 'friends_link_preview_not_html', $content_type );
+		}
+
+		$body = wp_remote_retrieve_body( $response );
+		if ( ! $body ) {
+			return new \WP_Error( 'friends_link_preview_empty_body' );
+		}
+
+		return self::parse( $body, self::get_final_url( $response, $url ), $url );
+	}
+
+	/**
+	 * Get the URL a request ended up at after following redirects.
+	 *
+	 * @param      array  $response  The response of wp_safe_remote_get.
+	 * @param      string $url       The url that was requested.
+	 *
+	 * @return     string  The final url.
+	 */
+	private static function get_final_url( $response, $url ) {
+		if ( ! isset( $response['http_response'] ) || ! is_object( $response['http_response'] ) ) {
+			return $url;
+		}
+		if ( ! method_exists( $response['http_response'], 'get_response_object' ) ) {
+			return $url;
+		}
+		$response_object = $response['http_response']->get_response_object();
+		if ( isset( $response_object->url ) && $response_object->url ) {
+			return $response_object->url;
+		}
+
+		return $url;
+	}
+
+	/**
+	 * Extract the Open Graph metadata from an HTML document.
+	 *
+	 * @param      string $html       The HTML document.
+	 * @param      string $final_url  The url the document was loaded from.
+	 * @param      string $url        The url as it appeared in the post.
+	 *
+	 * @return     array|\WP_Error  The link preview data or an error.
+	 */
+	public static function parse( $html, $final_url, $url = null ) {
+		if ( is_null( $url ) ) {
+			$url = $final_url;
+		}
+
+		$head = $html;
+		if ( preg_match( '/<head\b[^>]*>(.*?)<\/head>/is', $html, $m ) ) {
+			$head = $m[1];
+		}
+
+		$meta = array();
+		if ( preg_match_all( '/<meta\s((?>[^>"\']+|"[^"]*"|\'[^\']*\')*)\/?>/is', $head, $matches ) ) {
+			foreach ( $matches[1] as $attributes ) {
+				if ( ! preg_match( '/\b(?:property|name)\s*=\s*(["\'])\s*(.*?)\s*\1/is', $attributes, $m ) ) {
+					continue;
+				}
+				$key = strtolower( $m[2] );
+				if ( isset( $meta[ $key ] ) ) {
+					continue;
+				}
+				if ( ! preg_match( '/\bcontent\s*=\s*(["\'])(.*?)\1/is', $attributes, $m ) ) {
+					continue;
+				}
+				$meta[ $key ] = trim( html_entity_decode( $m[2], ENT_QUOTES, 'UTF-8' ) );
+			}
+		}
+
+		$title = self::first_of( $meta, array( 'og:title', 'twitter:title' ) );
+		if ( ! $title && preg_match( '/<title\b[^>]*>(.*?)<\/title>/is', $head, $m ) ) {
+			$title = trim( html_entity_decode( wp_strip_all_tags( $m[1] ), ENT_QUOTES, 'UTF-8' ) );
+		}
+
+		$description = self::first_of( $meta, array( 'og:description', 'twitter:description', 'description' ) );
+		$image       = self::first_of( $meta, array( 'og:image:secure_url', 'og:image:url', 'og:image', 'twitter:image', 'twitter:image:src' ) );
+		$site_name   = self::first_of( $meta, array( 'og:site_name', 'application-name' ) );
+
+		if ( $image ) {
+			$image = \WP_Http::make_absolute_url( $image, $final_url );
+			$scheme = wp_parse_url( $image, PHP_URL_SCHEME );
+			if ( ! in_array( strtolower( (string) $scheme ), array( 'http', 'https' ), true ) ) {
+				$image = '';
+			}
+		}
+
+		if ( ! $title && ! $description && ! $image ) {
+			return new \WP_Error( 'friends_link_preview_no_metadata', $url );
+		}
+
+		$preview = array(
+			'url'         => $url,
+			'host'        => self::pretty_host( $final_url ),
+			'title'       => self::shorten( sanitize_text_field( $title ), 200 ),
+			'description' => self::shorten( sanitize_text_field( $description ), 400 ),
+			'image'       => $image ? esc_url_raw( $image ) : '',
+			'site_name'   => self::shorten( sanitize_text_field( $site_name ), 100 ),
+		);
+
+		foreach ( array( 'width', 'height' ) as $dimension ) {
+			$value = isset( $meta[ 'og:image:' . $dimension ] ) ? intval( $meta[ 'og:image:' . $dimension ] ) : 0;
+			if ( $value > 0 ) {
+				$preview[ 'image_' . $dimension ] = $value;
+			}
+		}
+
+		return $preview;
+	}
+
+	/**
+	 * Get the first non-empty value of a list of keys.
+	 *
+	 * @param      array $meta   The metadata.
+	 * @param      array $keys   The keys to look at, in order.
+	 *
+	 * @return     string  The value or an empty string.
+	 */
+	private static function first_of( $meta, $keys ) {
+		foreach ( $keys as $key ) {
+			if ( ! empty( $meta[ $key ] ) ) {
+				return $meta[ $key ];
+			}
+		}
+
+		return '';
+	}
+
+	/**
+	 * Shorten a string to a maximum length.
+	 *
+	 * @param      string $text    The text.
+	 * @param      int    $length  The maximum length.
+	 *
+	 * @return     string  The shortened text.
+	 */
+	private static function shorten( $text, $length ) {
+		if ( mb_strlen( $text ) <= $length ) {
+			return $text;
+		}
+
+		return trim( mb_substr( $text, 0, $length - 1 ) ) . '…';
+	}
+
+	/**
+	 * Render the link preview card for the current post.
+	 *
+	 * @return     string  The HTML of the card or an empty string.
+	 */
+	public static function render() {
+		if ( ! self::is_enabled() ) {
+			return '';
+		}
+
+		ob_start();
+		Friends::template_loader()->get_template_part( 'frontend/parts/link-preview', get_post_format(), array() );
+		return ob_get_clean();
+	}
+
+	/**
+	 * Get the hostname of a URL without a leading www.
+	 *
+	 * @param      string $url    The url.
+	 *
+	 * @return     string  The hostname.
+	 */
+	public static function pretty_host( $url ) {
+		$host = wp_parse_url( $url, PHP_URL_HOST );
+		if ( ! $host ) {
+			return '';
+		}
+
+		return preg_replace( '/^www\./i', '', $host );
+	}
+}

--- a/templates/admin/settings.php
+++ b/templates/admin/settings.php
@@ -231,6 +231,24 @@ do_action( 'friends_settings_before_form' );
 				</td>
 			</tr>
 			<tr>
+				<th scope="row"><?php esc_html_e( 'Link Previews', 'friends' ); ?></th>
+				<td>
+					<fieldset>
+						<label for="disable_link_previews">
+							<input name="disable_link_previews" type="checkbox" id="disable_link_previews" value="1" <?php checked( '1', $args['disable_link_previews'] ); ?> />
+							<span><?php esc_html_e( 'Disable link previews for incoming posts.', 'friends' ); ?></span>
+						</label>
+						<p class="description">
+						<?php
+						esc_html_e( 'When a status contains a link but no image or video of its own, a preview card with the linked page\'s title, description and image can be shown below the post.', 'friends' );
+						echo '<br>';
+						esc_html_e( 'To do so, your site downloads the linked page in the background, so disable this if you\'d rather not have your site contact the linked websites.', 'friends' );
+						?>
+						</p>
+					</fieldset>
+				</td>
+			</tr>
+			<tr>
 				<th scope="row" rowspan="3"><?php esc_html_e( 'Frontend', 'friends' ); ?></th>
 				<td>
 					<fieldset>

--- a/templates/frontend/parts/entry-content.php
+++ b/templates/frontend/parts/entry-content.php
@@ -15,5 +15,7 @@ $content = get_the_content();
 	} else {
 		the_content();
 	}
+
+	Friends\Friends::template_loader()->get_template_part( 'frontend/parts/link-preview', get_post_format(), $args );
 	?>
 </div>

--- a/templates/frontend/parts/link-preview.php
+++ b/templates/frontend/parts/link-preview.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * This template contains the link preview card for an article on /friends/.
+ *
+ * @version 1.0
+ * @package Friends
+ */
+
+$link_preview = Friends\Link_Preview::get_for_post();
+if ( ! $link_preview ) {
+	return;
+}
+
+$link_preview_host = ! empty( $link_preview['site_name'] ) ? $link_preview['site_name'] : $link_preview['host'];
+?>
+<a class="friends-link-preview<?php echo empty( $link_preview['image'] ) ? ' no-image' : ''; ?>" href="<?php echo esc_url( $link_preview['url'] ); ?>" target="_blank" rel="noopener noreferrer nofollow">
+	<?php if ( ! empty( $link_preview['image'] ) ) : ?>
+		<span class="friends-link-preview-image">
+			<img src="<?php echo esc_url( $link_preview['image'] ); ?>" alt="" loading="lazy" decoding="async"
+			<?php
+			if ( ! empty( $link_preview['image_width'] ) && ! empty( $link_preview['image_height'] ) ) {
+				echo ' width="' . esc_attr( $link_preview['image_width'] ) . '" height="' . esc_attr( $link_preview['image_height'] ) . '"';
+			}
+			?>
+			/>
+		</span>
+	<?php endif; ?>
+	<span class="friends-link-preview-text">
+		<?php if ( $link_preview_host ) : ?>
+			<span class="friends-link-preview-host"><?php echo esc_html( $link_preview_host ); ?></span>
+		<?php endif; ?>
+		<?php if ( ! empty( $link_preview['title'] ) ) : ?>
+			<strong class="friends-link-preview-title"><?php echo esc_html( $link_preview['title'] ); ?></strong>
+		<?php endif; ?>
+		<?php if ( ! empty( $link_preview['description'] ) ) : ?>
+			<span class="friends-link-preview-description"><?php echo esc_html( $link_preview['description'] ); ?></span>
+		<?php endif; ?>
+	</span>
+</a>

--- a/templates/google-reader/google-reader.css
+++ b/templates/google-reader/google-reader.css
@@ -1704,3 +1704,62 @@
 	font-size: .8rem;
 	padding: 1px 6px;
 }
+
+/* === Link Previews === */
+.friends-page a.friends-link-preview {
+	display: flex;
+	gap: 10px;
+	margin-top: 8px;
+	padding: 8px;
+	border: 1px solid light-dark(#dadce0, #3c4043);
+	border-radius: 4px;
+	background: light-dark(#f8f9fa, #292a2d);
+	color: inherit;
+	text-decoration: none;
+}
+
+.friends-page a.friends-link-preview:hover {
+	background: light-dark(#f1f3f4, #35363a);
+	text-decoration: none;
+}
+
+.friends-page a.friends-link-preview .friends-link-preview-image {
+	flex: 0 0 auto;
+}
+
+.friends-page a.friends-link-preview .friends-link-preview-image img {
+	display: block;
+	width: 100px;
+	height: 75px;
+	object-fit: cover;
+	border-radius: 2px;
+}
+
+.friends-page a.friends-link-preview .friends-link-preview-text {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+	min-width: 0;
+}
+
+.friends-page a.friends-link-preview .friends-link-preview-host {
+	color: light-dark(#5f6368, #9aa0a6);
+	font-size: 11px;
+	text-transform: uppercase;
+}
+
+.friends-page a.friends-link-preview .friends-link-preview-title {
+	font-size: 13px;
+	font-weight: bold;
+	line-height: 1.3;
+}
+
+.friends-page a.friends-link-preview .friends-link-preview-description {
+	color: light-dark(#5f6368, #9aa0a6);
+	font-size: 12px;
+	line-height: 1.4;
+	display: -webkit-box;
+	-webkit-line-clamp: 2;
+	-webkit-box-orient: vertical;
+	overflow: hidden;
+}

--- a/templates/mastodon/mastodon.css
+++ b/templates/mastodon/mastodon.css
@@ -2530,3 +2530,59 @@ body.friends-page {
 .friends-page .posts.all-collapsed article.card.mast-current:not(.uncollapsed) {
 	background: light-dark(#f0f3f8, #2c3040);
 }
+
+/* === Link Previews === */
+.friends-page a.friends-link-preview {
+	display: flex;
+	flex-direction: column;
+	margin-top: 12px;
+	overflow: hidden;
+	border: 1px solid light-dark(#d4dde8, #393f4f);
+	border-radius: 8px;
+	background: light-dark(#f2f5f7, #1e2028);
+	color: inherit;
+	text-decoration: none;
+}
+
+.friends-page a.friends-link-preview:hover {
+	border-color: light-dark(#b6c3d4, #4a5266);
+	text-decoration: none;
+}
+
+.friends-page a.friends-link-preview .friends-link-preview-image img {
+	display: block;
+	width: 100%;
+	height: auto;
+	object-fit: cover;
+	aspect-ratio: 1.91 / 1;
+}
+
+.friends-page a.friends-link-preview .friends-link-preview-text {
+	display: flex;
+	flex-direction: column;
+	gap: 3px;
+	padding: 12px;
+	min-width: 0;
+}
+
+.friends-page a.friends-link-preview .friends-link-preview-host {
+	color: light-dark(#606984, #9baec8);
+	font-size: 13px;
+	text-transform: uppercase;
+}
+
+.friends-page a.friends-link-preview .friends-link-preview-title {
+	font-size: 15px;
+	font-weight: 600;
+	line-height: 1.3;
+}
+
+.friends-page a.friends-link-preview .friends-link-preview-description {
+	color: light-dark(#606984, #9baec8);
+	font-size: 14px;
+	line-height: 1.4;
+	display: -webkit-box;
+	-webkit-line-clamp: 3;
+	-webkit-box-orient: vertical;
+	overflow: hidden;
+}

--- a/templates/twitter/twitter.css
+++ b/templates/twitter/twitter.css
@@ -2450,3 +2450,57 @@ body.friends-page {
 .friends-page .posts.all-collapsed article.card.mast-current:not(.uncollapsed) {
 	background: light-dark(rgba(0,0,0,.03), rgba(231,233,234,.03));
 }
+
+/* === Link Previews === */
+.friends-page a.friends-link-preview {
+	display: flex;
+	flex-direction: column;
+	margin-top: 12px;
+	overflow: hidden;
+	border: 1px solid light-dark(#cfd9de, #2f3336);
+	border-radius: 16px;
+	color: inherit;
+	text-decoration: none;
+}
+
+.friends-page a.friends-link-preview:hover {
+	background: light-dark(#f7f9f9, #16181c);
+	text-decoration: none;
+}
+
+.friends-page a.friends-link-preview .friends-link-preview-image img {
+	display: block;
+	width: 100%;
+	height: auto;
+	object-fit: cover;
+	aspect-ratio: 1.91 / 1;
+}
+
+.friends-page a.friends-link-preview .friends-link-preview-text {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+	padding: 12px;
+	min-width: 0;
+}
+
+.friends-page a.friends-link-preview .friends-link-preview-host {
+	color: light-dark(#536471, #71767b);
+	font-size: 15px;
+}
+
+.friends-page a.friends-link-preview .friends-link-preview-title {
+	font-size: 15px;
+	font-weight: 400;
+	line-height: 1.3;
+}
+
+.friends-page a.friends-link-preview .friends-link-preview-description {
+	color: light-dark(#536471, #71767b);
+	font-size: 15px;
+	line-height: 1.3;
+	display: -webkit-box;
+	-webkit-line-clamp: 2;
+	-webkit-box-orient: vertical;
+	overflow: hidden;
+}


### PR DESCRIPTION
Fixes #708

Mastodon renders the preview card itself, per server — it is not part of the ActivityPub object, so nothing about it reaches us. A shared news article therefore arrives as text plus a bare link. This builds the card locally instead.

## Changes

* New `Friends\Link_Preview` class.
  * **Which posts:** post format `status`, `link` or `aside` (filter: `friends_link_preview_post_formats`), and only when the content carries no media of its own (`<img>`, `<video>`, `<audio>`, `<iframe>`, `<embed>`, `<object>`) — the same rule Mastodon uses, so an image post doesn't get a second image.
  * **Which link:** the first `<a>` that isn't a mention, hashtag, `rel="tag"`/`rel="author"`, a link back to the poster's own host, or a direct file link (filter: `friends_link_preview_url`, return `false` to suppress).
  * **Lookup:** `wp_safe_remote_get()` in a `wp_schedule_single_event()`, capped at 300 KB via `limit_response_size`, 10s timeout, 3 redirects, HTML content types only. Extracts `og:*` with `twitter:*` / `<title>` / `<meta name="description">` fallbacks; relative image URLs are resolved, non-http(s) image URLs dropped.
  * **Storage:** `link_preview` post meta (filter: `friends_link_preview`), plus `link_preview_checked` so a link that yields nothing isn't retried for a week.
  * **When:** new posts are queued from `friends_retrieved_new_posts`, so nothing is added to the latency of a feed refresh. Pre-existing posts are queued lazily on first display and show their card on the next page load.
* New `frontend/parts/link-preview` template part, rendered from `frontend/parts/entry-content` (so all four PHP themes pick it up) and appended to the `friends/post-content` block for the block theme. Styled in `friends.css`, `friends-blocks.css`, `mastodon.css`, `twitter.css` and `google-reader.css`.
* New setting under Settings → **Link Previews**: "Disable link previews for incoming posts" (`friends_disable_link_previews`). On by default; off means no card is shown *and* no outbound request is ever made.

## Testing instructions

* With the setting enabled (default), subscribe to a Mastodon account that posts news links, refresh the feed, and reload `/friends/` — a card with the article's title, description and image appears under the status. Posts that already contain an image are unchanged.
* Tick "Disable link previews for incoming posts" in Settings and reload: the cards are gone.
* Metadata extraction was exercised against live pages (`arstechnica.com`, `en.wikipedia.org`, `theguardian.com`, `example.com`) and against fixtures covering hashtag/mention-only statuses, statuses that already show an image, links to the poster's own host, direct image links, relative `og:image` paths, `data:` image URLs, `>` inside quoted attribute values, and pages with no metadata at all.
* Not verified end-to-end in a browser: the throwaway Playground fixture used for screenshots failed to render its synthetic subscription — the same truncation happens on unmodified `main`, so it's the fixture, not this branch.

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Type

- [x] Added - for new features

#### Message

Show a link preview card for posts that link to an article, with a setting to turn it off.

</details>

https://claude.ai/code/session_01J7aozaEFaZ3vLaLXith1qm

<!-- friends-playground-link:start -->
## Test this PR in WordPress Playground

You can test this pull request directly in WordPress Playground:

[Launch WordPress Playground](https://akirk.github.io/playground-step-library/?redir=1&step[0]=setLandingPage&landingPage[0]=/friends/&step[1]=installPlugin&url[1]=github.com/akirk/friends/tree/feature/link-previews&step[2]=importFriendFeeds&opml[2]=https://alex.kirk.at%20Alex%20Kirk%0Ahttps://adamadam.blog%20Adam%20Zieliński)

This will install and activate the plugin with the changes from this PR.
<!-- friends-playground-link:end -->