### PR TITLE
Add the 4.3 news page

### DIFF
--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -607,6 +607,11 @@ class Admin {
 			'friends_news_entries',
 			array(
 				array(
+					'version'  => '4.3',
+					'title'    => __( '4.3: Link Previews', 'friends' ),
+					'template' => 'admin/news-4-3',
+				),
+				array(
 					'version'  => '4.2',
 					'title'    => __( '4.2: Direct Messages', 'friends' ),
 					'template' => 'admin/news-4-2',

--- a/templates/admin/news-4-3.php
+++ b/templates/admin/news-4-3.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * This template contains the Friends 4.3 news entry.
+ *
+ * @package Friends
+ */
+
+?>
+<div class="friends-news-entry-body">
+	<h2><?php esc_html_e( 'Friends 4.3: Link Previews', 'friends' ); ?></h2>
+
+	<div class="friends-news-changes">
+		<div class="friends-news-change">
+			<h4><?php esc_html_e( 'Link Previews', 'friends' ); ?></h4>
+			<p><?php esc_html_e( 'When someone you follow shares a news article, their post arrives as plain text and a bare link. The preview card you see on Mastodon is rendered by their server and is not part of what gets sent across the fediverse, so it never reached your feed.', 'friends' ); ?></p>
+			<p>
+				<?php
+				echo wp_kses(
+					sprintf(
+						// translators: %s is a link to the friends page.
+						__( 'Friends now builds that card itself: %s shows the linked page\'s title, description and image below the post, in every theme.', 'friends' ),
+						'<a href="' . esc_url( home_url( '/friends/' ) ) . '">' . esc_html__( 'your feed', 'friends' ) . '</a>'
+					),
+					array(
+						'a' => array(
+							'href' => true,
+						),
+					)
+				);
+				?>
+			</p>
+		</div>
+
+		<div class="friends-news-change">
+			<h4><?php esc_html_e( 'Only Where It Adds Something', 'friends' ); ?></h4>
+			<p><?php esc_html_e( 'A card appears when a status contains a link but no image or video of its own, so posts that already show a photo are left alone. Mentions, hashtags and links back to the poster\'s own site are skipped.', 'friends' ); ?></p>
+			<p><?php esc_html_e( 'The linked page is downloaded in the background after a post arrives, never while you wait for a page to load, and the result is stored with the post so each link is only fetched once.', 'friends' ); ?></p>
+		</div>
+
+		<div class="friends-news-change">
+			<h4><?php esc_html_e( 'Your Call', 'friends' ); ?></h4>
+			<p><?php esc_html_e( 'Showing a preview means your site contacts the linked website. If you\'d rather it didn\'t, you can turn link previews off entirely — no cards are shown and no requests are made.', 'friends' ); ?></p>
+			<p>
+				<a class="button" href="<?php echo esc_url( admin_url( 'admin.php?page=friends-settings' ) ); ?>">
+					<?php esc_html_e( 'Go to Settings', 'friends' ); ?>
+				</a>
+			</p>
+		</div>
+
+		<div class="friends-news-change">
+			<h4><?php esc_html_e( 'Direct Messages in Mastodon Apps', 'friends' ); ?></h4>
+			<p><?php esc_html_e( 'Incoming direct messages now raise a notification in Mastodon apps connected through Enable Mastodon Apps, so a new message reaches you there instead of waiting to be discovered.', 'friends' ); ?></p>
+		</div>
+	</div>
+</div>

--- a/templates/admin/news-4-3.php
+++ b/templates/admin/news-4-3.php
@@ -49,7 +49,31 @@
 
 		<div class="friends-news-change">
 			<h4><?php esc_html_e( 'Direct Messages in Mastodon Apps', 'friends' ); ?></h4>
-			<p><?php esc_html_e( 'Incoming direct messages now raise a notification in Mastodon apps connected through Enable Mastodon Apps, so a new message reaches you there instead of waiting to be discovered.', 'friends' ); ?></p>
+			<?php
+			if ( class_exists( 'Enable_Mastodon_Apps\Mastodon_API' ) ) {
+				$mastodon_apps_link = '<a href="' . esc_url( admin_url( 'options-general.php?page=enable-mastodon-apps' ) ) . '">' . esc_html__( 'Enable Mastodon Apps', 'friends' ) . '</a>';
+			} else {
+				$mastodon_apps_link = '<a href="' . esc_url( admin_url( 'plugin-install.php?tab=plugin-information&plugin=enable-mastodon-apps&TB_iframe=true' ) ) . '" class="thickbox open-plugin-details-modal install-now" target="_blank">' . esc_html__( 'Enable Mastodon Apps', 'friends' ) . '</a>';
+			}
+			?>
+			<p>
+				<?php
+				echo wp_kses(
+					sprintf(
+						// translators: %s is a link to the Enable Mastodon Apps plugin.
+						__( 'Incoming direct messages now raise a notification in Mastodon apps connected through %s, so a new message reaches you there instead of waiting to be discovered.', 'friends' ),
+						$mastodon_apps_link
+					),
+					array(
+						'a' => array(
+							'href'   => true,
+							'class'  => true,
+							'target' => true,
+						),
+					)
+				);
+				?>
+			</p>
 		</div>
 	</div>
 </div>


### PR DESCRIPTION
## Changes

* Adds `templates/admin/news-4-3.php` and registers it at the top of `Admin::get_news_entries()`, so Friends → Home opens on it.
* Four cards, with link previews as the headline:
  * **Link Previews** — why a shared article used to arrive as bare text and a link (the card is rendered per-server on Mastodon and isn't part of what federates), and that Friends now builds it itself. Links to the feed.
  * **Only Where It Adds Something** — a card appears when a status has a link but no media of its own; mentions, hashtags and self-links are skipped; the fetch happens in the background after a post arrives and is stored with the post.
  * **Your Call** — showing a preview means contacting the linked site, and it can be turned off entirely. Links to Settings.
  * **Direct Messages in Mastodon Apps** — the #711 fix. "Enable Mastodon Apps" is a link: to its settings page when the plugin is
    installed, and to the plugin-install modal when it isn't, the same conditional the welcome page already uses. The news page
    enqueues thickbox, so the modal opens in place.

## Testing instructions

* Friends → Home → "4.3: Link Previews" in the sidebar. Both links were checked: "your feed" → `/friends/`, "Go to Settings" → `admin.php?page=friends-settings`.
* The Enable Mastodon Apps link was checked in both states in Playground: without the plugin it points at `plugin-install.php?...&plugin=enable-mastodon-apps&TB_iframe=true` with the `thickbox open-plugin-details-modal install-now` classes and the modal opens on click; with the plugin installed and active it points at `options-general.php?page=enable-mastodon-apps` with no classes.
* Rendered in Playground at 1500px (2-column grid) and at 782px, where the grid collapses to one column and the table of contents wraps inline. No overflow at either width.

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Type

- [ ] Added - for new features
- [ ] Changed - for changes in existing functionality
- [ ] Fixed - for any bug fixes
- [ ] Removed - for now removed features

#### Message

</details>

https://claude.ai/code/session_01J7aozaEFaZ3vLaLXith1qm

<!-- friends-playground-link:start -->
## Test this PR in WordPress Playground

You can test this pull request directly in WordPress Playground:

[Launch WordPress Playground](https://akirk.github.io/playground-step-library/?redir=1&step[0]=setLandingPage&landingPage[0]=/friends/&step[1]=installPlugin&url[1]=github.com/akirk/friends/tree/feature/news-4-3&step[2]=importFriendFeeds&opml[2]=https://alex.kirk.at%20Alex%20Kirk%0Ahttps://adamadam.blog%20Adam%20Zieliński)

This will install and activate the plugin with the changes from this PR.
<!-- friends-playground-link:end -->
