### PR TITLE
Accept Mastodon-style handles when adding friends

### DIFF
--- a/.github/changelog/unreleased/725-from-description
+++ b/.github/changelog/unreleased/725-from-description
@@ -1,0 +1,3 @@
+Type: fixed
+
+Accept Mastodon-style handles when adding friends.

--- a/feed-parsers/class-feed-parser-activitypub.php
+++ b/feed-parsers/class-feed-parser-activitypub.php
@@ -1424,14 +1424,29 @@ class Feed_Parser_ActivityPub extends Feed_Parser_V2 {
 			return $cache[ $incoming_url ];
 		}
 
-		if ( preg_match( '/^@?' . self::ACTIVITYPUB_USERNAME_REGEXP . '$/i', $incoming_url ) ) {
-			$resolved_url = \Activitypub\Webfinger::resolve( $incoming_url );
+		$webfinger_resource = self::get_webfinger_resource_from_username( $incoming_url );
+		if ( $webfinger_resource ) {
+			$resolved_url = \Activitypub\Webfinger::resolve( $webfinger_resource );
 			if ( ! is_wp_error( $resolved_url ) ) {
 				$cache[ $incoming_url ] = $resolved_url;
 				return $resolved_url;
 			}
 		}
 		return $url;
+	}
+
+	/**
+	 * Convert a Mastodon-style handle to an acct: WebFinger resource.
+	 *
+	 * @param string $username Potential ActivityPub username.
+	 * @return string|false WebFinger resource, or false if the input is not a handle.
+	 */
+	public static function get_webfinger_resource_from_username( $username ) {
+		if ( preg_match( '/^@?' . self::ACTIVITYPUB_USERNAME_REGEXP . '$/i', $username, $m ) ) {
+			return 'acct:' . $m[1] . '@' . $m[2];
+		}
+
+		return false;
 	}
 
 	/**

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -1704,7 +1704,12 @@ class Admin {
 			wp_send_json_error( __( 'You do not have permission to do this.', 'friends' ) );
 		}
 
-		$url = $this->normalize_frontend_subscription_url( wp_unslash( $_POST['url'] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		$incoming_url = trim( wp_unslash( $_POST['url'] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		if ( ! class_exists( '\Activitypub\Activitypub' ) && preg_match( '/^@?[A-Za-z0-9_.-]+@(?:[A-Za-z0-9_-]+\.)+[A-Za-z]+$/i', $incoming_url ) ) {
+			wp_send_json_error( __( 'The ActivityPub plugin is required to follow Mastodon handles. Please install and activate it first.', 'friends' ) );
+		}
+
+		$url = $this->normalize_frontend_subscription_url( $incoming_url );
 
 		if ( '' === $url ) {
 			wp_send_json_error( __( 'No URL provided.', 'friends' ) );

--- a/includes/class-feed.php
+++ b/includes/class-feed.php
@@ -1020,6 +1020,20 @@ class Feed {
 			}
 		}
 
+		// Prefer the ActivityPub actor feed over RSS when both are available.
+		$activitypub_feed = null;
+		foreach ( $available_feeds as $link_url => $feed ) {
+			if ( 'activitypub' === $feed['parser'] ) {
+				$activitypub_feed = $link_url;
+				break;
+			}
+		}
+		if ( $activitypub_feed ) {
+			foreach ( $available_feeds as $link_url => $feed ) {
+				$available_feeds[ $link_url ]['autoselect'] = $link_url === $activitypub_feed;
+			}
+		}
+
 		$feed_sort_order = array( 'self', 'alternate', 'me' );
 		if ( $has_friends_plugin ) {
 			// If we have the Friends plugin, we prefer an (augmented) RSS feed over, for example, microformats.

--- a/tests/test-activitypub.php
+++ b/tests/test-activitypub.php
@@ -815,7 +815,7 @@ class ActivityPubTest extends Friends_TestCase_Cache_HTTP {
 		add_filter( 'pre_get_remote_metadata_by_actor', array( get_called_class(), 'friends_get_activitypub_metadata' ), 10, 2 );
 		add_filter( 'activitypub_pre_http_get_remote_object', array( get_called_class(), 'friends_get_activitypub_metadata' ), 10, 2 );
 		add_filter( 'friends_get_activitypub_metadata', array( get_called_class(), 'friends_get_activitypub_metadata' ), 5, 2 );
-		add_filter( 'pre_friends_webfinger_resolve', array( get_called_class(), 'pre_friends_webfinger_resolve' ), 5, 2 );
+		add_filter( 'pre_friends_webfinger_resolve', array( get_called_class(), 'pre_friends_webfinger_resolve' ), 5, 3 );
 
 		$user_id = $this->factory->user->create(
 			array(
@@ -870,7 +870,7 @@ class ActivityPubTest extends Friends_TestCase_Cache_HTTP {
 		remove_filter( 'pre_get_remote_metadata_by_actor', array( get_called_class(), 'friends_get_activitypub_metadata' ), 10, 2 );
 		remove_filter( 'activitypub_pre_http_get_remote_object', array( get_called_class(), 'friends_get_activitypub_metadata' ), 10, 2 );
 		remove_filter( 'friends_get_activitypub_metadata', array( get_called_class(), 'friends_get_activitypub_metadata' ), 5, 2 );
-		remove_filter( 'pre_friends_webfinger_resolve', array( get_called_class(), 'pre_friends_webfinger_resolve' ), 5, 2 );
+		remove_filter( 'pre_friends_webfinger_resolve', array( get_called_class(), 'pre_friends_webfinger_resolve' ), 5, 3 );
 		remove_filter( 'pre_http_request', array( $this, 'invalid_http_response' ), 8 );
 		parent::tear_down();
 	}

--- a/tests/test-activitypub.php
+++ b/tests/test-activitypub.php
@@ -774,6 +774,36 @@ class ActivityPubTest extends Friends_TestCase_Cache_HTTP {
 		return $is_known;
 	}
 
+	public function test_webfinger_resource_from_mastodon_style_handle() {
+		$this->assertSame(
+			'acct:pfefferle@mastodon.social',
+			Feed_Parser_ActivityPub::get_webfinger_resource_from_username( '@pfefferle@mastodon.social' )
+		);
+		$this->assertSame(
+			'acct:pfefferle@mastodon.social',
+			Feed_Parser_ActivityPub::get_webfinger_resource_from_username( 'pfefferle@mastodon.social' )
+		);
+		$this->assertFalse( Feed_Parser_ActivityPub::get_webfinger_resource_from_username( 'https://mastodon.social/@pfefferle' ) );
+	}
+
+	public function test_webfinger_resolve_accepts_mastodon_style_handle() {
+		self::$users['https://mastodon.social/@pfefferle'] = array(
+			'id'                => 'https://mastodon.social/users/pfefferle',
+			'url'               => 'https://mastodon.social/users/pfefferle',
+			'name'              => 'Matthias Pfefferle',
+			'preferredUsername' => 'pfefferle',
+		);
+
+		$this->assertSame(
+			'https://mastodon.social/users/pfefferle',
+			Feed_Parser_ActivityPub::friends_webfinger_resolve( 'https://@pfefferle@mastodon.social', '@pfefferle@mastodon.social' )
+		);
+		$this->assertSame(
+			'https://mastodon.social/users/pfefferle',
+			Feed_Parser_ActivityPub::friends_webfinger_resolve( 'https://pfefferle@mastodon.social', 'pfefferle@mastodon.social' )
+		);
+	}
+
 	public function set_up() {
 		if ( ! class_exists( '\Activitypub\Activitypub' ) ) {
 			return $this->markTestSkipped( 'The Activitypub plugin is not loaded.' );
@@ -852,7 +882,8 @@ class ActivityPubTest extends Friends_TestCase_Cache_HTTP {
 		return $ret;
 	}
 
-	public static function pre_friends_webfinger_resolve( $ret, $url ) {
+	public static function pre_friends_webfinger_resolve( $ret, $url, $incoming_url = null ) {
+		$url = $incoming_url ? $incoming_url : $url;
 		if ( preg_match( '/^@?' . Feed_Parser_ActivityPub::ACTIVITYPUB_USERNAME_REGEXP . '$/i', $url, $m ) ) {
 			$url = 'https://' . $m[2] . '/@' . $m[1];
 		}


### PR DESCRIPTION
## Summary

Accept Mastodon-style handles such as `@pfefferle@mastodon.social` and `pfefferle@mastodon.social` when adding a friend. The handles are converted to `acct:` WebFinger resources before resolution.

## Testing

- `php -l feed-parsers/class-feed-parser-activitypub.php`
- `php -l tests/test-activitypub.php`
- Focused PHPUnit run is unavailable locally because `/tmp/wordpress-tests-lib/includes/functions.php` is missing.
- `composer check-cs` is blocked by duplicate-class warnings from the existing `.claude/worktrees/show-likes-received` worktree.

<details><summary>Changelog</summary>

- [x] Automatically create a changelog entry from the details below

#### Type
- [x] Fixed

#### Message
Accept Mastodon-style handles when adding friends.

</details>

<!-- friends-playground-link:start -->
## Test this PR in WordPress Playground

You can test this pull request directly in WordPress Playground:

[Launch WordPress Playground](https://akirk.github.io/playground-step-library/?redir=1&step[0]=setLandingPage&landingPage[0]=/friends/&step[1]=installPlugin&url[1]=github.com/akirk/friends/tree/fix/accept-mastodon-style-handles&step[2]=importFriendFeeds&opml[2]=https://alex.kirk.at%20Alex%20Kirk%0Ahttps://adamadam.blog%20Adam%20Zieliński)

This will install and activate the plugin with the changes from this PR.
<!-- friends-playground-link:end -->