### PR TITLE
Show likes received on direct messages

### DIFF
--- a/.github/changelog/unreleased/723-from-description
+++ b/.github/changelog/unreleased/723-from-description
@@ -1,0 +1,3 @@
+Type: fixed
+
+Show likes received on direct messages.

--- a/feed-parsers/class-feed-parser-activitypub.php
+++ b/feed-parsers/class-feed-parser-activitypub.php
@@ -3431,8 +3431,35 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 	}
 
 
+	/**
+	 * Resolve the object of a Like (or its Undo) to a local post.
+	 *
+	 * Besides the cached posts this also considers direct messages so that a
+	 * reaction to a message we sent doesn't get dropped.
+	 *
+	 * @param      string|array $liked_object  The object of the Like activity.
+	 *
+	 * @return     int|null  The post ID or null if it couldn't be resolved.
+	 */
+	private function liked_object_to_postid( $liked_object ) {
+		if ( is_array( $liked_object ) ) {
+			$liked_object = isset( $liked_object['id'] ) ? $liked_object['id'] : reset( $liked_object );
+		}
+
+		if ( ! is_string( $liked_object ) || ! $liked_object ) {
+			return null;
+		}
+
+		$post_id = Feed::url_to_postid( $liked_object );
+		if ( $post_id ) {
+			return $post_id;
+		}
+
+		return Messages::url_to_postid( $liked_object );
+	}
+
 	public function handle_incoming_like( $activity, $user_id ) {
-		$post_id = Feed::url_to_postid( $activity['object'] );
+		$post_id = $this->liked_object_to_postid( $activity['object'] );
 		if ( ! $post_id ) {
 			return false;
 		}
@@ -3465,7 +3492,7 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 	}
 
 	public function handle_incoming_unlike( $activity, $user_id ) {
-		$post_id = Feed::url_to_postid( $activity['object'] );
+		$post_id = $this->liked_object_to_postid( $activity['object'] );
 		if ( ! $post_id ) {
 			return false;
 		}

--- a/friends.css
+++ b/friends.css
@@ -2618,6 +2618,24 @@ h2#page-title a.dashicons {
 		& > :last-child { margin-bottom: 0; }
 	}
 
