### PR TITLE
Fix a fatal error when the ActivityPub plugin is not active

### DIFF
--- a/.github/changelog/unreleased/714-from-description
+++ b/.github/changelog/unreleased/714-from-description
@@ -1,0 +1,3 @@
+Type: fixed
+
+Fix a fatal error that stopped the friends page from rendering when the ActivityPub plugin is not active.

--- a/feed-parsers/class-feed-parser-activitypub.php
+++ b/feed-parsers/class-feed-parser-activitypub.php
@@ -117,6 +117,8 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 		add_filter( 'mastodon_api_in_reply_to_id', array( $this, 'mastodon_api_in_reply_to_id' ), 25 );
 		add_filter( 'friends_cache_url_post_id', array( $this, 'check_url_to_postid' ), 10, 2 );
 
+		add_filter( 'friends_author_display_name_html', array( self::class, 'author_display_name_html' ), 10, 3 );
+
 		add_action( 'friends_post_author_meta', array( self::class, 'friends_post_author_meta' ) );
 		add_action( 'friends_get_template_part_frontend/parts/header-menu', array( self::class, 'header_menu' ) );
 		add_action( 'friends_comments_form', array( self::class, 'comment_form' ) );
@@ -5092,6 +5094,26 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 			);
 		}
 		return $comments;
