### PR TITLE
Enable link previews for standard posts

### DIFF
--- a/.github/changelog/unreleased/726-from-description
+++ b/.github/changelog/unreleased/726-from-description
@@ -1,0 +1,3 @@
+Type: fixed
+
+Standard-format Friend posts now support link previews.

--- a/includes/class-link-preview.php
+++ b/includes/class-link-preview.php
@@ -172,7 +172,7 @@ class Link_Preview {
 		 * @param array    $post_formats  The post formats.
 		 * @param \WP_Post $post          The post.
 		 */
-		$post_formats = apply_filters( 'friends_link_preview_post_formats', array( 'status', 'link', 'aside' ), $post );
+		$post_formats = apply_filters( 'friends_link_preview_post_formats', array( 'standard', 'status', 'link', 'aside' ), $post );
 
 		return in_array( $post_format, $post_formats, true );
 	}

--- a/tests/test-link-preview.php
+++ b/tests/test-link-preview.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Class LinkPreviewTest
+ *
+ * @package Friends
+ */
+
+namespace Friends;
+
+/**
+ * Test link previews.
+ */
+class LinkPreviewTest extends \WP_UnitTestCase {
+	/**
+	 * Standard-format Friend posts support link previews.
+	 */
+	public function test_standard_posts_support_link_previews() {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_type'    => Friends::CPT,
+				'post_content' => '<p><a href="https://example.com/article">An article</a></p>',
+				'post_status'  => 'publish',
+				'guid'         => 'https://friend.example/posts/1',
+			)
+		);
+
+		$this->assertTrue( Link_Preview::is_supported_post( get_post( $post_id ) ) );
+	}
+}


### PR DESCRIPTION
## Summary

Allow link previews for Friend posts using the standard post format. This covers ActivityPub posts such as the reported Mastodon status, which currently arrives as `format-standard`.

## Testing

- `composer lint` passed.
- Changed files pass PHPCS.
- PHPUnit could not run because `/tmp/wordpress-tests-lib` is not installed in this environment.
- The full `composer check-cs` scan is blocked by duplicate-class warnings from pre-existing `.claude/worktrees` copies.

<details><summary>Changelog</summary>

- [x] Automatically create a changelog entry from the details below

#### Type
- [x] Fixed

#### Message
Standard-format Friend posts now support link previews.

</details>

<!-- friends-playground-link:start -->
## Test this PR in WordPress Playground

You can test this pull request directly in WordPress Playground:

[Launch WordPress Playground](https://akirk.github.io/playground-step-library/?redir=1&step[0]=setLandingPage&landingPage[0]=/friends/&step[1]=installPlugin&url[1]=github.com/akirk/friends/tree/fix/enable-standard-link-previews&step[2]=importFriendFeeds&opml[2]=https://alex.kirk.at%20Alex%20Kirk%0Ahttps://adamadam.blog%20Adam%20Zieliński)

This will install and activate the plugin with the changes from this PR.
<!-- friends-playground-link:end -->