+	& .friends-dm-message-reactions {
+		display: flex;
+		flex-wrap: wrap;
+		gap: .25rem;
+		margin-top: .2rem;
+	}
+
+	& .friends-dm-message-reaction {
+		background: var(--friends-color-surface);
+		border: 1px solid var(--friends-color-border);
+		border-radius: 1rem;
+		color: var(--friends-color-text-muted);
+		cursor: help;
+		font-size: .7rem;
+		line-height: 1.4;
+		padding: 0 .4rem;
+	}
+
 	& .friends-dm-reply {
 		background: var(--friends-color-surface-muted);
 		border-top: 1px solid var(--friends-color-border);

--- a/includes/class-feed.php
+++ b/includes/class-feed.php
@@ -1161,12 +1161,14 @@ class Feed {
 	 * @return int Post ID, or 0 on failure.
 	 */
 	public static function url_to_postid( $url, $author_id = false ) {
-		$cache_key = 'friends_url_to_postid_' . md5( $url ) . ( $author_id ? '_' . $author_id : '' );
+		$post_types = apply_filters( 'friends_frontend_post_types', array() );
+
+		// The post types are part of the cache key since they can be filtered per lookup.
+		$cache_key = 'friends_url_to_postid_' . md5( $url . '|' . implode( ',', $post_types ) ) . ( $author_id ? '_' . $author_id : '' );
 		$post_id = wp_cache_get( $cache_key, 'friends' );
 		if ( false !== $post_id ) {
 			return $post_id;
 		}
-		$post_types = apply_filters( 'friends_frontend_post_types', array() );
 		$args = $post_types;
 
 		global $wpdb;

--- a/includes/class-messages.php
+++ b/includes/class-messages.php
@@ -161,6 +161,27 @@ class Messages {
 		return $post_types;
 	}
 
+	/**
+	 * Look up a direct message by its URL.
+	 *
+	 * Messages live in their own post type which is not part of the frontend post
+	 * types, so Feed::url_to_postid() doesn't consider them by default.
+	 *
+	 * @param      string $url    The URL of the message.
+	 *
+	 * @return     int|null  The post ID or null if it wasn't found.
+	 */
+	public static function url_to_postid( $url ) {
+		$only_messages = function () {
+			return array( self::CPT );
+		};
+
+		add_filter( 'friends_frontend_post_types', $only_messages, 999 );
+		$post_id = Feed::url_to_postid( $url );
+		remove_filter( 'friends_frontend_post_types', $only_messages, 999 );
+
+		return $post_id;
+	}
 
 	public function save_incoming_message( User $friend_user, $message, $subject = '', $feed_url = null, $remote_url = null, $reply_to = null ) {
 		$post_data = array(

--- a/includes/class-reactions.php
+++ b/includes/class-reactions.php
@@ -163,7 +163,7 @@ class Reactions {
 			$reactions[ $term->slug ][ $user_id ] = $user_display_name;
 		}
 
-		$remote_reactions = maybe_unserialize( get_post_meta( $post, 'remote_reactions', true ) );
+		$remote_reactions = maybe_unserialize( get_post_meta( $post->ID, 'remote_reactions', true ) );
 		foreach ( $reactions as $emoji => $reacting_usernames ) {
 			$user_reacted = isset( $user_reactions[ $emoji ] );
 

--- a/templates/frontend/messages.php
+++ b/templates/frontend/messages.php
@@ -232,6 +232,14 @@ Friends\Friends::template_loader()->get_template_part( 'frontend/header', null, 
 								echo wp_kses_post( apply_filters( 'the_content', $content ) );
 								?>
 							</div>
+							<?php $reactions = Friends\Reactions::get_post_reactions( $message ); ?>
+							<?php if ( ! empty( $reactions ) ) : ?>
+								<div class="friends-dm-message-reactions">
+									<?php foreach ( $reactions as $reaction ) : ?>
+										<span class="friends-dm-message-reaction" title="<?php echo esc_attr( $reaction->usernames ); ?>"><?php echo esc_html( $reaction->emoji ); ?> <?php echo esc_html( number_format_i18n( $reaction->count ) ); ?></span>
+									<?php endforeach; ?>
+								</div>
+							<?php endif; ?>
 						</div>
 					</div>
 					<?php $previous_message_author_key = $author_key; ?>

--- a/tests/test-activitypub.php
+++ b/tests/test-activitypub.php
@@ -401,6 +401,54 @@ class ActivityPubTest extends Friends_TestCase_Cache_HTTP {
 		$this->assertStringStartsWith( $content, $posts[0]->post_content );
 	}
 
+	public function test_incoming_like_on_direct_message() {
+		$message_id = wp_insert_post(
+			array(
+				'post_type'    => Messages::CPT,
+				'post_title'   => 'Re: Hello',
+				'post_content' => 'Hi there!',
+				'post_status'  => 'friends_read',
+			)
+		);
+		$this->assertGreaterThan( 0, $message_id );
+
+		$message_url = get_post_field( 'guid', $message_id );
+		$this->assertNotEmpty( $message_url );
+
+		$response = $this->receive_activity(
+			get_current_user_id(),
+			array(
+				'type'   => 'Like',
+				'id'     => $this->actor . '/likes/1',
+				'actor'  => $this->actor,
+				'object' => $message_url,
+			)
+		);
+		$this->assertEquals( 202, $response->get_status() );
+
+		$reactions = Reactions::get_post_reactions( $message_id );
+		$this->assertArrayHasKey( '2b50', $reactions );
+		$this->assertEquals( 1, $reactions['2b50']->count );
+
+		$response = $this->receive_activity(
+			get_current_user_id(),
+			array(
+				'type'   => 'Undo',
+				'id'     => $this->actor . '/likes/1#undo',
+				'actor'  => $this->actor,
+				'object' => array(
+					'type'   => 'Like',
+					'id'     => $this->actor . '/likes/1',
+					'actor'  => $this->actor,
+					'object' => $message_url,
+				),
+			)
+		);
+		$this->assertEquals( 202, $response->get_status() );
+
+		$this->assertEmpty( Reactions::get_post_reactions( $message_id ) );
+	}
+
 	public function test_incoming_announce() {
 		$now = time() - 10;
 		$status_id = 123;


### PR DESCRIPTION
Fixes #697

Follow-up to the DM sending fix: when the recipient likes a direct message you sent, there was no way to see it.

An incoming ActivityPub `Like` is resolved with `Feed::url_to_postid()`, which matches guids among the *frontend* post types (`friend_post_cache`). Direct messages live in their own `friend_message` post type, so the lookup never matched and the like was dropped without a trace. Even had it landed, the Direct Messages view didn't render reactions.

## Changes

* `Messages::url_to_postid()` — look up a message by its URL (its guid, which is what the outgoing Note's `id` is set to).
* `Feed_Parser_ActivityPub::liked_object_to_postid()` — used by both `handle_incoming_like()` and `handle_incoming_unlike()`; falls back to direct messages when the liked object isn't a cached post, and tolerates an embedded object instead of a bare URL.
* Render the reactions on each message in the Direct Messages view, with the reacting handle as the tooltip.
* `Feed::url_to_postid()` cached by URL alone, but the post types it searches are filtered per lookup — a miss for one set of post types was returned as a miss for another within the same request. The cache key now includes them.
* `Reactions::get_post_reactions()` passed a `WP_Post` where `get_post_meta()` wants an ID.

## Testing instructions

1. From the Friends Direct Messages view, send a DM to a Mastodon account you follow.
2. Like that message from the receiving account.
3. Reload `/friends/messages/` — the message now shows a ⭐️ chip underneath, with the liker's handle as the tooltip. Removing the like removes the chip again.

Verified end-to-end in WordPress Playground (Friends + ActivityPub, actor metadata mocked): the delivered `Like` resolves to the message post, stores the reaction, and renders in the thread at 1280px and at a 390px phone viewport. `tests/test-activitypub.php` gains a test covering the `Like` and its `Undo` over the REST inbox; the test suite itself runs in CI.

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Type

- [x] Fixed - for any bug fixes

#### Message

Show likes received on direct messages.

</details>

https://claude.ai/code/session_0199NgHHo725kPdr3hq79q48

<!-- friends-playground-link:start -->
## Test this PR in WordPress Playground

You can test this pull request directly in WordPress Playground:

[Launch WordPress Playground](https://akirk.github.io/playground-step-library/?redir=1&step[0]=setLandingPage&landingPage[0]=/friends/&step[1]=installPlugin&url[1]=github.com/akirk/friends/tree/fix/likes-on-direct-messages&step[2]=importFriendFeeds&opml[2]=https://alex.kirk.at%20Alex%20Kirk%0Ahttps://adamadam.blog%20Adam%20Zieliński)

This will install and activate the plugin with the changes from this PR.
<!-- friends-playground-link:end -->