+	}
+
+	/**
+	 * Render a display name with the actor's custom emoji.
+	 *
+	 * Hooked to `friends_author_display_name_html`, which is only filtered while
+	 * this parser is registered, i.e. while the ActivityPub plugin is active.
+	 * Without it the escaped display name passed in is used as-is.
+	 *
+	 * @param string    $html         The display name as safe HTML.
+	 * @param string    $display_name The raw display name.
+	 * @param User|null $friend_user  The user the name belongs to.
+	 * @return string Safe HTML.
+	 */
+	public static function author_display_name_html( $html, $display_name, $friend_user = null ) {
+		if ( ! $friend_user instanceof User ) {
+			return $html;
+		}
+
+		return wp_kses( self::replace_custom_emojis_for_user( $display_name, $friend_user ), self::get_custom_emoji_allowed_html() );
 	}
 
 	public static function friends_post_author_meta( $friend_user ) {

--- a/includes/class-blocks.php
+++ b/includes/class-blocks.php
@@ -1323,7 +1323,7 @@ class Blocks {
 				'class' => 'wp-block-friends-author-name',
 				'id'    => 'page-title',
 			)
-		) . '>' . wp_kses( Feed_Parser_ActivityPub::replace_custom_emojis_for_user( $author->display_name, $author ), Feed_Parser_ActivityPub::get_custom_emoji_allowed_html() ) . '</h2>';
+		) . '>' . wp_kses_post( apply_filters( 'friends_author_display_name_html', esc_html( $author->display_name ), $author->display_name, $author ) ) . '</h2>';
 	}
 
 	/**

--- a/includes/class-frontend.php
+++ b/includes/class-frontend.php
@@ -897,7 +897,7 @@ class Frontend {
 				}
 
 				$author_name      = $author->display_name;
-				$author_name_html = Feed_Parser_ActivityPub::replace_custom_emojis_for_user( $author_name, $author );
+				$author_name_html = apply_filters( 'friends_author_display_name_html', esc_html( $author_name ), $author_name, $author );
 				$override_author_name = apply_filters( 'friends_override_author_name', '', $author_name, $block->context['postId'] );
 				if ( isset( $attributes['isLink'] ) && $attributes['isLink'] ) {
 					$author_name_html = sprintf( '<a href="%1$s" target="%2$s" class="wp-block-post-author-name__link">%3$s</a>', esc_url( $author->get_local_friends_page_url() ), esc_attr( $attributes['linkTarget'] ), $author_name_html );
@@ -922,7 +922,7 @@ class Frontend {
 					wp_kses(
 						$author_name_html,
 						array_merge(
-							Feed_Parser_ActivityPub::get_custom_emoji_allowed_html(),
+							wp_kses_allowed_html( 'post' ),
 							array(
 								'a' => array(
 									'class'  => true,

--- a/includes/class-user.php
+++ b/includes/class-user.php
@@ -1251,7 +1251,11 @@ class User extends \WP_User {
 		if ( $user_id ) {
 			return $user_id;
 		}
-		$user = Feed_Parser_ActivityPub::determine_mastodon_api_user( $user_id );
+		$user = false;
+		// The ActivityPub parser is only loaded when the ActivityPub plugin is active.
+		if ( class_exists( Feed_Parser_ActivityPub::class ) ) {
+			$user = Feed_Parser_ActivityPub::determine_mastodon_api_user( $user_id );
+		}
 		if ( ! $user ) {
 			$user = self::get_post_author( get_post( $post_id ) );
 		}
@@ -1294,7 +1298,8 @@ class User extends \WP_User {
 				$relationship = new \Enable_Mastodon_Apps\Entity\Relationship();
 			}
 			foreach ( $user->get_active_feeds() as $feed ) {
-				if ( Feed_Parser_ActivityPub::SLUG === $feed->get_parser() ) {
+				// Not Feed_Parser_ActivityPub::SLUG: this is reached above without the ActivityPub plugin, so that class may not exist.
+				if ( 'activitypub' === $feed->get_parser() ) {
 					$relationship->following = true;
 					break;
 				}

--- a/templates/frontend/author-header.php
+++ b/templates/frontend/author-header.php
@@ -10,7 +10,7 @@ $_feeds = count( $args['friend_user']->get_feeds() );
 $rules = count( $args['friend_user']->get_feed_rules() );
 $active_feeds = count( $args['friend_user']->get_active_feeds() );
 $hidden_post_count = $args['friend_user']->get_post_in_trash_count();
-$display_name_html = Friends\Feed_Parser_ActivityPub::replace_custom_emojis_for_user( $args['friend_user']->display_name, $args['friend_user'] );
+$display_name_html = apply_filters( 'friends_author_display_name_html', esc_html( $args['friend_user']->display_name ), $args['friend_user']->display_name, $args['friend_user'] );
 
 // Get ActivityPub feeds and their data (header image, profile URLs, summary).
 $activitypub_feeds = array();
@@ -25,11 +25,15 @@ foreach ( $args['friend_user']->get_active_feeds() as $feed ) {
 
 	$ap_actor_id = $feed->get_ap_actor_id();
 	$ap_actor_url = $feed->get_ap_actor_url();
-	$ap_actor_acct = Friends\Feed_Parser_ActivityPub::get_actor_acct_from_attributed_to(
-		array(
-			'ap_actor_id' => $ap_actor_id,
-		)
-	);
+	// The parser is only loaded while the ActivityPub plugin is active; a feed can still be marked as one without it.
+	$ap_actor_acct = '';
+	if ( class_exists( 'Friends\Feed_Parser_ActivityPub' ) ) {
+		$ap_actor_acct = Friends\Feed_Parser_ActivityPub::get_actor_acct_from_attributed_to(
+			array(
+				'ap_actor_id' => $ap_actor_id,
+			)
+		);
+	}
 
 	// If no actor URL from linked actor, use the feed URL as the actor URL.
 	if ( ! $ap_actor_url ) {
@@ -125,7 +129,7 @@ if ( $args['friends']->frontend->reaction ) {
 		<img src="<?php echo esc_attr( $args['friend_user']->get_avatar_url() ); ?>" alt="<?php echo esc_attr( $args['friend_user']->display_name ); ?>" class="avatar" width="36" height="36" style="vertical-align: middle;" />
 		<?php
 	}
-	echo wp_kses( $display_name_html, Friends\Feed_Parser_ActivityPub::get_custom_emoji_allowed_html() );
+	echo wp_kses_post( $display_name_html );
 }
 ?>
 </a>

--- a/templates/frontend/parts/header-status.php
+++ b/templates/frontend/parts/header-status.php
@@ -85,7 +85,7 @@ $author_url = apply_filters( 'friends_author_url', $friend_user->get_local_frien
 				$names_differ     = $is_external_user && $override_author_name && trim( str_replace( $override_author_name, '', $author_name ) ) === $author_name;
 				$display_name     = $names_differ ? $override_author_name : $friend_user->display_name;
 				?>
-				<a href="<?php echo esc_attr( $author_url ); ?>"><strong><?php echo wp_kses( Friends\Feed_Parser_ActivityPub::replace_custom_emojis_for_user( $display_name, $friend_user ), Friends\Feed_Parser_ActivityPub::get_custom_emoji_allowed_html() ); ?></strong></a>
+				<a href="<?php echo esc_attr( $author_url ); ?>"><strong><?php echo wp_kses_post( apply_filters( 'friends_author_display_name_html', esc_html( $display_name ), $display_name, $friend_user ) ); ?></strong></a>
 				<?php do_action( 'friends_post_author_meta', $friend_user ); ?>
 				<?php if ( get_post_meta( get_the_ID(), '_has_mention_in_comments', true ) ) : ?>
 					<span class="mention-indicator" title="<?php esc_attr_e( 'You were mentioned in a comment', 'friends' ); ?>">@</span>

--- a/templates/frontend/parts/header.php
+++ b/templates/frontend/parts/header.php
@@ -72,7 +72,7 @@ $author_url = apply_filters( 'friends_author_url', $friend_user->get_local_frien
 				$names_differ     = $is_external_user && $override_author_name && trim( str_replace( $override_author_name, '', $author_name ) ) === $author_name;
 				$display_name     = $names_differ ? $override_author_name : $friend_user->display_name;
 				?>
-				<a href="<?php echo esc_attr( $author_url ); ?>"><strong><?php echo wp_kses( Friends\Feed_Parser_ActivityPub::replace_custom_emojis_for_user( $display_name, $friend_user ), Friends\Feed_Parser_ActivityPub::get_custom_emoji_allowed_html() ); ?></strong></a>
+				<a href="<?php echo esc_attr( $author_url ); ?>"><strong><?php echo wp_kses_post( apply_filters( 'friends_author_display_name_html', esc_html( $display_name ), $display_name, $friend_user ) ); ?></strong></a>
 				<?php do_action( 'friends_post_author_meta', $friend_user ); ?>
 				<?php if ( get_post_meta( get_the_ID(), '_has_mention_in_comments', true ) ) : ?>
 					<span class="mention-indicator" title="<?php esc_attr_e( 'You were mentioned in a comment', 'friends' ); ?>">@</span>


### PR DESCRIPTION
Without the ActivityPub plugin, `/friends/` dies mid-render: the page stops inside the first post's header and nothing after it is sent. Profile pages go the same way.

`Feed_Parser_ActivityPub` is required only from the `friends_load_parsers` callback in `friends.php`, which returns early when `\Activitypub\Activitypub` doesn't exist — and there is no autoloader. But the templates that render an author's display name call its custom emoji helpers regardless, for **every** post:

* `templates/frontend/parts/header.php`, `parts/header-status.php` — every post in the feed
* `templates/frontend/author-header.php` — every profile page
* `includes/class-frontend.php`, `includes/class-blocks.php` — the author-name blocks

Friends works standalone, so this hits anyone who hasn't installed the ActivityPub plugin, or who deactivates it.

## Changes

Rather than scattering `class_exists()` over five call sites, the display name goes through a filter, which is the gating this plugin already uses for exactly this — two lines below the emoji call, `header.php` does `do_action( 'friends_post_author_meta', $friend_user )`, and the ActivityPub parser is what hooks it.

* New `friends_author_display_name_html` filter, applied wherever an author's display name is rendered, defaulting to `esc_html( $display_name )`.
* `Feed_Parser_ActivityPub::author_display_name_html()` hooks it from the constructor, alongside `friends_post_author_meta`. The parser is only constructed while the ActivityPub plugin is active, so the emoji rendering is added exactly then and the escaped default stands otherwise.

Two other places reached the parser unguarded, and get the gating the rest of their own file already uses:

* `templates/frontend/author-header.php` — `get_actor_acct_from_attributed_to()`. A feed can still be marked `activitypub` in the database with the plugin gone. Returns `''` in that case, which is what the helper itself does anyway.
* `includes/class-user.php` — `determine_mastodon_api_user()` in `mastodon_api_account_id()`, which is hooked from the Enable Mastodon Apps integration, so it runs whenever **EMA** is active, with or without ActivityPub. Its two sibling call sites at `:1178` and `:1290` were already guarded; this one was missed.
* `includes/class-user.php` — `mastodon_entity_relationship()` reads `Feed_Parser_ActivityPub::SLUG` *after* its own `class_exists()` if/else, on a path reached when the class is absent. It compares against the `'activitypub'` literal now, the way `author-header.php` already does.

Everything else that touches the parser is already behind a `class_exists`/`function_exists` check: the follower counts in the stats block and widget, direct message delivery status, webfinger resolution, `get_activitypub_actor_id()`, and the `::SLUG` uses across the migrations.

Two references remain formally unguarded and are deliberately left alone, since neither is reachable without the plugin:
* `templates/frontend/parts/activitypub/follow-link.php:9` is only ever rendered *from* `Feed_Parser_ActivityPub::friends_post_author_meta()`.
* `includes/class-migration.php:2815` sits downstream of `process_potential_reply_post()`, which calls `\Activitypub\Http::get_remote_object()` on its first line.

## Testing instructions

Two Playground instances on the same fixture (a subscription with three status posts), one without the ActivityPub plugin and one with it installed and active. A probe mu-plugin reports what is loaded and hooked on a `/friends/` request:

| | ActivityPub plugin | parser class loaded | `friends_author_display_name_html` hooked |
| --- | --- | --- | --- |
| without | no | no | **no** — filter returns the escaped default |
| with | yes | yes | **yes** |

Pages, before and after, without the ActivityPub plugin:

| page | before | after |
| --- | --- | --- |
| `/friends/` | 15,294 bytes, 1 truncated article | 49,542 bytes, 3 articles |
| `/friends/newssite/` | 13,386 bytes, 0 articles | 49,509 bytes, renders |

After the change `/friends/`, `/friends/newssite/`, `/friends/messages/`, `/friends/followers/` and the Friends and Settings admin pages all return 200 and close their HTML in **both** configurations, with no JS errors, and the feed shows 3 articles, 2 link preview cards and the correct author names either way.

`php -l` and `phpcs --standard=phpcs.xml` clean on all 7 touched files. PHPUnit was not run locally (no WordPress test library on this machine) — leaving that to CI. No test touches the changed code paths directly; the emoji helpers themselves are unchanged and their existing tests still call them as before.

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Type

- [x] Fixed - for any bug fixes

#### Message

Fix a fatal error that stopped the friends page from rendering when the ActivityPub plugin is not active.

</details>

https://claude.ai/code/session_01J7aozaEFaZ3vLaLXith1qm
