### PR TITLE
Fix outgoing DMs federating as a Tombstone

### DIFF
--- a/.github/changelog/unreleased/718-from-description
+++ b/.github/changelog/unreleased/718-from-description
@@ -1,0 +1,3 @@
+Type: fixed
+
+Fix direct messages being federated as a Tombstone so they never arrived at the recipient.

--- a/feed-parsers/activitypub/class-activitypub-transformer-message.php
+++ b/feed-parsers/activitypub/class-activitypub-transformer-message.php
@@ -20,6 +20,21 @@ class ActivityPub_Transformer_Message extends \Activitypub\Transformer\Post {
 	public $cc = array();
 	private $mentions;
 
+	/**
+	 * Whether the item should federate as a Tombstone.
+	 *
+	 * The parent class treats every post that is not publicly queryable as
+	 * redacted, and a direct message never is: it lives in a non-public post
+	 * type, in a custom post status, and carries a private content visibility.
+	 * Without this, `to_object()` returns a Tombstone and the remote silently
+	 * drops the message even though it accepted the delivery.
+	 *
+	 * @return bool Always false.
+	 */
+	protected function is_redacted() {
+		return false;
+	}
+
 	protected function get_in_reply_to() {
 		return $this->in_reply_to;
 	}

--- a/tests/test-activitypub.php
+++ b/tests/test-activitypub.php
@@ -790,6 +790,15 @@ class ActivityPubTest extends Friends_TestCase_Cache_HTTP {
 		$this->assertContains( $this->actor, $activity['to'] );
 		$this->assertContains( $this->actor, $activity['object']['to'] );
 		$this->assertStringContainsString( '@akirk', $activity['object']['content'] );
+
+		// A message that federates as a Tombstone is accepted by the remote but silently dropped.
+		$this->assertSame( 'Note', $activity['object']['type'] );
+		$this->assertArrayNotHasKey( 'formerType', $activity['object'] );
+
+		// Mastodon needs a Mention tag to attach the message to the recipient.
+		$this->assertNotEmpty( $activity['object']['tag'] );
+		$this->assertSame( 'Mention', $activity['object']['tag'][0]['type'] );
+		$this->assertSame( $this->actor, $activity['object']['tag'][0]['href'] );
 	}
 
 	public function test_direct_message_delivery_status_tracks_inbox_result() {


### PR DESCRIPTION
Fixes #697

Outgoing ActivityPub direct messages were federated as a `Create` of a **`Tombstone`**, not of a `Note`. The remote inbox accepts the delivery — which is why the sent indicator says "The remote inbox accepted this message" — and then discards the object, because a `Tombstone` is a deletion marker rather than a status. That is why replies never arrive on the other side.

Inspecting stored `ap_outbox` items for DMs shows the payload that actually goes out:

```json
{"type":"Create","to":["https://remote.example/users/someone"],"tag":[],
 "object":{"type":"Tombstone","formerType":"Note","content":"…","to":["…"]}}
```

Besides the wrong type, there is no `Mention` tag anywhere, so even a lenient remote would have nothing to attach the message to.

### Root cause

`ActivityPub_Transformer_Message` extends `\Activitypub\Transformer\Post`, whose `to_object()` begins with:

```php
if ( $this->is_redacted() ) { return $this->to_tombstone(); }
```

`is_redacted()` is `! is_post_publicly_queryable( $post )`, and a direct message fails that three times over: `friend_message` is a non-public post type without `activitypub` support, the post status is `friends_read` rather than `publish`, and `friends_send_direct_message()` itself sets `activitypub_content_visibility` to private.

`Feed_Parser_ActivityPub::friends_send_direct_message()` then calls `set_content()`, `set_to()` and `set_in_reply_to()` on that tombstone, which is why the result looks plausible enough that nothing ever errored.

## Changes

* Override `is_redacted()` in `ActivityPub_Transformer_Message` to return false, so a direct message federates as the `Note` it is. A DM is never publicly queryable by design; that is not the same as being deleted.
* Assert the object type and the `Mention` tag in `test_direct_message_is_added_to_activitypub_outbox`. The existing assertions only covered `to` and `content`, both of which are set by hand after `to_object()` returns, so the suite was blind to the object being a tombstone.

## Testing instructions

* Send a DM from Friends to a Mastodon account and confirm it arrives (it previously did not, despite the delivered indicator).
* To see the payload without sending, transform an existing `friend_message` post and check the result:

```php
$t = new \Friends\ActivityPub_Transformer_Message( get_post( $message_post_id ) );
$t->set_content_visibility( ACTIVITYPUB_CONTENT_VISIBILITY_PRIVATE );
$t->to = array( $recipient_actor_url );
echo $t->to_object()->get_type(); // "Tombstone" before, "Note" after
```

Running the full outbox path against a real message post on a live install now produces:

```json
{"type":"Create","to":["https://remote.example/users/someone"],
 "object":{"type":"Note","attributedTo":"https://local.example/author/me/",
   "tag":[{"type":"Mention","href":"https://remote.example/users/someone","name":"@someone@remote.example"}],
   "to":["https://remote.example/users/someone"],"content":"<p>…</p>"}}
```

`php -l` and `phpcs` are clean. The PHPUnit suite could not be run locally (no WordPress test library available), so verification was done by transforming real message posts and comparing the generated payload; no message was sent as part of this.

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Type

- [ ] Added - for new features
- [ ] Changed - for changes in existing functionality
- [x] Fixed - for any bug fixes
- [ ] Removed - for now removed features

#### Message

Fix direct messages being federated as a Tombstone so they never arrived at the recipient.

</details>

https://claude.ai/code/session_01Xe7PAJsPk3mWgrKEhiJzhZ

<!-- friends-playground-link:start -->
## Test this PR in WordPress Playground

You can test this pull request directly in WordPress Playground:

[Launch WordPress Playground](https://akirk.github.io/playground-step-library/?redir=1&step[0]=setLandingPage&landingPage[0]=/friends/&step[1]=installPlugin&url[1]=github.com/akirk/friends/tree/fix/dm-federates-as-tombstone&step[2]=importFriendFeeds&opml[2]=https://alex.kirk.at%20Alex%20Kirk%0Ahttps://adamadam.blog%20Adam%20Zieliński)

This will install and activate the plugin with the changes from this PR.
<!-- friends-playground-link:end -->