### PR TITLE
Make the Follow widget actually follow

### DIFF
--- a/.github/changelog/unreleased/724-from-description
+++ b/.github/changelog/unreleased/724-from-description
@@ -1,0 +1,3 @@
+Type: fixed
+
+The sidebar Follow field now opens the Add Friend review instead of silently reloading the Friends page.

--- a/friends.js
+++ b/friends.js
@@ -1844,6 +1844,14 @@
 		renderSingleSubscriptionPreview( value.trim() );
 	} );
 
+	// When the form was reached with a URL prefilled (e.g. from the Follow widget), review it right away.
+	$( function () {
+		const $prefilled = $( '#subscription-url' );
+		if ( $prefilled.length && $prefilled.val().trim() ) {
+			$prefilled.closest( 'form' ).trigger( 'submit' );
+		}
+	} );
+
 	$document.on( 'paste', '#subscription-url', function () {
 		const input = this;
 		clearTimeout( subscriptionPasteReviewTimer );

--- a/templates/frontend/add-friend-form.php
+++ b/templates/frontend/add-friend-form.php
@@ -6,6 +6,11 @@
  * @package Friends
  */
 
+$prefill_url = '';
+if ( isset( $_GET['url'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+	$prefill_url = sanitize_text_field( wp_unslash( $_GET['url'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+}
+
 ?>
 <section class="subscriptions add-friend-subscriptions">
 	<div class="card add-friend-card">
@@ -13,7 +18,7 @@
 			<form id="add-subscription-form" action="" method="post">
 				<?php wp_nonce_field( 'friends_add_subscription' ); ?>
 				<div class="add-subscription-input">
-					<textarea name="url" id="subscription-url" class="form-input" rows="4" placeholder="<?php esc_attr_e( 'Enter URLs, @user@instance handles, or paste OPML content', 'friends' ); ?>" required></textarea>
+					<textarea name="url" id="subscription-url" class="form-input" rows="4" placeholder="<?php esc_attr_e( 'Enter URLs, @user@instance handles, or paste OPML content', 'friends' ); ?>" required><?php echo esc_textarea( $prefill_url ); ?></textarea>
 					<button type="submit" class="btn btn-primary"><?php esc_html_e( 'Review', 'friends' ); ?></button>
 				</div>
 				<p class="opml-file-hint">

--- a/tests/test-add-friend-form.php
+++ b/tests/test-add-friend-form.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Class AddFriendFormTest
+ *
+ * @package Friends
+ */
+
+namespace Friends;
+
+/**
+ * Test the Follow widget and the Add Friend form it submits to.
+ */
+class AddFriendFormTest extends \WP_UnitTestCase {
+	/**
+	 * Render the Follow widget.
+	 *
+	 * @return string The widget HTML.
+	 */
+	private function render_widget() {
+		$widget = new Widget_Add_Subscription();
+		ob_start();
+		$widget->widget(
+			array(
+				'before_widget' => '',
+				'after_widget'  => '',
+				'before_title'  => '',
+				'after_title'   => '',
+			),
+			array()
+		);
+		return ob_get_clean();
+	}
+
+	/**
+	 * Render the Add Friend form.
+	 *
+	 * @return string The form HTML.
+	 */
+	private function render_form() {
+		ob_start();
+		Friends::template_loader()->get_template_part( 'frontend/add-friend-form' );
+		return ob_get_clean();
+	}
+
+	public function test_widget_submits_to_the_add_friend_page() {
+		$html = $this->render_widget();
+
+		$this->assertStringContainsString( 'action="' . esc_url( home_url( '/friends/add-friend/' ) ) . '"', $html );
+		$this->assertStringContainsString( 'name="url"', $html );
+
+		// The form used to post to an endpoint that doesn't exist, which silently rendered the main Friends page.
+		$this->assertStringNotContainsString( 'add-suscription', $html );
+	}
+
+	public function test_add_friend_form_is_empty_without_a_url() {
+		$html = $this->render_form();
+
+		$this->assertStringContainsString( 'id="subscription-url"', $html );
+		$this->assertStringContainsString( '></textarea>', $html );
+	}
+
+	public function test_add_friend_form_prefills_the_url() {
+		$_GET['url'] = '@pfefferle@mastodon.social';
+		$html = $this->render_form();
+		unset( $_GET['url'] );
+
+		$this->assertStringContainsString( '>@pfefferle@mastodon.social</textarea>', $html );
+	}
+
+	public function test_add_friend_form_escapes_the_prefilled_url() {
+		$_GET['url'] = '</textarea><script>alert(1)</script>';
+		$html = $this->render_form();
+		unset( $_GET['url'] );
+
+		$this->assertStringNotContainsString( '<script>', $html );
+	}
+}

--- a/widgets/class-widget-add-subscription.php
+++ b/widgets/class-widget-add-subscription.php
@@ -46,10 +46,9 @@ class Widget_Add_Subscription extends \WP_Widget {
 		}
 
 		?>
-		<form action="<?php echo esc_url( home_url( 'friends/add-suscription' ) ); ?>" method="post" class="form-horizontal">
-		<?php wp_nonce_field( 'add-suscription' ); ?>
+		<form action="<?php echo esc_url( home_url( '/friends/add-friend/' ) ); ?>" method="get" class="form-horizontal">
 		<div class="form-group">
-			<input type="text" name="friend_url" aria-label="<?php esc_attr_e( "Enter the Friend's URL", 'friends' ); ?>"  placeholder="<?php esc_attr_e( "Friend's URL", 'friends' ); ?>" class="form-input input-sm" />
+			<input type="text" name="url" required aria-label="<?php esc_attr_e( 'Enter a URL or an @user@instance handle to follow', 'friends' ); ?>" placeholder="<?php esc_attr_e( 'URL or @user@instance', 'friends' ); ?>" class="form-input input-sm" />
 		</div>
 		<div class="form-group">
 			<button class="btn btn-primary btn-sm"><?php esc_html_e( 'Follow', 'friends' ); ?></button>


### PR DESCRIPTION
Entering a handle like `@user@instance` in the sidebar Follow field and pressing Enter just re-rendered `/friends/` — no confirmation, no error, no way to tell whether anything happened.

The widget's form posted to `/friends/add-suscription`: a typo, and an endpoint that never existed either way. `Frontend::get_static_frontend_template()` returns `frontend/index` for any path it doesn't recognise, so the submission rendered the main feed and the input was dropped on the floor — the same silent outcome for a valid handle, a typo, or an unreachable host. Nothing else in the plugin referenced that endpoint.

## Changes

* The Follow widget now targets the Add Friend page (`GET /friends/add-friend/?url=…`) with the field named `url`, matching what that page expects. The stale nonce for the dead endpoint is gone, and the placeholder says handles are accepted, since they are.
* `frontend/add-friend-form` prefills its textarea from `url`, so the block theme's `friends/add-friend-form` block gets this too.
* `friends.js` runs the review on load when the field arrives prefilled, so the result is on screen without a second click.

The outcome is now the existing Add Friend review UI: the discovered feed with a Follow button, or a readable error.

## Testing instructions

1. On `/friends/`, type `@pfefferle@mastodon.social` into the sidebar Follow field and press Enter.
2. You land on Add Friend with the handle filled in and the account's feed already discovered, ready to follow.
3. Try a nonsense handle — you get "You entered an invalid URL." instead of a silent reload.

Verified in WordPress Playground (Friends + ActivityPub) against the live handle from the report: the widget navigates to `/friends/add-friend/?url=%40pfefferle%40mastodon.social`, auto-discovers `mastodon.social/@pfefferle.rss` and renders the Follow button; an unresolvable handle renders the error instead. Checked in all three classic themes (Mastodon, default, Twitter), which share this widget. `tests/test-add-friend-form.php` covers the widget target, the prefill and its escaping; the suite runs in CI.

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Type

- [x] Fixed - for any bug fixes

#### Message

The sidebar Follow field now opens the Add Friend review instead of silently reloading the Friends page.

</details>

https://claude.ai/code/session_0199NgHHo725kPdr3hq79q48

<!-- friends-playground-link:start -->
## Test this PR in WordPress Playground

You can test this pull request directly in WordPress Playground:

[Launch WordPress Playground](https://akirk.github.io/playground-step-library/?redir=1&step[0]=setLandingPage&landingPage[0]=/friends/&step[1]=installPlugin&url[1]=github.com/akirk/friends/tree/fix/follow-widget-feedback&step[2]=importFriendFeeds&opml[2]=https://alex.kirk.at%20Alex%20Kirk%0Ahttps://adamadam.blog%20Adam%20Zieliński)

This will install and activate the plugin with the changes from this PR.
<!-- friends-playground-link:end -->