### PR TITLE
Use frontend subscriptions links

### DIFF
--- a/.github/changelog/unreleased/728-from-description
+++ b/.github/changelog/unreleased/728-from-description
@@ -1,0 +1,3 @@
+Type: fixed
+
+Use the frontend Following page for subscriptions links instead of the legacy WordPress users screen.

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -264,10 +264,10 @@ class Admin {
 							'</p>' .
 							'<p>' .
 							sprintf(
-								// translators: %1$s is a URL, %2$s is the name of a wp-admin screen.
-								__( 'There are more settings available for each friend or subscription individually. To get there, click on the user on the <a href=%1$s>%2$s</a> screen.', 'friends' ),
+								// translators: %1$s is a URL, %2$s is the name of a page.
+								__( 'There are more settings available for each friend or subscription individually. To get there, click on the user on the <a href=%1$s>%2$s</a> page.', 'friends' ),
 								'"' . esc_attr( self::get_users_url() ) . '"',
-								__( 'Friends &amp; Requests', 'friends' )
+								__( 'Following', 'friends' )
 							) .
 							'</p>',
 					)


### PR DESCRIPTION
Update the remaining subscriptions links and help text to use the current frontend Following page. This removes the last legacy assumption that subscriptions are real WordPress users.

Checks: PHP lint and git diff --check passed.

<details><summary>Changelog</summary>

- [x] Automatically create a changelog entry from the details below

#### Type
- [x] Fixed

#### Message
Use the frontend Following page for subscriptions links instead of the legacy WordPress users screen.

</details>

<!-- friends-playground-link:start -->
## Test this PR in WordPress Playground

You can test this pull request directly in WordPress Playground:

[Launch WordPress Playground](https://akirk.github.io/playground-step-library/?redir=1&step[0]=setLandingPage&landingPage[0]=/friends/&step[1]=installPlugin&url[1]=github.com/akirk/friends/tree/fix/unfriend-redirect&step[2]=importFriendFeeds&opml[2]=https://alex.kirk.at%20Alex%20Kirk%0Ahttps://adamadam.blog%20Adam%20Zieliński)

This will install and activate the plugin with the changes from this PR.
<!-- friends-playground-link:end -->