### PR TITLE
Fix unfriend redirect

### DIFF
--- a/.github/changelog/unreleased/727-from-description
+++ b/.github/changelog/unreleased/727-from-description
@@ -1,0 +1,3 @@
+Type: fixed
+
+Redirect to the current subscriptions page after unfriending and remove stale links to the deleted friends-list admin screen.

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -266,7 +266,7 @@ class Admin {
 							sprintf(
 								// translators: %1$s is a URL, %2$s is the name of a wp-admin screen.
 								__( 'There are more settings available for each friend or subscription individually. To get there, click on the user on the <a href=%1$s>%2$s</a> screen.', 'friends' ),
-								'"' . esc_attr( self_admin_url( self::get_users_url() ) ) . '"',
+								'"' . esc_attr( self::get_users_url() ) . '"',
 								__( 'Friends &amp; Requests', 'friends' )
 							) .
 							'</p>',
@@ -2879,7 +2879,7 @@ class Admin {
 	}
 
 	public static function get_users_url() {
-		return 'users.php?role=subscription';
+		return home_url( '/friends/following/' );
 	}
 
 	/**

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -2879,7 +2879,7 @@ class Admin {
 	}
 
 	public static function get_users_url() {
-		return 'admin.php?page=friends-list';
+		return 'users.php?role=subscription';
 	}
 
 	/**

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -2354,7 +2354,7 @@ class Admin {
 		if ( isset( $_GET['_wp_http_referer'] ) ) {
 			wp_safe_redirect( wp_get_referer() );
 		} else {
-			wp_safe_redirect( add_query_arg( $arg, $arg_value, self_admin_url( 'admin.php?page=friends-list' ) ) );
+			wp_safe_redirect( add_query_arg( $arg, $arg_value, home_url( '/friends/following/' ) ) );
 		}
 		exit;
 	}


### PR DESCRIPTION
Fix the redirect after removing a subscription and update the remaining subscriptions users link to the current WordPress users screen.

Checks: PHP lint and git diff --check passed.

<details><summary>Changelog</summary>

- [x] Automatically create a changelog entry from the details below

#### Type
- [x] Fixed

#### Message
Redirect to the current subscriptions page after unfriending and remove stale links to the deleted friends-list admin screen.

</details>

<!-- friends-playground-link:start -->
## Test this PR in WordPress Playground

You can test this pull request directly in WordPress Playground:

[Launch WordPress Playground](https://akirk.github.io/playground-step-library/?redir=1&step[0]=setLandingPage&landingPage[0]=/friends/&step[1]=installPlugin&url[1]=github.com/akirk/friends/tree/fix/unfriend-redirect&step[2]=importFriendFeeds&opml[2]=https://alex.kirk.at%20Alex%20Kirk%0Ahttps://adamadam.blog%20Adam%20Zieliński)

This will install and activate the plugin with the changes from this PR.
<!-- friends-playground-link:end -->