### PR TITLE
Do not resolve a remotely linked mention to a local user

### DIFF
--- a/.github/changelog/unreleased/721-from-description
+++ b/.github/changelog/unreleased/721-from-description
@@ -1,0 +1,3 @@
+Type: fixed
+
+A mention that links to somebody on another server is no longer mistaken for a mention of a friend who happens to have the same name.

--- a/feed-parsers/class-feed-parser-activitypub.php
+++ b/feed-parsers/class-feed-parser-activitypub.php
@@ -3765,12 +3765,27 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 	 * @return mixed The discovered mentions.
 	 */
 	public function activitypub_extract_mentions( $mentions, $post_content ) {
+		// Names that are already linked to somebody else's server. Collected before the tags
+		// are stripped, because the link is the only thing that tells them apart from a
+		// mention of a local user who happens to have the same name.
+		$linked_remotely = $this->get_remotely_linked_mention_names( $post_content );
+
 		// Find all @mentions in the content.
 		if ( ! preg_match_all( '/@([a-zA-Z0-9_.-]+(?:@[a-zA-Z0-9.-]+)?)\b/i', wp_strip_all_tags( $post_content ), $matches ) ) {
 			return $mentions;
 		}
 
 		foreach ( array_unique( $matches[1] ) as $handle ) {
+			/*
+			 * A bare @name that is the text of a link to another server is a remote mention
+			 * that lost its domain on the way in, not a mention of the local friend of that
+			 * name. Resolving it here would address the wrong actor entirely. A handle that
+			 * still carries its @host is resolved as before, remotely.
+			 */
+			if ( false === strpos( $handle, '@' ) && in_array( strtolower( $handle ), $linked_remotely, true ) ) {
+				continue;
+			}
+
 			$url = $this->resolve_mention_to_url( $handle );
 			if ( $url ) {
 				$mentions[ '@' . $handle ] = $url;
@@ -3778,6 +3793,37 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 		}
 
 		return $mentions;
+	}
+
+	/**
+	 * Get the names of bare @mentions that link to another server.
+	 *
+	 * Only a link whose text is the bare name is of interest: a link whose text still spells
+	 * out @user@host needs no help, it resolves remotely on its own.
+	 *
+	 * @param string $post_content The post content.
+	 * @return array Lowercased names, without the leading @.
+	 */
+	private function get_remotely_linked_mention_names( $post_content ) {
+		if ( false === stripos( $post_content, '<a' ) ) {
+			return array();
+		}
+
+		if ( ! preg_match_all( '#<a\s[^>]*href=([\'"])(?P<href>[^\'"]+)\1[^>]*>\s*@(?P<name>[a-zA-Z0-9_.-]+)\s*</a>#i', $post_content, $matches, PREG_SET_ORDER ) ) {
+			return array();
+		}
+
+		$names     = array();
+		$site_host = wp_parse_url( home_url(), PHP_URL_HOST );
+
+		foreach ( $matches as $match ) {
+			$link_host = wp_parse_url( $match['href'], PHP_URL_HOST );
+			if ( $link_host && strtolower( $link_host ) !== strtolower( $site_host ) ) {
+				$names[] = strtolower( $match['name'] );
+			}
+		}
+
+		return $names;
 	}
 
 	/**

--- a/tests/test-activitypub.php
+++ b/tests/test-activitypub.php
@@ -486,6 +486,76 @@ class ActivityPubTest extends Friends_TestCase_Cache_HTTP {
 		\wp_trash_post( $post_id );
 	}
 
+	public function test_dont_resolve_a_remotely_linked_mention_locally() {
+		add_filter( 'activitypub_cache_possible_friend_mentions', '__return_false' );
+		$post_id = \wp_insert_post(
+			array(
+				'post_author'  => 1,
+				'post_content' => 'Hi <a rel="mention" class="u-url mention" href="https://mastodon.social/@' . $this->friend_nicename . '">@' . $this->friend_nicename . '</a>  hello',
+				'post_status'  => 'publish',
+			)
+		);
+
+		$activitypub_post = new \Activitypub\Transformer\Post( get_post( $post_id ) );
+		$object = $activitypub_post->to_object();
+
+		$tags = $object->get_tag();
+		if ( ! $tags ) {
+			$tags = array();
+		}
+
+		// The link points at another server, so the local friend of that name must not be addressed.
+		$this->assertNotContains(
+			array(
+				'type' => 'Mention',
+				'href' => $this->actor,
+				'name' => '@' . $this->friend_nicename,
+			),
+			$tags
+		);
+		$this->assertNotContains( $this->actor, $object->get_cc() );
+
+		remove_all_filters( 'activitypub_from_post_object' );
+		remove_all_filters( 'activitypub_cache_possible_friend_mentions' );
+
+		\wp_trash_post( $post_id );
+	}
+
+	public function test_resolve_a_locally_linked_mention_locally() {
+		add_filter( 'activitypub_cache_possible_friend_mentions', '__return_false' );
+		$post_id = \wp_insert_post(
+			array(
+				'post_author'  => 1,
+				'post_content' => 'Hi <a rel="mention" class="u-url mention" href="' . home_url( '/author/' . $this->friend_nicename ) . '">@' . $this->friend_nicename . '</a>  hello',
+				'post_status'  => 'publish',
+			)
+		);
+
+		$activitypub_post = new \Activitypub\Transformer\Post( get_post( $post_id ) );
+		$object = $activitypub_post->to_object();
+
+		$tags = $object->get_tag();
+		if ( ! $tags ) {
+			$tags = array();
+		}
+
+		// A link that stays on this site is still a mention of the local friend.
+		$this->assertContains(
+			array(
+				'type' => 'Mention',
+				'href' => $this->actor,
+				'name' => '@' . $this->friend_nicename,
+			),
+			$tags
+		);
+		$this->assertContains( $this->actor, $object->get_cc() );
+
+		remove_all_filters( 'activitypub_from_post_object' );
+		remove_all_filters( 'activitypub_cache_possible_friend_mentions' );
+
+		\wp_trash_post( $post_id );
+	}
+
 	public function test_dont_override_activitypub_mentions() {
 		add_filter( 'activitypub_cache_possible_friend_mentions', '__return_false' );
 		$post_id = \wp_insert_post(


### PR DESCRIPTION
Found while tracing https://github.com/akirk/enable-mastodon-apps/issues/309.

## Proposed changes:

`Feed_Parser_ActivityPub::activitypub_extract_mentions()` runs `wp_strip_all_tags()` before it looks for `@mentions`, so a mention that arrives as a link keeps only its visible text. The ActivityPub plugin's own mention markup links `@user@host` with just `@user` as the text, so after stripping, the domain survives nowhere but the `href` — which stripping has just discarded.

The leftover bare `@user` was then resolved the way a mention typed by the author is resolved: against friends, subscriptions, then local users. On a site that has a friend of that name the mention did not merely go missing, it was **re-pointed at that local actor**, and the post federated addressing the wrong person.

Names linked to another server are now collected before the tags are stripped, and skipped when resolving locally. The rule is deliberately narrow:

* only a link whose text is the *bare* name is treated this way — text that still spells out `@user@host` resolves remotely on its own, as it already did;
* a link that stays on this site is still a mention of the local friend;
* a mention the author typed, with no link at all, is untouched.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

Two tests, mirroring the existing `test_dont_override_activitypub_mentions`: one asserts the local friend is not in `tag`/`cc` when the mention links to another server, one asserts they still are when the link stays on this site.

## Testing instructions:

Measured against a live site with a friend named `pfefferle`, calling the filter directly. Only the third row changes:

| content | before | after |
| --- | --- | --- |
| `Hi @pfefferle@mastodon.social` | remote actor | remote actor |
| `Hi <a href="…mastodon.social/@pfefferle">@pfefferle@mastodon.social</a>` | remote actor | remote actor |
| `Hi <a href="…mastodon.social/@pfefferle">@pfefferle</a>` | **local actor** | nothing |
| `Hi @pfefferle` | local actor | local actor |
| `Hi <a href="<site>/author/pfefferle">@pfefferle</a>` | local actor | local actor |
| `Hi <a href="/author/pfefferle">@pfefferle</a>` | local actor | local actor |
| `Hi <a href="…mastodon.social/@pfefferle">@pfefferle</a> and @pfefferle@mastodon.social` | remote actor | remote actor |

By hand: with a friend or subscription whose name matches somebody you follow elsewhere, post content that mentions the remote person as a link. Before, the federated object addressed your local friend; after, it does not.

`composer check-cs` passes. `composer test` was **not** run — there is no test database on this machine — so the two new tests want a CI run.

How the content came to be linkified in the first place is a separate fix in the ActivityPub plugin (https://github.com/Automattic/wordpress-activitypub/pull/3734); this one stands on its own, since content can arrive already linkified from anywhere.

<details><summary>Changelog</summary>

- [x] Automatically create a changelog entry from the details below

#### Type
- [x] Fixed

#### Message
A mention that links to somebody on another server is no longer mistaken for a mention of a friend who happens to have the same name.

</details>

https://claude.ai/code/session_01Lz9siENjr1dxjBK1eosc8a

<!-- friends-playground-link:start -->
## Test this PR in WordPress Playground

You can test this pull request directly in WordPress Playground:

[Launch WordPress Playground](https://akirk.github.io/playground-step-library/?redir=1&step[0]=setLandingPage&landingPage[0]=/friends/&step[1]=installPlugin&url[1]=github.com/akirk/friends/tree/fix/linked-remote-mention-local-resolution&step[2]=importFriendFeeds&opml[2]=https://alex.kirk.at%20Alex%20Kirk%0Ahttps://adamadam.blog%20Adam%20Zieliński)

This will install and activate the plugin with the changes from this PR.
<!-- friends-playground-link:end -->