### PR TITLE
Avoid duplicate future feed posts

### DIFF
--- a/.github/changelog/unreleased/730-from-description
+++ b/.github/changelog/unreleased/730-from-description
@@ -1,0 +1,3 @@
+Type: fixed
+
+Prevent duplicate imports and notifications for future-dated feed items.

--- a/includes/class-feed.php
+++ b/includes/class-feed.php
@@ -1207,7 +1207,9 @@ class Feed {
 			)
 		);
 
-		wp_cache_set( $cache_key, $post_id, 'friends' );
+		if ( $post_id ) {
+			wp_cache_set( $cache_key, $post_id, 'friends' );
+		}
 		return $post_id;
 	}
 

--- a/includes/class-notifications.php
+++ b/includes/class-notifications.php
@@ -93,6 +93,8 @@ class Notifications {
 		if (
 			// Post might be trashed through rules.
 			'trash' === $post->post_status
+			// Don't notify about posts that WordPress scheduled for future publishing.
+			|| 'future' === $post->post_status
 			// Don't notify about posts older than a week.
 			|| strtotime( $post->post_date_gmt ) + WEEK_IN_SECONDS < time()
 		) {

--- a/includes/class-user.php
+++ b/includes/class-user.php
@@ -930,7 +930,7 @@ class User extends \WP_User {
 		$existing_posts = new \WP_Query();
 		foreach ( array(
 			'post_type'   => Friends::CPT,
-			'post_status' => array( 'publish', 'private', 'trash' ),
+			'post_status' => array( 'publish', 'private', 'trash', 'future' ),
 			'nopaging'    => true,
 			'fields'      => 'ids',
 		) as $key => $value ) {

--- a/tests/test-feed.php
+++ b/tests/test-feed.php
@@ -180,6 +180,64 @@ class FeedTest extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test parsing a feed does not recreate future-dated posts.
+	 */
+	public function test_parse_feed_deduplicates_future_posts() {
+		$user = User::get_user_by_id( $this->friend_id );
+		$friends = Friends::get_instance();
+		$parser = new Feed_Parser_Local_File( $friends->feed );
+		$friends->feed->register_parser( 'local', $parser );
+		add_filter( 'friends_pre_check_url', '__return_true' );
+
+		$user_feed = $user->save_feed(
+			'http://friend.local/feed/',
+			array( 'parser' => 'local' )
+		);
+		$this->assertNotWPError( $user_feed );
+
+		$item = new Feed_Item(
+			array(
+				'permalink'     => 'http://friend.local/future-post',
+				'title'         => 'Future Friend Post',
+				'content'       => 'This post is scheduled.',
+				'date'          => time() + DAY_IN_SECONDS,
+				'comment_count' => 0,
+			)
+		);
+
+		$new_items = $friends->feed->process_incoming_feed_items( array( $item ), $user_feed );
+		$this->assertCount( 1, $new_items );
+
+		$posts = get_posts(
+			array(
+				'post_type'   => Friends::CPT,
+				'post_status' => 'any',
+				'numberposts' => -1,
+				'meta_key'    => 'feed_url',
+				'meta_value'  => $user_feed->get_url(),
+			)
+		);
+		$this->assertCount( 1, $posts );
+		$this->assertEquals( 'future', $posts[0]->post_status );
+
+		$new_items = $friends->feed->process_incoming_feed_items( array( $item ), $user_feed );
+		$this->assertCount( 0, $new_items );
+
+		$posts = get_posts(
+			array(
+				'post_type'   => Friends::CPT,
+				'post_status' => 'any',
+				'numberposts' => -1,
+				'meta_key'    => 'feed_url',
+				'meta_value'  => $user_feed->get_url(),
+			)
+		);
+		$this->assertCount( 1, $posts );
+
+		remove_filter( 'friends_pre_check_url', '__return_true' );
+	}
+
+	/**
 	 * Test parsing a direct feed URL that is served as text/plain.
 	 */
 	public function test_parse_direct_feed_url_with_text_plain_content_type() {

--- a/tests/test-notifications.php
+++ b/tests/test-notifications.php
@@ -91,6 +91,43 @@ class NotificationTest extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test future posts don't trigger notifications.
+	 */
+	public function test_no_notify_future_post() {
+		add_filter(
+			'notify_user_about_friend_post',
+			function ( $do_send ) {
+				$this->fail( 'Future posts should return before notification filters run.' );
+				return $do_send;
+			}
+		);
+		add_filter(
+			'friends_send_mail',
+			function ( $do_send ) {
+				$this->fail( 'Future posts should not send email.' );
+				return $do_send;
+			}
+		);
+
+		$user = new User( $this->friend_id );
+		add_filter( 'friends_pre_check_url', '__return_true' );
+		$user_feed = User_Feed::save( $user, 'http://friend.local/feed/', array( 'parser' => Feed_Parser_SimplePie::SLUG ) );
+		remove_filter( 'friends_pre_check_url', '__return_true' );
+
+		$post = $this->factory->post->create_and_get(
+			array(
+				'post_type'     => Friends::CPT,
+				'post_title'    => 'Future Friend Post',
+				'post_date_gmt' => gmdate( 'Y-m-d H:i:s', time() + DAY_IN_SECONDS ),
+				'post_status'   => 'future',
+				'post_author'   => $this->friend_id,
+			)
+		);
+
+		Friends::get_instance()->notifications->notify_new_friend_post( $post, $user_feed, false );
+	}
+
+	/**
 	 * Test message notifications link to the direct message view.
 	 */
 	public function test_notify_friend_message_received_links_to_conversation() {


### PR DESCRIPTION
Feed imports now treat scheduled friend posts as existing content when building the remote-post lookup, so future-dated RSS items are not recreated on every refresh before their publish time. URL lookup misses are no longer persisted in the Friends cache, which avoids keeping a stale "not found" result after an item is inserted, and future posts no longer send new-post email notifications before WordPress publishes them.

This addresses feeds that publish entries with future timestamps, such as Terminal Trove, where repeated 15-minute refreshes could create duplicate scheduled posts and duplicate notifications.

Testing:
- php -l includes/class-user.php
- php -l includes/class-feed.php
- php -l includes/class-notifications.php
- php -l tests/test-feed.php
- php -l tests/test-notifications.php
- php ./vendor/squizlabs/php_codesniffer/bin/phpcs includes/class-user.php includes/class-feed.php includes/class-notifications.php tests/test-feed.php tests/test-notifications.php
- composer test -- --filter 'test_parse_feed_deduplicates_future_posts|test_no_notify_future_post' (fails: missing /tmp/wordpress-tests-lib/includes/functions.php)
- composer check-cs (fails on pre-existing duplicate-class warnings from .claude/worktrees/show-likes-received)

<details><summary>Changelog</summary>

- [x] Automatically create a changelog entry from the details below

#### Type
- [x] Fixed

#### Message
Prevent duplicate imports and notifications for future-dated feed items.

</details>

<!-- friends-playground-link:start -->
## Test this PR in WordPress Playground

You can test this pull request directly in WordPress Playground:

[Launch WordPress Playground](https://akirk.github.io/playground-step-library/?redir=1&step[0]=setLandingPage&landingPage[0]=/friends/&step[1]=installPlugin&url[1]=github.com/akirk/friends/tree/fix/future-feed-duplicates&step[2]=importFriendFeeds&opml[2]=https://alex.kirk.at%20Alex%20Kirk%0Ahttps://adamadam.blog%20Adam%20Zieliński)

This will install and activate the plugin with the changes from this PR.
<!-- friends-playground-link:end -->